### PR TITLE
Make ElectronDiffraction signal to minimaly work with lazy data

### DIFF
--- a/pycrystem/__init__.py
+++ b/pycrystem/__init__.py
@@ -41,4 +41,4 @@ __status__ = "Development"
 
 def load(*args, **kwargs):
     signal = hsload(*args, **kwargs)
-    return ElectronDiffraction(signal)
+    return ElectronDiffraction(**signal._to_dictionary())

--- a/pycrystem/diffraction_signal.py
+++ b/pycrystem/diffraction_signal.py
@@ -20,6 +20,7 @@ from __future__ import division
 import tqdm
 from hyperspy import roi
 from hyperspy.signals import Signal2D, Signal1D
+from hyperspy._lazy_signals import LazySignal2D
 from scipy.ndimage import variance
 
 from scipy.ndimage import variance
@@ -32,7 +33,7 @@ Signal class for Electron Diffraction Data
 """
 
 
-class ElectronDiffraction(Signal2D):
+class ElectronDiffraction(LazySignal2D, Signal2D):
     _signal_type = "electron_diffraction"
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Probably does not enable all proper lazy functions (I have not tested), but at
least does not require to load all previously lazily loaded data.