### PR TITLE
Add package numexpr to dependencies, update hyperspy version to 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dill==0.2.5
 docutils==0.12
 enum34==1.1.6
 h5py==2.6.0
-hyperspy==1.1.1
+hyperspy==1.2
 imagesize==0.7.1
 ipykernel==4.5.0
 ipyparallel==5.2.0
@@ -26,6 +26,7 @@ mpmath==0.19
 natsort==5.0.1
 networkx==1.11
 nose==1.3.7
+numexpr==2.6.2
 numpy==1.11.2
 palettable==2.1.1
 pexpect==4.2.1


### PR DESCRIPTION
Got import errors when trying out a notebook @dnjohnstone was so kind to give me. I pip installed requirements.txt. numexpr was needed by hyperspy._components.expression to evalute functions, and Hyperspy 1.2 was needed for lazy loading and evaluation.