### PR TITLE
Development of correlate_library

### DIFF
--- a/pycrystem/utils/__init__.py
+++ b/pycrystem/utils/__init__.py
@@ -54,10 +54,9 @@ def correlate(image, pattern,
     shape = image.shape
     half_shape = tuple(i // 2 for i in shape)
 
-    pixel_coordinates = pattern.calibrated_coordinates.astype(int)[
-        :, :2] + half_shape
-    in_bounds = np.product((pixel_coordinates > 0) *
-                           (pixel_coordinates < shape[0]), axis=1).astype(bool)
+    pixel_coordinates = np.rint(pattern.calibrated_coordinates[:,:2]+half_shape).astype(int)
+    in_bounds = np.product((pixel_coordinates > 0) *(pixel_coordinates < shape[0]), axis=1)
+    
     pattern_intensities = pattern.intensities
     large_intensities = pattern_intensities > sim_threshold
     mask = np.logical_and(in_bounds, large_intensities)

--- a/pycrystem/utils/__init__.py
+++ b/pycrystem/utils/__init__.py
@@ -112,7 +112,4 @@ def correlate_component(image, pattern):
 
 
 def _correlate(intensities_1, intensities_2):
-    return np.dot(intensities_1, intensities_2) / (
-        np.sqrt(np.dot(intensities_1, intensities_1)) *
-        np.sqrt(np.dot(intensities_2, intensities_2))
-    )
+    return np.dot(intensities_1, intensities_2) / (np.sqrt(np.dot(intensities_1, intensities_1) * np.dot(intensities_2, intensities_2)))


### PR DESCRIPTION
This does a few things:
In correlate, the main slow part of the correlate_library routine:

1) Fixes a bad rounding `.astype(int)` to a correct `np.rint()` for a small speed gain
2) Leaves a 1,0 as it is rather than converting to a bool, for a small speed gain
3) In _correlate cuts the number of calls to np.sqrt for a (medium ~50%) gain

However to make this meaningfully quicker we will probably have to resort to Cython.

In correlate_library:
Introduces `keys` an argument that takes the phase keys. This specifies an ordering so that the output remains consistent numbering. Previously the dictionary would 'randomly' pick the order of the phases. This has limited overhead, for single phase system no changes are required.

This has been 'tested' on a si/ga demo notebook, and seems to be working okay.