### PR TITLE
Development of adding markers

### DIFF
--- a/pycrystem/utils/plot.py
+++ b/pycrystem/utils/plot.py
@@ -106,10 +106,9 @@ def generate_marker_inputs_from_peaks(peaks):
         dp.add_marker(m,plot_marker=True,permanent=False)
 
     """
+    ### XXX: non-square signals or single images
     max_peak_len = _find_max_length_peaks(peaks)
-    #TODO - Fix for a single image
     pad = np.array(list(itertools.zip_longest(*np.concatenate(peaks.data),fillvalue=[np.nan,np.nan])))
-    # Not tested for non-square signal, return flat to square
     pad = pad.reshape((max_peak_len),peaks.data.shape[0],peaks.data.shape[1],2)
     xy_cords = np.transpose(pad,[3,0,1,2]) #move the x,y pairs to the front 
     x = xy_cords[0] 

--- a/pycrystem/utils/sim_utils.py
+++ b/pycrystem/utils/sim_utils.py
@@ -342,3 +342,21 @@ def astar_style_orientations(
     gamma = np.radians(np.arange(*alpha_range, resolution))
     orientations = np.array([(a, b, c) for a, (b, c) in itertools.product(gamma, grid)])
     return orientations
+
+def peaks_from_best_template(single_match_result,phase,library):
+    """ Takes a match_result object and return the associated peaks, to be used with
+    in combination with map.
+    
+    Example : peaks= match_results.map(peaks_from_best_template,phase=phase,library=library)
+    
+    phase : list
+        of keys to library, should be the same as passed to IndexationGenerator.correlate()
+        
+    library : nested dictionary containing keys of [phase][rotation]
+    """
+    
+    best_fit = single_match_result[np.argmax(single_match_result[:,4])]
+    _phase = phase[int(best_fit[0])]
+    pattern = library[_phase][best_fit[1],best_fit[2],best_fit[3]]
+    peaks = pattern.coordinates[:,:2] #cut z
+    return peaks

--- a/tests/notebooks/.gitignore
+++ b/tests/notebooks/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/tests/notebooks/.gitignore
+++ b/tests/notebooks/.gitignore
@@ -1,1 +1,2 @@
-.ipynb_checkpoints
+# Use -f to force the addition, because of .ipynb auto-updating a hurdle is in place
+*

--- a/tests/notebooks/marker_attachment_testbook.ipynb
+++ b/tests/notebooks/marker_attachment_testbook.ipynb
@@ -2,11 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:hyperspy.api:The ipywidgets GUI elements are not available, probably because the hyperspy_gui_ipywidgets package is not installed.\n",
+      "WARNING:hyperspy.api:The traitsui GUI elements are not available, probably because the hyperspy_gui_traitui package is not installed.\n"
+     ]
+    }
+   ],
    "source": [
     "%matplotlib tk\n",
     "import numpy as np\n",
@@ -110,31 +119,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "indexer = IndexationGenerator(test_data, library)\n",
     "phase=[\"si\",\"ga\"] \n",
-    "match_results = indexer.correlate()"
+    "match_results = indexer.correlate(keys=phase)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "peaks= match_results.map(peaks_from_best_template,phase=phase,library=library,inplace=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },

--- a/tests/notebooks/marker_attachment_testbook.ipynb
+++ b/tests/notebooks/marker_attachment_testbook.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib tk\n",
+    "import numpy as np\n",
+    "import hyperspy.api as hs\n",
+    "import pycrystem as pc\n",
+    "import pymatgen as pmg\n",
+    "from matplotlib import pyplot as plt\n",
+    "from pymatgen.transformations.standard_transformations import RotationTransformation\n",
+    "from pycrystem.indexation_generator import IndexationGenerator\n",
+    "from pycrystem.utils.sim_utils import peaks_from_best_template\n",
+    "from pycrystem.utils.plot import generate_marker_inputs_from_peaks\n",
+    "from scipy.constants import pi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "si = pmg.Element(\"Si\")\n",
+    "lattice = pmg.Lattice.cubic(5.431)\n",
+    "silicon = pmg.Structure.from_spacegroup(\"Fd-3m\",lattice, [si], [[0, 0, 0]])\n",
+    "\n",
+    "ga = pmg.Element(\"Ga\")\n",
+    "lattice = pmg.Lattice.hexagonal(1.531,5)\n",
+    "gall = pmg.Structure.from_spacegroup(\"P6_3mc\",lattice, [ga], [[0, 0, 0]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "size = 256\n",
+    "radius=1.5\n",
+    "ediff = pc.ElectronDiffractionCalculator(300., 0.025)\n",
+    "\n",
+    "rotaxis = [0, 0, 1]\n",
+    "thetas = np.arange(0, 46, 45)\n",
+    "\n",
+    "data_silicon = []\n",
+    "data_gall = []\n",
+    "for theta in thetas:\n",
+    "    rot = RotationTransformation(rotaxis, theta)\n",
+    "    sieg,garr = rot.apply_transformation(silicon),rot.apply_transformation(gall)\n",
+    "    diff_dat_s,diff_dat_g = ediff.calculate_ed_data(sieg, radius),ediff.calculate_ed_data(garr, radius)\n",
+    "    dpi_s     ,dpi_g      = diff_dat_s.as_signal(256, 0.03, 1.2), diff_dat_g.as_signal(256, 0.03, 1.2)\n",
+    "    data_silicon.append(dpi_s.data)\n",
+    "    data_gall.append(dpi_g.data)\n",
+    "    \n",
+    "data = [data_silicon] + [data_gall]\n",
+    "test_data = pc.ElectronDiffraction(data)\n",
+    "test_data.set_calibration(1.2/128)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "rot_list = []\n",
+    "nstep=119\n",
+    "for i in np.arange(nstep):\n",
+    "    theta = (i*59.5/(nstep-1))/180*pi\n",
+    "    rot_list.append((theta, 0., 0.))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": []
+    }
+   ],
+   "source": [
+    "edc = pc.ElectronDiffractionCalculator(300, 0.025)\n",
+    "diff_gen = pc.DiffractionLibraryGenerator(edc)\n",
+    "struc_lib = dict()\n",
+    "struc_lib['si'] = (silicon, rot_list)\n",
+    "struc_lib['ga'] = (gall,rot_list)\n",
+    "library = diff_gen.get_diffraction_library(struc_lib,\n",
+    "                                            calibration=1.2/128,\n",
+    "                                            reciprocal_radius=1.5,\n",
+    "                                            representation='euler')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "indexer = IndexationGenerator(test_data, library)\n",
+    "phase=[\"si\",\"ga\"] \n",
+    "match_results = indexer.correlate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "peaks= match_results.map(peaks_from_best_template,phase=phase,library=library,inplace=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mmx,mmy = generate_marker_inputs_from_peaks(peaks)\n",
+    "test_data.plot(cmap='viridis') \n",
+    "for mx,my in zip(mmx,mmy):\n",
+    "    m = hs.markers.point(x=mx,y=my,color='red',marker='x')\n",
+    "    test_data.add_marker(m,plot_marker=True,permanent=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Adds a notebook (in docs/notebooks) contain an implementation of the new marker plotting scheme. Also contains a sim_util function (`peaks_from_best_template`) that extracts the peaks contained in the best template in a matching results object (to be used in combination with `map`, see notebook)

**known issue:** Non-square dps remain a problem, this may be hyperspy and not pyxem though.