### PR TITLE
Major Corrections to Orientation Mapping

### DIFF
--- a/pyxem/utils/__init__.py
+++ b/pyxem/utils/__init__.py
@@ -85,9 +85,9 @@ def correlate(image, pattern,
     
     # Take care here to use ALL image pixels in the imageimage product.
     numerator = np.dot(image_intensities,pattern_intensities)
-    denominator = np.dot(pattern_intensities,pattern_intensities)*np.dot(image,image)
+    denominator = np.sqrt(np.dot(pattern_intensities,pattern_intensities)*np.dot(image,image))
     
-    return np.nan_to_num(numerator,denominator)
+    return np.nan_to_num(numerator/denominator)
 
 
 def _correlate(intensities_1, intensities_2):

--- a/pyxem/utils/__init__.py
+++ b/pyxem/utils/__init__.py
@@ -59,7 +59,7 @@ def correlate(image, pattern,
     """
     shape = image.shape
     half_shape = tuple(i // 2 for i in shape)
-
+    
     pixel_coordinates = np.rint(pattern.calibrated_coordinates[:,:2]+half_shape).astype(int)
     in_bounds = np.product((pixel_coordinates > 0) *(pixel_coordinates < shape[0]), axis=1)
 
@@ -79,13 +79,12 @@ def correlate(image, pattern,
         image_intensities = ip.ev(pattern.coordinates[:, 0][mask],
                                   pattern.coordinates[:, 1][mask])
     else:
-        image_intensities = image.T[pixel_coordinates[:, 0][mask], pixel_coordinates[:, 1][mask]]
+        image_intensities = image[pixel_coordinates[:, 0][mask], pixel_coordinates[:, 1][mask]]
     
     pattern_intensities = pattern_intensities[mask]
-    
     # Take care here to use ALL image pixels in the imageimage product.
     numerator = np.dot(image_intensities,pattern_intensities)
-    denominator = np.sqrt(np.dot(pattern_intensities,pattern_intensities)*np.dot(image,image))
+    denominator = np.sqrt(np.dot(pattern_intensities,pattern_intensities)*np.sum(np.dot(image,image)))
     
     return np.nan_to_num(numerator/denominator)
 

--- a/pyxem/utils/__init__.py
+++ b/pyxem/utils/__init__.py
@@ -80,8 +80,14 @@ def correlate(image, pattern,
                                   pattern.coordinates[:, 1][mask])
     else:
         image_intensities = image.T[pixel_coordinates[:, 0][mask], pixel_coordinates[:, 1][mask]]
+    
     pattern_intensities = pattern_intensities[mask]
-    return np.nan_to_num(_correlate(image_intensities, pattern_intensities))
+    
+    # Take care here to use ALL image pixels in the imageimage product.
+    numerator = np.dot(image_intensities,pattern_intensities)
+    denominator = np.dot(pattern_intensities,pattern_intensities)*np.dot(image,image)
+    
+    return np.nan_to_num(numerator,denominator)
 
 
 def _correlate(intensities_1, intensities_2):

--- a/pyxem/utils/plot.py
+++ b/pyxem/utils/plot.py
@@ -117,7 +117,7 @@ def generate_marker_inputs_from_peaks(peaks):
     pad = np.array(list(itertools.zip_longest(*np.concatenate(peaks.data),fillvalue=[np.nan,np.nan])))
     pad = pad.reshape((max_peak_len),peaks.data.shape[0],peaks.data.shape[1],2)
     xy_cords = np.transpose(pad,[3,0,1,2]) #move the x,y pairs to the front
-    x = xy_cords[0]
-    y = xy_cords[1]
+    x = xy_cords[1]
+    y = xy_cords[0]
 
     return x,y

--- a/tests/notebooks/marker_attachment_testbook.ipynb
+++ b/tests/notebooks/marker_attachment_testbook.ipynb
@@ -2,20 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:hyperspy.api:The ipywidgets GUI elements are not available, probably because the hyperspy_gui_ipywidgets package is not installed.\n",
-      "WARNING:hyperspy.api:The traitsui GUI elements are not available, probably because the hyperspy_gui_traitui package is not installed.\n"
-     ]
-    }
-   ],
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%matplotlib tk\n",
     "import numpy as np\n",
@@ -32,9 +21,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -49,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 46,
    "metadata": {
     "collapsed": true
    },
@@ -68,7 +76,7 @@
     "    rot = RotationTransformation(rotaxis, theta)\n",
     "    sieg,garr = rot.apply_transformation(silicon),rot.apply_transformation(gall)\n",
     "    diff_dat_s,diff_dat_g = ediff.calculate_ed_data(sieg, radius),ediff.calculate_ed_data(garr, radius)\n",
-    "    dpi_s     ,dpi_g      = diff_dat_s.as_signal(256, 0.03, 1.2), diff_dat_g.as_signal(256, 0.03, 1.2)\n",
+    "    dpi_s     ,dpi_g      = diff_dat_s.as_signal(256, 0.05, 1.2), diff_dat_g.as_signal(256, 0.05, 1.2)\n",
     "    data_silicon.append(dpi_s.data)\n",
     "    data_gall.append(dpi_g.data)\n",
     "    \n",
@@ -79,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 47,
    "metadata": {
     "collapsed": true
    },
@@ -94,15 +102,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 48,
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": []
+     "text": [
+      "                                                 \r"
+     ]
     }
    ],
    "source": [
@@ -119,11 +127,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 49,
+   "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "675d0008b8d348db87981eb4292e9051",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -140,11 +160,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 50,
+   "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69d040b131d74bbd8c103ce0370d1f12",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -159,9 +191,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 51,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -176,9 +208,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -190,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Several bugs have become apparent

These include:

- Diffraction Patterns (experimental) being transposed internally during the matching process. It's possible some users will have corrected for this by transposing libraries.
 
- The final sum function should sum over all pixels. This in general simplifies for the terms involving the templates (which are zero almost everywhere) - however, the previous version of this only used images pixels that had non-pattern elements in the imageimage dot product to non-trivial effect.
 
- Marker plotting also had an xy error, although this is a much newer functionality and so is unlikely to hurt as many users.

It will surprise nobody to hear that testing is under construction.