### PR TITLE
Factorising pattern normalization to the library generation step

### DIFF
--- a/pyxem/generators/library_generator.py
+++ b/pyxem/generators/library_generator.py
@@ -120,7 +120,9 @@ class DiffractionLibraryGenerator(object):
                 pixel_coordinates = np.rint(data.calibrated_coordinates[:,:2]+half_shape).astype(int)[mask]
                 # Construct diffraction simulation library.
                 phase_diffraction_library[tuple(orientation)] = \
-                {'Sim':data,'intensities':pattern_intensities,'pixel_coords':pixel_coordinates}
+                {'Sim':data,'intensities':pattern_intensities, \
+                 'pixel_coords':pixel_coordinates, \
+                 'pattern_norm': np.sqrt(np.dot(pattern_intensities,pattern_intensities))}
             diffraction_library[key] = phase_diffraction_library
         return diffraction_library
 

--- a/pyxem/utils/__init__.py
+++ b/pyxem/utils/__init__.py
@@ -55,7 +55,8 @@ def correlate(image, pattern_dictionary):
     
     pattern_intensities = pattern_dictionary['intensities']
     pixel_coordinates   = pattern_dictionary['pixel_coords'] 
+    pattern_normalization = pattern_dictionary['pattern_norm']
     
     image_intensities = image[pixel_coordinates[:, 0], pixel_coordinates[:, 1]]
     
-    return np.dot(image_intensities,pattern_intensities)/np.sqrt(np.dot(pattern_intensities,pattern_intensities))
+    return np.dot(image_intensities,pattern_intensities)/pattern_normalization


### PR DESCRIPTION
This has been tested on the GaAs nanowire data where it does not effect the results (as would be expected, it's merely changing where things are done, rather than what is done)