### PR TITLE
Subpixel beam align

### DIFF
--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -176,7 +176,7 @@ class DiffractionVectors(BaseSignal):
         crystim : Signal2D
             2D map of diffracting pixels.
         """
-        crystim = self.map(get_npeaks, inplace=False).as_signal2D((0,1))
+        crystim = self.T.map(get_npeaks, inplace=False).as_signal2D((0,1))
 
         if binary==True:
             crystim = crystim == 1

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -176,7 +176,7 @@ class DiffractionVectors(BaseSignal):
         crystim : Signal2D
             2D map of diffracting pixels.
         """
-        crystim = self.T.map(get_npeaks, inplace=False).as_signal2D((0,1))
+        crystim = self.map(get_npeaks, inplace=False).as_signal2D((0,1))
 
         if binary==True:
             crystim = crystim == 1

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -518,6 +518,7 @@ class ElectronDiffraction(Signal2D):
             shifts = self.map(find_beam_offset_cross_correlation,
                               radius_start=radius_start,radius_finish=radius_finish,
                               inplace=False)
+	    shifts = shifts.data
 
         else:
             centers = self.map(find_beam_position_blur,

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -519,7 +519,7 @@ class ElectronDiffraction(Signal2D):
                               radius_start=radius_start,radius_finish=radius_finish,
                               inplace=False)
 
-            shifts = shifts.data
+            shifts = -1*shifts.data
 
         else:
             centers = self.map(find_beam_position_blur,

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -518,7 +518,8 @@ class ElectronDiffraction(Signal2D):
             shifts = self.map(find_beam_offset_cross_correlation,
                               radius_start=radius_start,radius_finish=radius_finish,
                               inplace=False)
-	    shifts = shifts.data
+
+            shifts = shifts.data
 
         else:
             centers = self.map(find_beam_position_blur,

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -481,7 +481,8 @@ class ElectronDiffraction(Signal2D):
 
 
     def center_direct_beam(self,
-                           sigma=3,
+                           subpixel=False,
+                           sigma=3, radius_start=4, radius_finish=8,
                            *args, **kwargs):
 
         """Estimate the direct beam position in each experimentally acquired
@@ -491,9 +492,18 @@ class ElectronDiffraction(Signal2D):
         Parameters
         ----------
 
-        sigma : int
+        subpixel : bool
+            Choice of subpixel cross-correlation method (blur method if False)
+            
+        sigma : int, optional
             Standard deviation for the gaussian convolution (only for
             'blur' method).
+        
+        radius_start : int, optional
+            The lower bound for the radius of the central disc to be used in the alignment
+        
+        radius_finish : int, optional
+            The upper bounds for the radius of the central disc to be used in the alignment
 
         Returns
         -------
@@ -504,10 +514,17 @@ class ElectronDiffraction(Signal2D):
         nav_shape_y = self.data.shape[1]
         half_tuple = (self.data.shape[2]/2,self.data.shape[3]/2)
 
-        centers = self.map(find_beam_position_blur,
-                           sigma=sigma,
-                           inplace=False)
-        shifts = centers.data - np.array(half_tuple)
+        if subpixel:
+            shifts = self.map(find_beam_offset_cross_correlation,
+                              radius_start=radius_start,radius_finish=radius_finish,
+                              inplace=False)
+
+        else:
+            centers = self.map(find_beam_position_blur,
+                               sigma=sigma,
+                               inplace=False)
+            shifts = centers.data - np.array(half_tuple)
+            
         shifts = shifts.reshape(nav_shape_x*nav_shape_y,2)
         return self.align2D(shifts=shifts, crop=False, fill_value=0)
 


### PR DESCRIPTION
I've added a cross-correlation based method for sub-pixel centering of the direct beam for electron diffraction data. The method uses a circle perimeter as a reference. It first does a quick evaluation of the appropriate circle radius and then does a calculation of shifts at higher upsampling. The method is incorporated within the extant function as an option to call the 'blur' method or the added 'subpixel' method (subpixel=True).