### PR TITLE
Tests for electron diffraction

### DIFF
--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -417,7 +417,7 @@ class ElectronDiffraction(Signal2D):
 
         return self.align2D(shifts=shifts, crop=False, fill_value=0,*args,**kwargs)
 
-    def remove_background(self, *args, **kwargs):
+    def remove_background(self, method, *args, **kwargs):
         """Perform background subtraction via multiple methods.
 
         Parameters

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -113,8 +113,6 @@ class ElectronDiffraction(Signal2D):
             Position of the central beam, in pixels. If None the center of the
             frame is assumed to be the center of the pattern.
         """
-        # TODO: extend to get calibration from a list of stored calibrations for
-        # the camera length recorded in metadata.
         if center is None:
             center = np.array(self.axes_manager.signal_shape)/2 * calibration
 
@@ -250,55 +248,6 @@ class ElectronDiffraction(Signal2D):
 
         return signal_mask
 
-    def get_vacuum_mask(self, radius, threshold,
-                        closing=True, opening=False):
-        """Generate a navigation mask to exclude SED patterns acquired in vacuum.
-
-        Vacuum regions are identified crudely based on searching for a peak
-        value in each diffraction pattern, having masked the direct beam, above
-        a user defined threshold value. Morphological opening or closing of the
-        mask obtained is supported.
-
-        Parameters
-        ----------
-        radius: float
-            Radius of circular mask to exclude direct beam.
-        threshold: float
-            Minimum intensity required to consider a diffracted beam to be
-            present.
-        center: tuple, optional
-            User specified position of the diffraction pattern center. If None
-            it is assumed that the pattern center is the center of the image.
-        closing: bool, optional
-            Flag to perform morphological closing.
-        opening: bool, optional
-            Flag to perform morphological opening.
-
-        Returns
-        -------
-        mask : Signal2D
-            The mask of the region of interest. Vacuum regions to be masked are
-            set True.
-
-        See also
-        --------
-        get_direct_beam_mask
-        """
-        db = np.invert(self.get_direct_beam_mask(radius=radius))
-        diff_only = db * self
-        mask = (diff_only.max((-1, -2)) <= threshold)
-        if closing:
-            mask.data = ndi.morphology.binary_dilation(mask.data,
-                                                       border_value=0)
-            mask.data = ndi.morphology.binary_erosion(mask.data,
-                                                      border_value=1)
-        if opening:
-            mask.data = ndi.morphology.binary_erosion(mask.data,
-                                                      border_value=1)
-            mask.data = ndi.morphology.binary_dilation(mask.data,
-                                                       border_value=0)
-        return mask
-
     def apply_affine_transformation(self,
                                     D,
                                     order=3,
@@ -392,7 +341,6 @@ class ElectronDiffraction(Signal2D):
             profiles = ed.get_radial_profile()
             profiles.plot()
         """
-
         # TODO: the cython implementation is throwing dtype errors
         radial_profiles = self.map(radial_average, cython=cython,
                                    inplace=inplace,**kwargs)
@@ -408,55 +356,6 @@ class ElectronDiffraction(Signal2D):
             radial_profiles.axes_manager.signal_axes[0].offset = 0
             signal_axis = radial_profiles.axes_manager.signal_axes[0]
             return ElectronDiffractionProfile(radial_profiles.as_signal1D(signal_axis))
-
-    def reproject_as_polar(self, origin=None, jacobian=False, dr=1, dt=None):
-        """Reproject the diffraction data into polar coordinates.
-
-        Parameters
-        ----------
-        origin : tuple
-            The coordinate (x0, y0) of the image center, relative to bottom-left.
-            If 'None'defaults to the center of the pattern.
-        Jacobian : boolean
-            Include ``r`` intensity scaling in the coordinate transform.
-            This should be included to account for the changing pixel size that
-            occurs during the transform.
-        dr : float
-            Radial coordinate spacing for the grid interpolation
-            tests show that there is not much point in going below 0.5
-        dt : float
-            Angular coordinate spacing (in radians)
-            if ``dt=None``, dt will be set such that the number of theta values
-            is equal to the maximum value between the height or the width of
-            the image.
-
-        Returns
-        -------
-        output : ElectronDiffraction
-            The electron diffraction data in polar coordinates.
-
-        """
-        return self.map(reproject_polar,
-                        origin=origin,
-                        jacobian=jacobian,
-                        dr=dr, dt=dt)
-
-    # TODO: This method needs to keep track of what's what better, with labels
-    # axes also need to track calibrations.
-    def get_diffraction_variance(self):
-        """Calculates the variance of associated with each diffraction pixel.
-
-        Returns
-        -------
-        ElectronDiffraction
-              A two dimensional signal containing the mean,
-              mean squared, and variance.
-        """
-        mean = self.mean(axis=self.axes_manager.navigation_axes)
-        square = np.square(self)
-        meansquare = square.mean(axis=square.axes_manager.navigation_axes)
-        variance = meansquare / np.square(mean) - 1
-        return stack((mean, meansquare, variance))
 
     def get_direct_beam_position(self, radius_start,
                                  radius_finish,
@@ -483,7 +382,6 @@ class ElectronDiffraction(Signal2D):
                               radius_start=radius_start,radius_finish=radius_finish,
                               inplace=False,*args,**kwargs)
         return shifts
-
 
     def center_direct_beam(self,
                            radius_start, radius_finish,
@@ -519,7 +417,7 @@ class ElectronDiffraction(Signal2D):
 
         return self.align2D(shifts=shifts, crop=False, fill_value=0,*args,**kwargs)
 
-    def remove_background(self, method='model', *args, **kwargs):
+    def remove_background(self, *args, **kwargs):
         """Perform background subtraction via multiple methods.
 
         Parameters
@@ -528,9 +426,6 @@ class ElectronDiffraction(Signal2D):
             Specify the method used to determine the direct beam position.
 
             * 'h-dome' -
-            * 'model' - fit a model to the radial profile of the average
-                diffraction pattern and then smooth remaining noise using
-                an h-dome method.
             * 'gaussian_difference' - Uses a difference between two gaussian
 				convolutions to determine where the peaks are, and sets
 				all other pixels to 0.
@@ -538,9 +433,6 @@ class ElectronDiffraction(Signal2D):
             * 'reference_pattern' - Subtract a user-defined reference patterns
                 from every diffraction pattern.
 
-        saturation_radius : int, optional
-            The radius, in pixels, of the saturated data (if any) in the direct
-            beam if the model method is used (h-dome / model only).
         sigma_min : int, float
             Standard deviation for the minimum gaussian convolution
             (gaussian_difference only)
@@ -559,10 +451,6 @@ class ElectronDiffraction(Signal2D):
         bg_subtracted : :obj:`ElectronDiffraction`
             A copy of the data with the background subtracted.
 
-        See Also
-        --------
-        :meth:`get_background_model`
-
         """
         if method == 'h-dome':
             scale = self.data.max()
@@ -571,19 +459,6 @@ class ElectronDiffraction(Signal2D):
                                      inplace=False, *args, **kwargs)
             bg_subtracted.map(filters.rank.mean, selem=square(3))
             bg_subtracted.data = bg_subtracted.data / bg_subtracted.data.max()
-
-        elif method == 'model':
-            bg = self.get_background_model(*args, **kwargs)
-
-            bg_removed = np.clip(self - bg, self.min(), self.max())
-
-            h = max(bg.data.min(), 1e-6)
-            bg_subtracted = ElectronDiffraction(
-                bg_removed.map(regional_flattener, h=h, inplace=False))
-            bg_subtracted.axes_manager.update_axes_attributes_from(
-                self.axes_manager.navigation_axes)
-            bg_subtracted.axes_manager.update_axes_attributes_from(
-                self.axes_manager.signal_axes)
 
         elif method == 'gaussian_difference':
             bg_subtracted = self.map(subtract_background_dog,
@@ -602,100 +477,7 @@ class ElectronDiffraction(Signal2D):
                 "documentation for available implementations.".format(method))
 
         return bg_subtracted
-
-    def get_background_model(self, saturation_radius):
-        """Creates a model for the background of the signal.
-
-        The mean radial profile is fitted with the following three components:
-
-        * Voigt profile for the central beam
-        * Exponential profile for the diffuse scatter
-        * Linear profile for the background offset and to improve the fit
-
-        Using the exponential profile and the linear profile, an
-        ElectronDiffraction signal is produced representing the mean background
-        of the signal. This may be used for background subtraction.
-
-        Parameters
-        ----------
-        saturation_radius : int
-            The radius of the region about the central beam in which pixels are
-            saturated.
-
-        Returns
-        -------
-        ElectronDiffraction
-            The mean background of the signal.
-
-        """
-        # TODO: get this done without taking the mean
-        profile = self.get_radial_profile().mean()
-        model = profile.create_model()
-        e1 = saturation_radius * profile.axes_manager.signal_axes[0].scale
-        model.set_signal_range(e1)
-
-        direct_beam = Voigt()
-        direct_beam.centre.value = 0
-        direct_beam.centre.free = False
-        direct_beam.FWHM.value = 0.1
-        direct_beam.area.bmin = 0
-        model.append(direct_beam)
-
-        diffuse_scatter = Exponential()
-        diffuse_scatter.A.value = 0
-        diffuse_scatter.A.bmin = 0
-        diffuse_scatter.tau.value = 0
-        diffuse_scatter.tau.bmin = 0
-        model.append(diffuse_scatter)
-
-        linear_decay = Polynomial(1)
-        model.append(linear_decay)
-
-        model.fit(bounded=True)
-
-        x_axis = self.axes_manager.signal_axes[0].axis
-        y_axis = self.axes_manager.signal_axes[1].axis
-        xs, ys = np.meshgrid(x_axis, y_axis)
-        rs = (xs ** 2 + ys ** 2) ** 0.5
-        bg = ElectronDiffraction(
-            diffuse_scatter.function(rs) + linear_decay.function(rs))
-        for i in (0, 1):
-            bg.axes_manager.signal_axes[i].update_from(
-                self.axes_manager.signal_axes[i])
-        return bg
-
-    def get_no_diffraction_mask(self, *args, **kwargs):
-        """Identify electron diffraction patterns containing no diffraction
-        peaks to remove from further processing.
-
-        Parameters
-        ----------
-        method : string
-            Choice of method
-
-        Returns
-        -------
-        mask : Signal
-            Signal object containing the mask.
-        """
-        raise NotImplementedError("This function is not yet implemented")
-        """
-        #TODO: Make this actually work.
-        if method == 'shapiro-wilk':
-            shapiro_values = self.map(stats.shapiro)
-            mask = shapiro_values > threshold
-
-        elif method == 'threshold':
-            mask = self.sum((2,3)) > threshold
-
-        else:
-            raise NotImplementedError("The method specified is not implemented. "
-                                      "See documentation for available "
-                                      "implementations.")
-
-        return mask
-        """
-        
+      
     def decomposition(self, *args, **kwargs):
         """Decomposition with a choice of algorithms.
 
@@ -786,10 +568,3 @@ class ElectronDiffraction(Signal2D):
         peakfinder = peakfinder2D_gui.PeakFinderUIIPYW(imshow_kwargs=imshow_kwargs)
         peakfinder.interactive(self)
 
-
-class LazyElectronDiffraction(LazySignal, ElectronDiffraction):
-
-    _lazy = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -469,10 +469,10 @@ class ElectronDiffraction(Signal2D):
         ----------
         radius_start : int
             The lower bound for the radius of the central disc to be used in the alignment
-        
+
         radius_finish : int
             The upper bounds for the radius of the central disc to be used in the alignment
-            
+
         Returns
         -------
         centers : ndarray
@@ -498,7 +498,7 @@ class ElectronDiffraction(Signal2D):
 
         radius_start : int
             The lower bound for the radius of the central disc to be used in the alignment
-        
+
         radius_finish : int
             The upper bounds for the radius of the central disc to be used in the alignment
 
@@ -511,7 +511,7 @@ class ElectronDiffraction(Signal2D):
         nav_shape_y = self.data.shape[1]
         origin_coordinates = np.array((self.data.shape[2]/2-0.5,self.data.shape[3]/2-0.5))
 
-      
+
         shifts = self.get_direct_beam_position(radius_start,radius_finish,*args,**kwargs)
 
         shifts = -1*shifts.data
@@ -678,6 +678,8 @@ class ElectronDiffraction(Signal2D):
         mask : Signal
             Signal object containing the mask.
         """
+        raise NotImplementedError("This function is not yet implemented")
+        """
         #TODO: Make this actually work.
         if method == 'shapiro-wilk':
             shapiro_values = self.map(stats.shapiro)
@@ -692,7 +694,8 @@ class ElectronDiffraction(Signal2D):
                                       "implementations.")
 
         return mask
-
+        """
+        
     def decomposition(self, *args, **kwargs):
         """Decomposition with a choice of algorithms.
 

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -340,5 +340,6 @@ class TestSimpleMaps:
 
     methods = ['threshold']
     @pytest.mark.parametrize('method', methods)
+    @pytest.mark.xfail(raises=NotImplementedError)
     def test_get_no_diffraction_mask(self, diffraction_pattern,method):
         mask = diffraction_pattern.get_no_diffraction_mask(method = method)

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -19,6 +19,7 @@
 import numpy as np
 import pytest
 from hyperspy.signals import Signal1D, Signal2D
+from hyperspy.roi import CircleROI
 from pyxem.signals.electron_diffraction import ElectronDiffraction
 
 
@@ -97,6 +98,46 @@ def diffraction_pattern(request):
 
 def diffraction_pattern_SED(request):
     return ElectronDiffraction(request.param)
+
+
+class TestSimpleMaps:
+    #Confirms that maps run without error.
+
+    def test_get_direct_beam_postion(self,diffraction_pattern_SED):
+        shifts = diffraction_pattern_SED.get_direct_beam_position(radius_start=1,radius_finish=3)
+
+    def test_center_direct_beam(self,diffraction_pattern_SED):
+        assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #before inplace transform applied
+        diffraction_pattern_SED.center_direct_beam(radius_start=1,radius_finish=3)
+        assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #after inplace transform applied
+
+class TestSimpleHyperspy:
+    # Tests functions that assign to hyperspy metadata
+
+    def test_set_experimental_parameters(self,diffraction_pattern_SED):
+        diffraction_pattern_SED.set_experimental_parameters(accelerating_voltage=3,
+                                                             camera_length=3,
+                                                             scan_rotation=1,
+                                                             convergence_angle=1,
+                                                             rocking_angle=1,
+                                                             rocking_frequency=1,
+                                                             exposure_time=1)
+        assert isinstance(diffraction_pattern_SED,ElectronDiffraction)
+
+    def set_scan_calibration(self,diffraction_pattern_SED):
+        diffraction_pattern_SED.set_scan_calibration(19)
+        assert isinstance(diffraction_pattern_SED,ElectronDiffraction)
+
+class TestVirtualImaging:
+    # Tests that virtual imaging runs without failure
+
+    def test_plot_interactive_virtual_image(self,diffraction_pattern_SED):
+        roi = CircleROI(3,3,5)
+        diffraction_pattern_SED.plot_interactive_virtual_image(roi)
+
+    def test_get_virtual_image(self,diffraction_pattern_SED):
+        roi = CircleROI(3,3,5)
+        diffraction_pattern_SED.get_virtual_image(roi)
 
 
 @pytest.mark.skip(reason='Defaults not implemented in pyXem')
@@ -290,15 +331,3 @@ class TestPeakFinding:
         assert output.inav[0,0].isig[1] == (45-(128/2)) #y
         #but at
         assert np.sum(output.inav[0,1].data.shape) == 4 # 2+2
-
-class TestSimpleMaps:
-    #This class simply confirms that maps run without error.
-    # These tests are not suitable for objects that may return ragged arrays
-
-    def test_get_direct_beam_postion(self,diffraction_pattern_SED):
-        shifts = diffraction_pattern_SED.get_direct_beam_position(radius_start=1,radius_finish=3)
-
-    def test_center_direct_beam(self,diffraction_pattern_SED):
-        assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #before inplace transform applied
-        diffraction_pattern_SED.center_direct_beam(radius_start=1,radius_finish=3)
-        assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #after inplace transform applied

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -54,9 +54,48 @@ from pyxem.signals.electron_diffraction import ElectronDiffraction
                [0., 0., 0., 2., 2., 2., 0., 0.],
                [0., 0., 0., 0., 2., 0., 0., 0.],
                [0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0.]]]),
+               [0., 0., 0., 0., 0., 0., 0., 0.]]])
 ])
 def diffraction_pattern(request):
+    return ElectronDiffraction(request.param)
+
+
+@pytest.fixture(params=[
+    np.array([[[0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 1., 0., 0., 0., 0.],
+               [0., 0., 1., 2., 1., 0., 0., 0.],
+               [0., 0., 0., 1., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.]],
+              [[0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 1., 0., 0., 0.],
+               [0., 0., 0., 1., 2., 1., 0., 0.],
+               [0., 0., 0., 0., 1., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.]],
+              [[0., 0., 0., 0., 0., 0., 0., 2.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 1., 0., 0., 0., 0.],
+               [0., 0., 1., 2., 1., 0., 0., 0.],
+               [0., 0., 0., 1., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.]],
+              [[0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 2., 0., 0., 0.],
+               [0., 0., 0., 2., 2., 2., 0., 0.],
+               [0., 0., 0., 0., 2., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0.]]]).reshape(2,2,8,8)
+])
+
+def diffraction_pattern_SED(request):
     return ElectronDiffraction(request.param)
 
 
@@ -150,7 +189,7 @@ class TestRadialProfile:
                                [2., 3., 3., 4., 4., 3., 3., 2.],
                                [0., 2., 3., 3., 3., 3., 2., 0.],
                                [0., 0., 2., 2., 2., 2., 0., 0.]])
-    
+
         dp.data[1] = np.array([[0., 0., 0., 0., 0., 0., 0., 0.],
                                [0., 0., 0., 0., 0., 0., 0., 0.],
                                [0., 0., 0., 0., 0., 0., 0., 0.],
@@ -171,7 +210,7 @@ class TestRadialProfile:
             [[5., 4., 3., 2., 0.],
              [1., 0., 0., 0., 0.]]
         ))])
-    
+
     def test_radial_profile(self, diffraction_pattern,expected):
         rp = diffraction_pattern.get_radial_profile()
         assert np.allclose(rp.data, expected, atol=1e-3)
@@ -260,7 +299,7 @@ class TestPeakFinding:
     @pytest.fixture
     def ragged_peak(self):
         pattern = np.zeros((2,2,128,128))
-        pattern[:,:,40,45] = 1 
+        pattern[:,:,40,45] = 1
         pattern[1,0,71,21] = 1
         return ElectronDiffraction(pattern)
 
@@ -268,7 +307,7 @@ class TestPeakFinding:
     def test_argless_run(self,single_peak):
         single_peak.find_peaks()
         pass
-    
+
     @pytest.mark.parametrize('method', methods)
     def test_findpeaks_single(self,single_peak,method):
         output = (single_peak.find_peaks(method)).inav[0,0] #should be <2,2|2,1>
@@ -276,7 +315,7 @@ class TestPeakFinding:
         assert output.isig[0] == 1        #  correct number of peaks
         assert output.isig[0] == (40-(128/2)) #x
         assert output.isig[1] == (45-(128/2)) #y
-        
+
     def test_findpeaks_ragged(self,ragged_peak,method):
         output = (ragged_peak.find_peaks(method))
         # as before at 0,0
@@ -284,5 +323,22 @@ class TestPeakFinding:
         assert output.inav[0,0].isig[0] == 1        #  correct number of peaks
         assert output.inav[0,0].isig[0] == (40-(128/2)) #x
         assert output.inav[0,0].isig[1] == (45-(128/2)) #y
-        #but at 
+        #but at
         assert np.sum(output.inav[0,1].data.shape) == 4 # 2+2
+
+class TestSimpleMaps:
+    #This class simply confirms that maps run without error.
+    # These tests are not suitable for objects that may return ragged arrays
+
+    def test_get_direct_beam_postion(self,diffraction_pattern_SED):
+        shifts = diffraction_pattern_SED.get_direct_beam_position(radius_start=1,radius_finish=3)
+
+    def test_center_direct_beam(self,diffraction_pattern_SED):
+        assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #before inplace transform applied
+        diffraction_pattern_SED.center_direct_beam(radius_start=1,radius_finish=3)
+        assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #after inplace transform applied
+
+    methods = ['threshold']
+    @pytest.mark.parametrize('method', methods)
+    def test_get_no_diffraction_mask(self, diffraction_pattern,method):
+        mask = diffraction_pattern.get_no_diffraction_mask(method = method)

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -132,21 +132,6 @@ def test_apply_gain_normalisation(diffraction_pattern: ElectronDiffraction,
     assert diffraction_pattern.min() == dark_reference
 
 
-def test_reproject_as_polar(diffraction_pattern: ElectronDiffraction):
-    shape_cartesian = diffraction_pattern.axes_manager.signal_shape
-    diffraction_pattern.reproject_as_polar()
-    assert isinstance(diffraction_pattern, Signal2D)
-    shape_polar = diffraction_pattern.axes_manager.signal_shape
-    assert shape_polar[0] == max(shape_cartesian)
-    assert shape_polar[1] > np.sqrt(2) * shape_cartesian[0] / 2
-
-
-def test_get_diffraction_variance(diffraction_pattern: ElectronDiffraction):
-    dv = diffraction_pattern.get_diffraction_variance()
-    assert dv.axes_manager.navigation_shape == (3,)
-    assert dv.axes_manager.signal_shape == diffraction_pattern.axes_manager.signal_shape
-
-
 class TestDirectBeamMethods:
 
     @pytest.mark.parametrize('mask_expected', [
@@ -164,16 +149,6 @@ class TestDirectBeamMethods:
         mask_calculated = diffraction_pattern.get_direct_beam_mask(2)
         assert isinstance(mask_calculated, Signal2D)
         assert np.equal(mask_calculated, mask_expected)
-
-    @pytest.mark.parametrize('closing, opening, mask_expected', [
-        (False, False, np.array([True, True, False, True])),
-        (True, False, np.array([True, True, True, True])),
-        (False, True, np.array([True, True, False, False])),
-    ])
-    def test_get_vacuum_mask(self, diffraction_pattern, closing, opening, mask_expected):
-        mask_calculated = diffraction_pattern.get_vacuum_mask(
-            radius=3, threshold=1, closing=closing, opening=opening)
-        assert np.allclose(mask_calculated, mask_expected)
 
 
 class TestRadialProfile:
@@ -266,18 +241,8 @@ class TestApplyAffineTransformation:
 
 class TestBackgroundMethods:
 
-    @pytest.mark.parametrize('saturation_radius', [
-        1,
-        2,
-    ])
-    def test_get_background_model(
-            self, diffraction_pattern: ElectronDiffraction, saturation_radius):
-        bgm = diffraction_pattern.get_background_model(saturation_radius)
-        assert bgm.axes_manager.signal_shape == diffraction_pattern.axes_manager.signal_shape
-
     @pytest.mark.parametrize('method, kwargs', [
         ('h-dome', {'h': 1}),
-        ('model', {'saturation_radius': 2, }),
         ('gaussian_difference', {'sigma_min': 0.5, 'sigma_max': 1, }),
         ('median', {'footprint': 4, })
     ])

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -302,9 +302,3 @@ class TestSimpleMaps:
         assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #before inplace transform applied
         diffraction_pattern_SED.center_direct_beam(radius_start=1,radius_finish=3)
         assert isinstance(diffraction_pattern_SED,ElectronDiffraction) #after inplace transform applied
-
-    methods = ['threshold']
-    @pytest.mark.parametrize('method', methods)
-    @pytest.mark.xfail(raises=NotImplementedError)
-    def test_get_no_diffraction_mask(self, diffraction_pattern,method):
-        mask = diffraction_pattern.get_no_diffraction_mask(method = method)


### PR DESCRIPTION
I think it would be sensible structuring to have the ElectronDiffraction test suite do as little as possible in terms of functionality. 

For example, every structure that ends like:
`
return self.map(func)`

should simply check that the object returned is of the correct type.

This could be quite a large refactor though, as some of the things that are tested here currently will need to be shifted over to testing on the numpy array in utils files.