### PR TITLE
Peak finding improvements, including ragged array tidying up

### DIFF
--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -404,4 +404,10 @@ def peaks_as_gvectors(z, center, calibration):
         peak positions in calibrated units.
     """
     g = (z - center) * calibration
-    return np.array([g[0].T[1], g[0].T[0]]).T
+    try:    # ragged case
+        return np.array([g[0].T[1], g[0].T[0]]).T
+    except IndexError: # non-ragged case
+        try:
+            return np.array([g[:,1], g[:,0]]).T
+        except IndexError: # no peaks case
+            return np.array([np.nan,np.nan])

--- a/pyxem/utils/peakfinders2D.py
+++ b/pyxem/utils/peakfinders2D.py
@@ -19,7 +19,7 @@
 import numpy as np
 import scipy.ndimage as ndi
 
-NO_PEAKS = np.array([[np.nan, np.nan]])
+NO_PEAKS = np.array([[[np.nan, np.nan]]])
 
 
 def clean_peaks(peaks):


### PR DESCRIPTION
This begins to fix up the ragged array case, it seems easier to test for raggedness in the actual functions (numpy functions) than the things that offer the map. Will expand this to some other stuff in time for 0.6 ~ ideally will address #155 in full 