### PR TITLE
Improving how we handle ragged arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
 sudo: false
 
 before_install:
-  - "pip install sphinx hyperspy pymatgen"
-  - "pip install Cython transforms3d lxml ipywidgets scikit-learn"
+  - "pip install sphinx"
+  - "pip install transforms3d lxml ipywidgets scikit-learn"
   - "pip install sphinx_bootstrap_theme"
   - "pip install pytest pytest-cov"
   - "pip install coveralls"

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -71,6 +71,10 @@ class DiffractionVectors(BaseSignal):
                                   inplace=False,
                                   *args, **kwargs)
 
+        # now convert all arrays into equivilant ragged format
+        magnitudes = BaseSignal(calculate_norms(self))
+        magnitudes.axes_manager.set_signal_dimension(0)
+
         return magnitudes
 
     def get_magnitude_histogram(self, bins):

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -72,7 +72,7 @@ class DiffractionVectors(BaseSignal):
                                   *args, **kwargs)
 
         # now convert all arrays into equivilant ragged format
-        magnitudes = BaseSignal(calculate_norms(self))
+        magnitudes = BaseSignal(magnitudes)
         magnitudes.axes_manager.set_signal_dimension(0)
 
         return magnitudes

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -67,15 +67,9 @@ class DiffractionVectors(BaseSignal):
             navigation position.
 
         """
-        #If ragged the signal axes will not be defined
-        if len(self.axes_manager.signal_axes)==0:
-            magnitudes = self.map(calculate_norms_ragged,
+        magnitudes = self.map(calculate_norms,
                                   inplace=False,
                                   *args, **kwargs)
-        #Otherwise easier to calculate.
-        else:
-            magnitudes = BaseSignal(calculate_norms(self))
-            magnitudes.axes_manager.set_signal_dimension(0)
 
         return magnitudes
 

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -339,21 +339,12 @@ class ElectronDiffraction(Signal2D):
             profiles = ed.get_radial_profile()
             profiles.plot()
         """
-        # TODO: the cython implementation is throwing dtype errors
         radial_profiles = self.map(radial_average,
                                    inplace=inplace,**kwargs)
-        # TODO: check this
-        ragged = len(radial_profiles.data.shape) == 1
-        if ragged:
-            max_len = max(map(len, radial_profiles.data))
-            radial_profiles = Signal1D([
-                np.pad(row.reshape(-1,), (0, max_len-len(row)), mode="constant", constant_values=0)
-                for row in radial_profiles.data])
-            return ElectronDiffractionProfile(radial_profiles)
-        else:
-            radial_profiles.axes_manager.signal_axes[0].offset = 0
-            signal_axis = radial_profiles.axes_manager.signal_axes[0]
-            return ElectronDiffractionProfile(radial_profiles.as_signal1D(signal_axis))
+        radial_profiles.axes_manager.signal_axes[0].offset = 0
+        signal_axis = radial_profiles.axes_manager.signal_axes[0]
+
+        return ElectronDiffractionProfile(radial_profiles.as_signal1D(signal_axis))
 
     def get_direct_beam_position(self, radius_start,
                                  radius_finish,

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -405,9 +405,17 @@ def peaks_as_gvectors(z, center, calibration):
     """
     g = (z - center) * calibration
     try:    # ragged case
+        _ = z[0,0,0]
+        ragged = True
+    except IndexError:
+        ragged = False
+
+    if ragged:
         return np.array([g[0].T[1], g[0].T[0]]).T
-    except IndexError: # non-ragged case
+    else:
         try:
             return np.array([g[:,1], g[:,0]]).T
         except IndexError: # no peaks case
             return np.array([np.nan,np.nan])
+
+        

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -19,15 +19,20 @@
 import numpy as np
 
 def calculate_norms(z):
-    norms = []
-    for i in z:
-        norms.append(np.linalg.norm(i))
-    return np.asarray(norms)
+    try: #ragged
+        _  = z[0,0,0] #will raise an index error on a non-ragged signal
+        ragged = True
+    except IndexError:
+        ragged = False
 
-def calculate_norms_ragged(z):
     norms = []
-    for i in z[0]:
-        norms.append(np.linalg.norm(i))
+    if ragged:
+        for i in z[0]:
+            norms.append(np.linalg.norm(i))
+    else: #non-ragged
+        for i in z:
+            norms.append(np.linalg.norm(i))
+
     return np.asarray(norms)
 
 def get_indices_from_distance_matrix(distances, distance_threshold):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ alabaster==0.7.9
 atomicfile==1.0
 Babel==2.3.4
 cycler==0.10.0
-cython==0.27.3
 dask==0.11.0
 decorator==4.0.10
 dill==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ pybtex==0.20.1
 PyDispatcher==2.0.5
 pyface==5.1.0
 Pygments==2.1.3
-pymatgen==4.4.8
+pymatgen>=2018.7.23
 pyparsing==2.1.10
 python-dateutil==2.5.3
 pytz==2016.7

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,11 @@ setup(
     ],
 
     install_requires=[
-    	'hyperspy',
-        'pymatgen',
-        'transforms3d']
+    	'hyperspy > 1.3',
+        'pymatgen >= 2018.7.23',
+        'transforms3d'],
 #        'cython',
-#        'lxml',
-#    ],
+#        'lxml'
 
     package_data={
         "": ["LICENSE", "readme.rst", "requirements.txt"],

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ setup(
         'pyxem.libraries'
     ],
 
-#    install_requires=[
-#    	'hyperspy',
-#        'pymatgen',
-#        'transforms3d',
+    install_requires=[
+    	'hyperspy',
+        'pymatgen',
+        'transforms3d']
 #        'cython',
 #        'lxml',
 #    ],

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -234,18 +234,14 @@ class TestPeakFinding:
     @pytest.mark.parametrize('peak',[ragged_peak,nonragged_peak])
     def test_findpeaks_ragged(self,peak,method):
         output = peak(self).find_peaks(method=method)
+
+        assert output.inav[0,1].data.shape == (2,)
+        assert output.inav[0,0].data.shape == (2,)
+
         if method != 'difference_of_gaussians':
             # three methods return the expect peak
             assert output.inav[0,0].isig[1] == 2        #  correct number of dims (boring square)
-            assert output.inav[0,0].isig[0] == 1        #   """ peaks """
-            if peak(self).data[1,0,72,22] == 1: # 3 peaks
-                assert output.inav[0,1].data.shape == (3,2)
-            else: #2 peaks
-                assert output.data.shape == (2,2,2,2)
-        else:
-            # DoG doesn't find the correct peaks, but runs without error
-            if peak(self).data[1,0,72,22] == 1: # 3 peaks
-                assert output.data.shape == (2,2) # tests we have a sensible ragged array
+            assert output.inav[0,0].isig[0] == 1        #   ditto peaks
 
 
     def test_argless_run(self,ragged_peak):

--- a/tests/test_utils/test_expt_utils.py
+++ b/tests/test_utils/test_expt_utils.py
@@ -77,14 +77,18 @@ def test_polar2cart(r, theta, x, y):
     np.testing.assert_almost_equal(xc, x)
     np.testing.assert_almost_equal(yc, y)
 
-@pytest.mark.parametrize('z, center, calibration, g',[
-    (np.array([[100,100],
-              [200,200],
-              [150,-150]]),
+@pytest.mark.parametrize('z, center, calibration, g',
+    [(np.array([[100,100],
+               [200,200],
+               [150,-150]]),
      np.array((127.5, 127.5)),
      0.0039,
-     np.array([-0.10725, -0.10725])),
-])
+     np.array([[-0.10725, -0.10725],
+               [0.28275,  0.28275],
+               [-1.08225,  0.08775]
+              ])
+    )])
+
 def test_peaks_as_gvectors(z, center, calibration, g):
     gc = peaks_as_gvectors(z=z, center=center, calibration=calibration)
     np.testing.assert_almost_equal(gc, g)


### PR DESCRIPTION
EDIT: _Italics for solved_

Given our new understanding of how .map() works on ragged arrays, existing functionality will be tidied up to reflect this. The main changes will be:

Handling within the `peak finder`
_Handling within the `radial_profile` method (converting it to non-ragged only)_ 
Sorting out generate marker from peaks in a similar way

_Current thinking is to make the numpy functions deal with the ragged nature, most likely with either `if` or `try` blocks._

~################ Also ####################~
~Other small adjustments include testing `remove_deadpixel()` method~