### PR TITLE
making the method argument of .find_peaks() non-optional

### DIFF
--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -488,7 +488,7 @@ class ElectronDiffraction(Signal2D):
         self.learning_results.loadings = np.nan_to_num(
             self.learning_results.loadings)
 
-    def find_peaks(self, method='stat', *args, **kwargs):
+    def find_peaks(self, method, *args, **kwargs):
         """Find the position of diffraction peaks.
 
         Function to locate the positive peaks in an image using various, user

--- a/tests/test_signals/test_electron_diffraction.py
+++ b/tests/test_signals/test_electron_diffraction.py
@@ -253,9 +253,6 @@ class TestPeakFinding:
                 assert output.data.shape == (2,2) # tests we have a sensible ragged array
 
 
-    def test_argless_run(self,ragged_peak):
-        ragged_peak.find_peaks()
-
     @pytest.mark.xfail(raises=NotImplementedError)
     def test_failing_run(self,ragged_peak):
         ragged_peak.find_peaks(method='no_such_method_exists')


### PR DESCRIPTION
Saves some testing time, cleans up the code a bit.