### PR TITLE
removing uneeded scikit-learn and lxml installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 
 before_install:
   - "pip install sphinx"
-  - "pip install lxml ipywidgets scikit-learn"
+  - "pip install ipywidgets"
   - "pip install sphinx_bootstrap_theme"
   - "pip install pytest pytest-cov"
   - "pip install coveralls"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
     install_requires=[
     	'hyperspy >= 1.3',
         'pymatgen >= 2018.8.7',
-        'transforms3d'
+        'transforms3d',
+	'scikit-learn >= 0.19'
       ],
 
     package_data={


### PR DESCRIPTION
Ipywidgets has been left in until a better way to handle optional dependencies is found.