### PR TITLE
Adjusting save to mtex

### DIFF
--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -139,7 +139,7 @@ class CrystallographicMap(BaseSignal):
         x_size_nav = self.data.shape[1]
         y_size_nav = self.data.shape[0]
         results_array = np.zeros((x_size_nav*y_size_nav,7))
-        for i in tqdm(range(0,x_size_nav),ascii=True):
-            for j in range (0, y_size_nav):
+        for j in tqdm(range(0,y_size_nav),ascii=True):
+            for i in range (0, x_size_nav):
                 results_array[(i)*y_size_nav+j] = np.append(self.inav[i,j].data[0:5],[i,j])
         np.savetxt(filename, results_array, delimiter = "\t", newline="\r\n")

--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -141,5 +141,5 @@ class CrystallographicMap(BaseSignal):
         results_array = np.zeros((x_size_nav*y_size_nav,7))
         for i in tqdm(range(0,x_size_nav),ascii=True):
             for j in range (0, y_size_nav):
-                results_array[(j)*x_size_nav+i] = np.append(self.inav[j,i].data[0:5],[j,i])
+                results_array[(j)*x_size_nav+i] = np.append(self.inav[i,j].data[0:5],[i,j])
         np.savetxt(filename, results_array, delimiter = "\t", newline="\r\n")

--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -36,7 +36,7 @@ def load_mtex_map(filename):
         y_max = np.max(load_array[:,6]).astype(int)
         # add one for zero indexing
         array = load_array.reshape(x_max+1,y_max+1,7)
-        array = np.transpose(array,(1,0,2)) #this gets x,y in the hs convention
+        #array = np.transpose(array,(1,0,2)) #this gets x,y in the hs convention
         cmap = Signal2D(array).transpose(navigation_axes=2)
         return CrystallographicMap(cmap.isig[:5]) #don't keep x/y
 

--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -36,7 +36,6 @@ def load_mtex_map(filename):
         y_max = np.max(load_array[:,6]).astype(int)
         # add one for zero indexing
         array = load_array.reshape(x_max+1,y_max+1,7)
-        #array = np.transpose(array,(1,0,2)) #this gets x,y in the hs convention
         cmap = Signal2D(array).transpose(navigation_axes=2)
         return CrystallographicMap(cmap.isig[:5]) #don't keep x/y
 

--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -139,7 +139,7 @@ class CrystallographicMap(BaseSignal):
         x_size_nav = self.data.shape[1]
         y_size_nav = self.data.shape[0]
         results_array = np.zeros((x_size_nav*y_size_nav,7))
-        for j in tqdm(range(0,y_size_nav),ascii=True):
-            for i in range (0, x_size_nav):
-                results_array[(i)*y_size_nav+j] = np.append(self.inav[i,j].data[0:5],[i,j])
+        for i in tqdm(range(0,x_size_nav),ascii=True):
+            for j in range (0, y_size_nav):
+                results_array[(j)*x_size_nav+i] = np.append(self.inav[j,i].data[0:5],[j,i])
         np.savetxt(filename, results_array, delimiter = "\t", newline="\r\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 atomicwrites==1.1.5
 attrs==18.1.0
 backcall==0.1.0
-certifi==2018.8.13
+certifi>=2018.8.13
 chardet==3.0.4
 cloudpickle==0.5.3
 coverage==4.5.1


### PR DESCRIPTION
Previously the ordering of x and y (when viewed as a column) differed from the produced by the commercial software used locally in conjunction with MTEX. This change means saved CrystallographicMaps can be loaded into MTEX and used as a mask for commercially indexed (.ang) data.