### PR TITLE
Moves to a circle based geometry rather than an angle based one

### DIFF
--- a/pyxem/generators/diffraction_generator.py
+++ b/pyxem/generators/diffraction_generator.py
@@ -105,10 +105,9 @@ class DiffractionGenerator(object):
 
         # Identify points intersecting the Ewald sphere within maximum
         # excitation error and store the magnitude of their excitation error.
-        radius = 1 / wavelength
-        r = np.sqrt(np.sum(np.square(cartesian_coordinates[:, :2]), axis=1))
-        theta = np.arcsin(r / radius)
-        z_sphere = radius * (1 - np.cos(theta))
+        r_sphere = 1 / wavelength
+        r_spot = np.sqrt(np.sum(np.square(cartesian_coordinates[:, :2]), axis=1))
+        z_sphere = -np.sqrt(r_sphere**2-r_spot**2) + r_sphere
         proximity = np.absolute(z_sphere - cartesian_coordinates[:, 2])
         intersection = proximity < max_excitation_error
         # Mask parameters corresponding to excited reflections.


### PR DESCRIPTION
In the adjusting this base of code for diffpy I found this (minor) bug.

Previously angles were used, it seems likely there was a stray `sin` where `tan` would have been better (although the angles were small) . Regardless, using the properties of the Ewald sphere seemed simpler and will be brought in with the diffpy PR. This just confirms this change (not related to diffpy) passes the old pymatgen tests.