### PR TITLE
Bugfixes and minor addition for the orientation mapping workflow

### DIFF
--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -23,9 +23,8 @@ from scipy.constants import h, m_e, e, c, pi
 import collections
 
 from .atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
-
 from pyxem.signals.electron_diffraction import ElectronDiffraction
-
+from transforms3d.quaternions import mat2quat,rotate_vector
 
 def get_electron_wavelength(accelerating_voltage):
     """Calculates the (relativistic) electron wavelength in Angstroms
@@ -178,6 +177,8 @@ def get_kinematical_intensities(structure,
     f_hkls = []
     for n in np.arange(len(g_indices)):
         g = g_indices[n]
+        q3 = mat2quat(structure.lattice.baserot)
+        g = rotate_vector(g,q3)
         fs = fss[n]
         dw_correction = np.exp(-dwfactors * s2s[n])
         f_hkl = np.sum(fs * occus * np.exp(2j * np.pi * np.dot(fcoords, g))


### PR DESCRIPTION
---
about: Having spent some time with the diffpy version of the code it's clear problems exist this PR attempt to address some of them

---

**What does this PR do? Please describe or link to an open issue.**
Firstly, it fixes the rotation bug. Then see WIP list

**Work in progress?**

- [ ] Have `.generate_library()` warn if it looks like you've not got enough spots to separate results (2D)
- [ ] Make `.get_crystallographic_map()` work sensibly with duplicate correlations*
- [ ] Add a method to match results that checks for duplicated correlations**
- [ ] Facilitate the pre-rotation of structures to a known orientation

*throw an error
**making use of this potentially
