### PR TITLE
Transfer axes between classes related by functions/generators

### DIFF
--- a/pyxem/generators/diffraction_generator.py
+++ b/pyxem/generators/diffraction_generator.py
@@ -169,7 +169,7 @@ class DiffractionGenerator(object):
 
         # Obtain crystallographic reciprocal lattice points within range
         recip_latt = latt.reciprocal()
-        spot_indicies, _ , spot_distances = get_points_in_sphere(recip_latt,reciprocal_radius)
+        spot_indicies, _ , spot_distances = get_points_in_sphere(recip_latt, reciprocal_radius)
 
         peaks = {}
         mask = np.logical_not((np.any(spot_indicies,axis=1) == 0))

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -41,10 +41,12 @@ def correlate_library(image, library,n_largest,mask,keys=[]):
         for key in library.keys():
             correlations = dict()
             for orientation, diffraction_pattern in library[key].items():
-                #diffraction_pattern here is in fact a library of diffraction_pattern_properties
+                #diffraction_pattern here is in fact a library of
+                #diffraction_pattern_properties
                 correlation = correlate(image, diffraction_pattern)
                 correlations[orientation] = correlation
-                res = nlargest(n_largest, correlations.items(), key=itemgetter(1))
+                res = nlargest(n_largest, correlations.items(),
+                               key=itemgetter(1))
             for j in np.arange(n_largest):
                 out_arr[j + i*n_largest][0] = i
                 out_arr[j + i*n_largest][1] = res[j][0][0]
@@ -102,10 +104,10 @@ class IndexationGenerator():
         Returns
         -------
         matching_results : pyxem.signals.indexation_results.IndexationResults
-            Navigation axes of the electron diffraction signal containing correlation
-            results for each diffraction pattern. As an example, the signal in
-            Euler reads ( Library Number , Z , X , Z , Correlation Score )
-
+            Navigation axes of the electron diffraction signal containing
+            correlation results for each diffraction pattern. As an example, the
+            signal in Euler reads:
+                    ( Library Number , Z , X , Z , Correlation Score)
 
         """
         signal = self.signal
@@ -160,10 +162,10 @@ class ProfileIndexationGenerator():
         Returns
         -------
         matching_results : pyxem.signals.indexation_results.IndexationResults
-            Navigation axes of the electron diffraction signal containing correlation
-            results for each diffraction pattern. As an example, the signal in
-            Euler reads ( Library Number , Z , X , Z , Correlation Score )
-
+            Navigation axes of the electron diffraction signal containing
+            correlation results for each diffraction pattern. As an example, the
+            signal in Euler reads:
+                    ( Library Number , Z , X , Z , Correlation Score)
 
         """
         mags = self.magnitudes

--- a/pyxem/generators/library_generator.py
+++ b/pyxem/generators/library_generator.py
@@ -63,8 +63,8 @@ class DiffractionLibraryGenerator(object):
         Parameters
         ----------
         structure_library : pyxem:StructureLibrary Object
-            Dictionary of structures and associated orientations for which electron diffraction
-            is to be simulated.
+            Dictionary of structures and associated orientations for which
+            electron diffraction is to be simulated.
 
         calibration : float
             The calibration of experimental data to be correlated with the
@@ -93,14 +93,20 @@ class DiffractionLibraryGenerator(object):
             phase_diffraction_library = dict()
             structure = structure_library[key][0]
             a,b,c = structure.lattice.a,structure.lattice.b,structure.lattice.c
-            alpha,beta,gamma = structure.lattice.alpha,structure.lattice.beta,structure.lattice.gamma
+            alpha = structure.lattice.alpha
+            beta = structure.lattice.beta
+            gamma = structure.lattice.gamma
             orientations = structure_library[key][1]
             # Iterate through orientations of each phase.
             for orientation in tqdm(orientations, leave=False):
                 _orientation = np.deg2rad(orientation)
-                matrix = euler2mat(_orientation[0],_orientation[1],_orientation[2], 'rzxz')
+                matrix = euler2mat(_orientation[0],
+                                   _orientation[1],
+                                   _orientation[2], 'rzxz')
 
-                latt_rot = diffpy.structure.lattice.Lattice(a,b,c,alpha,beta,gamma,baserot=matrix)
+                latt_rot = diffpy.structure.lattice.Lattice(a, b, c,
+                                                            alpha, beta, gamma,
+                                                            baserot=matrix)
                 structure.placeInLattice(latt_rot)
 
                 # Calculate electron diffraction for rotated structure
@@ -111,11 +117,13 @@ class DiffractionLibraryGenerator(object):
                 data.calibration = calibration
                 pattern_intensities = data.intensities
                 pixel_coordinates = np.rint(data.calibrated_coordinates[:,:2]+half_shape).astype(int)
-                # Construct diffraction simulation library, removing those that contain no peaks
+                # Construct diffraction simulation library, removing those that
+                # contain no peaks
                 if len(pattern_intensities) > 0:
                     phase_diffraction_library[tuple(orientation)] = \
                     {'Sim':data,'intensities':pattern_intensities, \
                      'pixel_coords':pixel_coordinates, \
-                     'pattern_norm': np.sqrt(np.dot(pattern_intensities,pattern_intensities))}
+                     'pattern_norm': np.sqrt(np.dot(pattern_intensities,
+                                                    pattern_intensities))}
                     diffraction_library[key] = phase_diffraction_library
         return diffraction_library

--- a/pyxem/generators/vdf_generator.py
+++ b/pyxem/generators/vdf_generator.py
@@ -91,6 +91,18 @@ class VDFGenerator():
             raise ValueError("DiffractionVectors non-specified by user. Please "
                              "initialize VDFGenerator with some vectors. ")
 
+        #Set calibration to same as signal
+        x = vdfim.axes_manager.signal_axes[0]
+        y = vdfim.axes_manager.signal_axes[1]
+
+        x.name = 'x'
+        x.scale = self.signal.axes_manager.navigation_axes[0].scale
+        x.units = 'nm'
+
+        y.name = 'y'
+        y.scale = self.signal.axes_manager.navigation_axes[0].scale
+        y.units = 'nm'
+
         return vdfim
 
     def get_concentric_vdf_images(self,
@@ -139,5 +151,19 @@ class VDFGenerator():
 
         if normalize==True:
             vdfim.map(normalize_vdf)
+
+        #Set calibration to same as signal
+        x = vdfim.axes_manager.signal_axes[0]
+        y = vdfim.axes_manager.signal_axes[1]
+
+        x.name = 'x'
+        x.scale = self.signal.axes_manager.navigation_axes[0].scale
+        x.units = 'nm'
+
+        y.name = 'y'
+        y.scale = self.signal.axes_manager.navigation_axes[0].scale
+        y.units = 'nm'
+
+        return vdfim
 
         return vdfim

--- a/pyxem/generators/vdf_generator.py
+++ b/pyxem/generators/vdf_generator.py
@@ -165,5 +165,3 @@ class VDFGenerator():
         y.units = 'nm'
 
         return vdfim
-
-        return vdfim

--- a/pyxem/libraries/structure_library.py
+++ b/pyxem/libraries/structure_library.py
@@ -23,12 +23,14 @@ class StructureLibrary(dict):
     A dictionary containing all the structures and their associated rotations
     in the .struct_lib attribute.
 
-    identifiers: list of strings/ints
-
-    structures: list of diffpy.structure.Structures
-
-    orientations: a list (over identifiers)
-    of lists of euler angles (as tuples) in rzxz conventions
+    identifiers : list of strings/ints
+        A list of phase identifiers referring to different atomic structures.
+    structures : list of diffpy.structure.Structure objects.
+        A list of diffpy.structure.Structure objects describing the atomic
+        structure associated with each phase in the library.
+    orientations : list
+        A list over identifiers of lists of euler angles (as tuples) in the rzxz
+        convention and in degrees.
     """
 
     def __init__(self,

--- a/pyxem/signals/crystallographic_map.py
+++ b/pyxem/signals/crystallographic_map.py
@@ -94,8 +94,8 @@ class CrystallographicMap(BaseSignal):
 
     def get_reliability_map_phase(self):
         """Obtain a reliability map showing the difference between the highest
-        correlation score of the most suitable phase
-        and the next best score from a different phase at each navigation position.
+        correlation score of the most suitable phase and the next best score
+        from a different phase at each navigation position.
         """
         return self.isig[6].as_signal2D((0,1))
 
@@ -119,7 +119,8 @@ class CrystallographicMap(BaseSignal):
         see also: method: save_mtex_map
         """
         modal_angle = self.get_modal_angles()[0]
-        return self.isig[1:4].map(_distance_from_fixed_angle,fixed_angle=modal_angle,inplace=False)
+        return self.isig[1:4].map(_distance_from_fixed_angle,
+                                  fixed_angle=modal_angle,inplace=False)
 
 
     def save_mtex_map(self, filename):

--- a/pyxem/signals/diffraction_simulation.py
+++ b/pyxem/signals/diffraction_simulation.py
@@ -22,7 +22,7 @@ import numpy as np
 from pyxem.signals.electron_diffraction import ElectronDiffraction
 
 class DiffractionSimulation:
-    """Holds the result of a given kinematic simulation of a diffraction pattern.
+    """Holds the result of a kinematic diffraction pattern simulation.
 
     Parameters
     ----------
@@ -137,7 +137,8 @@ class DiffractionSimulation:
 
         l,delta_l = np.linspace(-max_r, max_r, size,retstep=True)
 
-        mask_for_max_r = np.logical_and(np.abs(self.coordinates[:,0])<max_r,np.abs(self.coordinates[:,1])<max_r)
+        mask_for_max_r = np.logical_and(np.abs(self.coordinates[:,0])<max_r,
+                                        np.abs(self.coordinates[:,1])<max_r)
 
         coords = self.coordinates[mask_for_max_r]
         inten  = self.intensities[mask_for_max_r]
@@ -147,7 +148,8 @@ class DiffractionSimulation:
         if len(x) > 0: #avoiding problems in the peakless case
             num = np.digitize(x,l,right=True),np.digitize(y,l,right=True)
             dp_dat[num] = inten
-            dp_dat = point_spread(dp_dat,sigma=sigma/delta_l).T #sigma in terms of pixels. transpose for Hyperspy
+            #sigma in terms of pixels. transpose for Hyperspy
+            dp_dat = point_spread(dp_dat,sigma=sigma/delta_l).T
             dp_dat = dp_dat/np.max(dp_dat)
 
         dp = ElectronDiffraction(dp_dat)
@@ -178,7 +180,8 @@ class ProfileSimulation:
         self.intensities = intensities
         self.hkls = hkls
 
-    def get_plot(self, g_max, annotate_peaks=True, with_labels=True, fontsize=12):
+    def get_plot(self, g_max, annotate_peaks=True,
+                 with_labels=True, fontsize=12):
         """Plots the diffraction profile simulation.
 
         Parameters

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -17,12 +17,14 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 from hyperspy.signals import BaseSignal, Signal1D
+from hyperspy.api import markers
 
 import matplotlib.pyplot as plt
 from scipy.spatial import distance_matrix
 
 from pyxem.utils.expt_utils import *
 from pyxem.utils.vector_utils import *
+from pyxem.utils.plot import generate_marker_inputs_from_peaks
 
 """
 Signal class for diffraction vectors.
@@ -57,6 +59,15 @@ class DiffractionVectors(BaseSignal):
         ax.set_ylim(-ylim, ylim)
         ax.set_aspect('equal')
         return fig
+
+    def plot_diffraction_vectors_on_signal(self, signal):
+        """Plot the diffraction vectors on a signal.
+        """
+        mmx,mmy = generate_marker_inputs_from_peaks(self)
+        signal.plot(cmap='viridis', vmax=50)
+        for mx,my in zip(mmx,mmy):
+            m = markers.point(x=mx, y=my, color='red', marker='x')
+            signal.add_marker(m, plot_marker=True, permanent=False)
 
     def get_magnitudes(self, *args, **kwargs):
         """Calculate the magnitude of diffraction vectors.

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -109,7 +109,7 @@ class DiffractionVectors(BaseSignal):
         else:
             ghis = gmags.get_histogram(bins=bins)
 
-        ghis.axes_manager.signal_axes[0].name = 'g-vector magnitude'
+        ghis.axes_manager.signal_axes[0].name = 'k'
         ghis.axes_manager.signal_axes[0].units = '$A^{-1}$'
 
         return ghis

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -76,11 +76,21 @@ class DiffractionVectors(BaseSignal):
         ax.set_aspect('equal')
         return fig
 
-    def plot_diffraction_vectors_on_signal(self, signal):
+    def plot_diffraction_vectors_on_signal(self, signal, *args, **kwargs):
         """Plot the diffraction vectors on a signal.
+
+        Parameters
+        ----------
+        signal : ElectronDiffraction
+            The ElectronDiffraction signal object on which to plot the peaks.
+            This signal must have the same navigation dimensions as the peaks.
+        *args :
+            Arguments passed to signal.plot()
+        **kwargs :
+            Keyword arguments passed to signal.plot()
         """
         mmx,mmy = generate_marker_inputs_from_peaks(self)
-        signal.plot(cmap='viridis', vmax=50)
+        signal.plot(*args, **kwargs)
         for mx,my in zip(mmx,mmy):
             m = markers.point(x=mx, y=my, color='red', marker='x')
             signal.add_marker(m, plot_marker=True, permanent=False)

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -70,7 +70,7 @@ class DiffractionVectors(BaseSignal):
         #Plot the gvector positions
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(unique_vectors.data.T[1], unique_vectors.data.T[0], 'ro')
+        ax.plot(unique_vectors.data.T[0], unique_vectors.data.T[1], 'ro')
         ax.set_xlim(-xlim, xlim)
         ax.set_ylim(-ylim, ylim)
         ax.set_aspect('equal')

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -179,4 +179,17 @@ class DiffractionVectors(BaseSignal):
             crystim = crystim == 1
 
         crystim.change_dtype('float')
+
+        #Set calibration to same as signal
+        x = crystim.axes_manager.signal_axes[0]
+        y = crystim.axes_manager.signal_axes[1]
+
+        x.name = 'x'
+        x.scale = self.axes_manager.navigation_axes[0].scale
+        x.units = 'nm'
+
+        y.name = 'y'
+        y.scale = self.axes_manager.navigation_axes[0].scale
+        y.units = 'nm'
+
         return crystim

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -46,11 +46,27 @@ class DiffractionVectors(BaseSignal):
     def __init__(self, *args, **kwargs):
         BaseSignal.__init__(self, *args, **kwargs)
 
-    def plot_diffraction_vectors(self, xlim, ylim):
+    def plot_diffraction_vectors(self, xlim, ylim, distance_threshold):
         """Plot the unique diffraction vectors.
+
+        Parameters
+        ----------
+        xlim : float
+            The maximum x coordinate to be plotted.
+        ylim : float
+            The maximum y coordinate to be plotted.
+        distance_threshold : float
+            The minimum distance between diffraction vectors to be passed to
+            get_unique_vectors.
+
+        Returns
+        -------
+        fig : matplotlib figure
+            The plot as a matplot lib figure.
+
         """
         #Find the unique gvectors to plot.
-        unique_vectors = self.get_unique_vectors()
+        unique_vectors = self.get_unique_vectors(distance_threshold)
         #Plot the gvector positions
         fig = plt.figure()
         ax = fig.add_subplot(111)
@@ -72,6 +88,13 @@ class DiffractionVectors(BaseSignal):
     def get_magnitudes(self, *args, **kwargs):
         """Calculate the magnitude of diffraction vectors.
 
+        Parameters
+        ----------
+        *args:
+            Arguments to be passed to map().
+        **kwargs:
+            Keyword arguments to map().
+
         Returns
         -------
         magnitudes : BaseSignal
@@ -92,21 +115,25 @@ class DiffractionVectors(BaseSignal):
 
         return magnitudes
 
-    def get_magnitude_histogram(self, bins):
+    def get_magnitude_histogram(self, bins, *args, **kwargs):
         """Obtain a histogram of gvector magnitudes.
 
         Parameters
         ----------
         bins : numpy array
             The bins to be used to generate the histogram.
+        *args:
+            Arguments to get_magnitudes().
+        **kwargs:
+            Keyword arguments to get_magnitudes().
 
         Returns
         -------
-        ghist : Signal1D
+        ghis : Signal1D
             Histogram of gvector magnitudes.
 
         """
-        gmags = self.get_magnitudes()
+        gmags = self.get_magnitudes(*args, **kwargs)
 
         if len(self.axes_manager.signal_axes)==0:
             glist=[]

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -70,7 +70,7 @@ class DiffractionVectors(BaseSignal):
         #Plot the gvector positions
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(unique_vectors.data.T[0], unique_vectors.data.T[1], 'ro')
+        ax.plot(unique_vectors.data.T[0], -unique_vectors.data.T[1], 'ro')
         ax.set_xlim(-xlim, xlim)
         ax.set_ylim(-ylim, ylim)
         ax.set_aspect('equal')

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -444,19 +444,22 @@ class ElectronDiffraction(Signal2D):
         """
         nav_shape_x = self.data.shape[0]
         nav_shape_y = self.data.shape[1]
-        origin_coordinates = np.array((self.data.shape[2]/2-0.5,self.data.shape[3]/2-0.5))
+        origin_coordinates = np.array((self.data.shape[2]/2-0.5,
+                                       self.data.shape[3]/2-0.5))
 
         if square_width is not None:
             min_index = np.int(origin_coordinates[0]-(0.5+square_width))
             max_index = np.int(origin_coordinates[0]+(1.5+square_width)) #fails if non-square dp
             shifts = self.isig[min_index:max_index,min_index:max_index].get_direct_beam_position(radius_start,radius_finish,*args,**kwargs)
         else:
-            shifts = self.get_direct_beam_position(radius_start,radius_finish,*args,**kwargs)
+            shifts = self.get_direct_beam_position(radius_start, radius_finish,
+                                                   *args, **kwargs)
 
         shifts = -1*shifts.data
-        shifts = shifts.reshape(nav_shape_x*nav_shape_y,2)
+        shifts = shifts.reshape(nav_shape_x*nav_shape_y, 2)
 
-        return self.align2D(shifts=shifts, crop=False, fill_value=0,*args,**kwargs)
+        return self.align2D(shifts=shifts, crop=False, fill_value=0,
+                            *args, **kwargs)
 
     def remove_background(self, method,
                           *args, **kwargs):
@@ -523,7 +526,8 @@ class ElectronDiffraction(Signal2D):
                                      inplace=False, *args, **kwargs)
 
         elif method == 'reference_pattern':
-            bg_subtracted = self.map(subtract_reference, inplace=False, *args, **kwargs)
+            bg_subtracted = self.map(subtract_reference, inplace=False,
+                                     *args, **kwargs)
 
         else:
             raise NotImplementedError(
@@ -605,7 +609,7 @@ class ElectronDiffraction(Signal2D):
 
         peaks = self.map(method, *args, **kwargs, inplace=False, ragged=True)
         peaks.map(peaks_as_gvectors,
-                  center=np.array(self.axes_manager.signal_shape)/2 - 0.5,
+                  center=np.array(self.axes_manager.signal_shape) / 2 - 0.5,
                   calibration=self.axes_manager.signal_axes[0].scale)
         peaks = DiffractionVectors(peaks)
         peaks.axes_manager.set_signal_dimension(0)

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -373,7 +373,7 @@ class ElectronDiffraction(Signal2D):
         rp = ElectronDiffractionProfile(radial_profiles.as_signal1D(signal_axis))
         rp.axes_manager.navigation_axes = self.axes_manager.navigation_axes
         rp_axis = rp.axes_manager.signal_axes[0]
-        rp_axis.name = 'q'
+        rp_axis.name = 'k'
         rp_axis.scale = self.axes_manager.signal_axes[0].scale
         rp_axis.units = '$A^{-1}$'
 

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -52,15 +52,15 @@ class ElectronDiffraction(Signal2D):
                                     rocking_angle=None,
                                     rocking_frequency=None,
                                     exposure_time=None):
-        """Set the experimental parameters in metadata.
+        """Set experimental parameters in metadata.
 
         Parameters
         ----------
-        accelerating_voltage: float
+        accelerating_voltage : float
             Accelerating voltage in kV
         camera_length: float
             Camera length in cm
-        scan_rotation: float
+        scan_rotation : float
             Scan rotation in degrees
         convergence_angle : float
             Convergence angle in mrad
@@ -76,6 +76,10 @@ class ElectronDiffraction(Signal2D):
         if accelerating_voltage is not None:
             md.set_item("Acquisition_instrument.TEM.accelerating_voltage",
                         accelerating_voltage)
+        if camera_length is not None:
+            md.set_item(
+                "Acquisition_instrument.TEM.Detector.Diffraction.camera_length",
+                camera_length)
         if scan_rotation is not None:
             md.set_item("Acquisition_instrument.TEM.scan_rotation",
                         scan_rotation)
@@ -88,16 +92,10 @@ class ElectronDiffraction(Signal2D):
         if rocking_frequency is not None:
             md.set_item("Acquisition_instrument.TEM.rocking_frequency",
                         rocking_frequency)
-        if camera_length is not None:
-            md.set_item(
-                "Acquisition_instrument.TEM.Detector.Diffraction.camera_length",
-                camera_length
-            )
         if exposure_time is not None:
             md.set_item(
                 "Acquisition_instrument.TEM.Detector.Diffraction.exposure_time",
-                exposure_time
-            )
+                exposure_time)
 
     def set_diffraction_calibration(self, calibration, center=None):
         """Set diffraction pattern pixel size in reciprocal Angstroms and origin
@@ -105,9 +103,9 @@ class ElectronDiffraction(Signal2D):
 
         Parameters
         ----------
-        calibration: float
+        calibration : float
             Diffraction pattern calibration in reciprocal Angstroms per pixel.
-        center: tuple
+        center : tuple
             Position of the direct beam center, in pixels. If None the center of
             the data array is assumed to be the center of the pattern.
         """

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -193,12 +193,12 @@ class ElectronDiffraction(Signal2D):
 
         Parameters
         ----------
-        roi: :obj:`hyperspy.roi.BaseInteractiveROI`
+        roi : :obj:`hyperspy.roi.BaseInteractiveROI`
             Any interactive ROI detailed in HyperSpy.
 
         Returns
         -------
-        dark_field_sum: :obj:`hyperspy.signals.BaseSignal`
+        dark_field_sum : :obj:`hyperspy.signals.BaseSignal`
             The virtual image signal associated with the specified roi.
 
         Examples
@@ -215,8 +215,21 @@ class ElectronDiffraction(Signal2D):
             axis=dark_field.axes_manager.signal_axes
         )
         dark_field_sum.metadata.General.title = "Virtual Dark Field"
-        vdf = dark_field_sum.as_signal2D((0,1))
-        return vdf
+        vdfim = dark_field_sum.as_signal2D((0,1))
+
+        #Set calibration to same as signal
+        x = vdfim.axes_manager.signal_axes[0]
+        y = vdfim.axes_manager.signal_axes[1]
+
+        x.name = 'x'
+        x.scale = self.axes_manager.navigation_axes[0].scale
+        x.units = 'nm'
+
+        y.name = 'y'
+        y.scale = self.axes_manager.navigation_axes[0].scale
+        y.units = 'nm'
+
+        return vdfim
 
     def get_direct_beam_mask(self, radius):
         """Generate a signal mask for the direct beam.

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -485,7 +485,7 @@ class ElectronDiffraction(Signal2D):
             Size of the window that is convoluted with the array to determine
             the median. Should be large enough that it is about 3x as big as the
             size of the peaks (median only).
-        implementation: 'scipy' or 'skimage'
+        implementation : 'scipy' or 'skimage'
             (median only) see expt_utils.subtract_background_median
             for details, if not selected 'scipy' is used
         bg : array
@@ -609,6 +609,18 @@ class ElectronDiffraction(Signal2D):
                   calibration=self.axes_manager.signal_axes[0].scale)
         peaks = DiffractionVectors(peaks)
         peaks.axes_manager.set_signal_dimension(0)
+
+        #Set calibration to same as signal
+        x = peaks.axes_manager.navigation_axes[0]
+        y = peaks.axes_manager.navigation_axes[1]
+
+        x.name = 'x'
+        x.scale = self.axes_manager.navigation_axes[0].scale
+        x.units = 'nm'
+
+        y.name = 'y'
+        y.scale = self.axes_manager.navigation_axes[0].scale
+        y.units = 'nm'
 
         return peaks
 

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -193,7 +193,7 @@ class ElectronDiffraction(Signal2D):
 
         Parameters
         ----------
-        roi : :obj:`hyperspy.roi.BaseInteractiveROI`
+        roi: :obj:`hyperspy.roi.BaseInteractiveROI`
             Any interactive ROI detailed in HyperSpy.
 
         Returns
@@ -216,18 +216,6 @@ class ElectronDiffraction(Signal2D):
         )
         dark_field_sum.metadata.General.title = "Virtual Dark Field"
         vdfim = dark_field_sum.as_signal2D((0,1))
-
-        #Set calibration to same as signal
-        x = vdfim.axes_manager.signal_axes[0]
-        y = vdfim.axes_manager.signal_axes[1]
-
-        x.name = 'x'
-        x.scale = self.axes_manager.navigation_axes[0].scale
-        x.units = 'nm'
-
-        y.name = 'y'
-        y.scale = self.axes_manager.navigation_axes[0].scale
-        y.units = 'nm'
 
         return vdfim
 
@@ -556,10 +544,8 @@ class ElectronDiffraction(Signal2D):
 
         Returns
         -------
-
         The results are stored in self.learning_results. For a full description
         of parameters see :meth:`hyperspy.learn.mva.MVA.decomposition`
-
 
         """
         super(Signal2D, self).decomposition(*args, **kwargs)
@@ -590,10 +576,10 @@ class ElectronDiffraction(Signal2D):
             * 'xc' - A cross correlation peakfinder
 
 
-        *args
-            associated with above methods
-        **kwargs
-            associated with above methods.
+        *args:
+            Arguments to be passed to the peak finders.
+        **kwargs:
+            Keyword arguments to be passed to the peak finders.
 
         Returns
         -------

--- a/tests/test_generators/test_library_generator.py
+++ b/tests/test_generators/test_library_generator.py
@@ -46,8 +46,10 @@ class TestDiffractionLibraryGenerator:
     def test_get_diffraction_library(
             self,
             library_generator: DiffractionLibraryGenerator,
-            structure_library, calibration, reciprocal_radius, half_shape, with_direct_beam
+            structure_library, calibration,
+            reciprocal_radius, half_shape, with_direct_beam
             ):
         library = library_generator.get_diffraction_library(
-            structure_library, calibration, reciprocal_radius,half_shape, with_direct_beam)
+            structure_library, calibration,
+            reciprocal_radius,half_shape, with_direct_beam)
         assert isinstance(library, DiffractionLibrary)

--- a/tests/test_library/test_diffraction_library.py
+++ b/tests/test_library/test_diffraction_library.py
@@ -30,17 +30,24 @@ from pyxem.libraries.structure_library import StructureLibrary
 def get_library(default_structure):
         diffraction_calculator = pxm.DiffractionGenerator(300., 0.02)
         dfl = pxm.DiffractionLibraryGenerator(diffraction_calculator)
-        structure_library = StructureLibrary(['Phase'],[default_structure],[[(0, 0, 0),(0,0.2,0)]])
+        structure_library = StructureLibrary(['Phase'],
+                                             [default_structure],
+                                             [[(0, 0, 0),(0,0.2,0)]])
 
-        return dfl.get_diffraction_library(structure_library, 0.017, 2.4, (72,72))
+        return dfl.get_diffraction_library(structure_library,
+                                           0.017, 2.4, (72,72))
 
 def test_get_library_entry_assertionless(get_library):
-        assert isinstance(get_library.get_library_entry()['Sim'],DiffractionSimulation)
-        assert isinstance(get_library.get_library_entry(phase='Phase')['Sim'],DiffractionSimulation)
+        assert isinstance(get_library.get_library_entry()['Sim'],
+                                                        DiffractionSimulation)
+        assert isinstance(get_library.get_library_entry(phase='Phase')['Sim'],
+                                                        DiffractionSimulation)
 
 def test_get_library_small_offeset(get_library):
-    alpha = get_library.get_library_entry(phase='Phase',angle=(0,0,0))['intensities']
-    beta  = get_library.get_library_entry(phase='Phase',angle=(1e-8,0,0))['intensities']
+    alpha = get_library.get_library_entry(phase='Phase',
+                                          angle=(0,0,0))['intensities']
+    beta  = get_library.get_library_entry(phase='Phase',
+                                          angle=(1e-8,0,0))['intensities']
     assert np.allclose(alpha,beta)
 
 
@@ -48,13 +55,17 @@ def test_library_io(get_library):
     get_library.pickle_library('file_01.pickle')
     loaded_library = load_DiffractionLibrary('file_01.pickle',safety=True)
     os.remove('file_01.pickle')
-    # we can't check that the entire libraries are the same as the memory location of the 'Sim' changes
-    assert np.allclose(get_library['Phase'][(0,0,0)]['intensities'],loaded_library['Phase'][(0,0,0)]['intensities'])
+    # We can't check that the entire libraries are the same as the memory
+    # location of the 'Sim' changes
+    assert np.allclose(get_library['Phase'][(0,0,0)]['intensities'],
+                       loaded_library['Phase'][(0,0,0)]['intensities'])
 
 @pytest.mark.xfail(raises=ValueError)
 def test_unknown_library_entry(get_library):
     # The angle we have asked for is not in the library
-    assert isinstance(get_library.get_library_entry(phase='Phase',angle=(1e-3,0,0))['Sim'],DiffractionSimulation)
+    assert isinstance(get_library.get_library_entry(phase='Phase',
+                                                    angle=(1e-3,0,0))['Sim'],
+                                                    DiffractionSimulation)
 
 @pytest.mark.xfail(raises=RuntimeError)
 def test_unsafe_loading(get_library):

--- a/tests/test_signals/test_diffraction_vectors.py
+++ b/tests/test_signals/test_diffraction_vectors.py
@@ -83,6 +83,10 @@ def test_plot_diffraction_vectors(diffraction_vectors_map):
     diffraction_vectors_map.plot_diffraction_vectors(xlim=1., ylim=1.,
                                                      distance_threshold=0)
 
+def test_plot_diffraction_vectors_on_signal(diffraction_vectors_map,
+                                            diffraction_pattern):
+    diffraction_vectors_map.plot_diffraction_vectors_on_signal(diffraction_pattern)
+
 
 class TestMagnitudes:
 

--- a/tests/test_signals/test_diffraction_vectors.py
+++ b/tests/test_signals/test_diffraction_vectors.py
@@ -80,7 +80,8 @@ def diffraction_vectors_map(request):
     return dvm
 
 def test_plot_diffraction_vectors(diffraction_vectors_map):
-    diffraction_vectors_map.plot_diffraction_vectors(xlim=1., ylim=1.)
+    diffraction_vectors_map.plot_diffraction_vectors(xlim=1., ylim=1.,
+                                                     distance_threshold=0)
 
 
 class TestMagnitudes:


### PR DESCRIPTION
This PR will ensure that all functions/generators that convert between signal classes in pyxem transfer the appropriate axes to the resulting class, this requires identifying where this currently does not happen and correcting the behavior.