### PR TITLE
Store vectors used to generate VDFImage object as an attribute

### DIFF
--- a/pyxem/generators/vdf_generator.py
+++ b/pyxem/generators/vdf_generator.py
@@ -106,7 +106,7 @@ class VDFGenerator():
         y.units = 'nm'
 
         # Assign vectors used to generate images to vdfim property
-        vdfim.vectors = vectors.data
+        vdfim.vectors = self.vectors.data
 
         return vdfim
 

--- a/pyxem/generators/vdf_generator.py
+++ b/pyxem/generators/vdf_generator.py
@@ -105,6 +105,9 @@ class VDFGenerator():
         y.scale = self.signal.axes_manager.navigation_axes[0].scale
         y.units = 'nm'
 
+        # Assign vectors used to generate images to vdfim property
+        vdfim.vectors = vectors.data
+
         return vdfim
 
     def get_concentric_vdf_images(self,

--- a/pyxem/generators/vdf_generator.py
+++ b/pyxem/generators/vdf_generator.py
@@ -105,7 +105,7 @@ class VDFGenerator():
         y.scale = self.signal.axes_manager.navigation_axes[0].scale
         y.units = 'nm'
 
-        # Assign vectors used to generate images to vdfim property
+        # Assign vectors used to generate images to vdfim attribute.
         vdfim.vectors = self.vectors.data
 
         return vdfim

--- a/pyxem/signals/vdf_image.py
+++ b/pyxem/signals/vdf_image.py
@@ -27,3 +27,4 @@ class VDFImage(Signal2D):
 
     def __init__(self, *args, **kwargs):
         Signal2D.__init__(self, *args, **kwargs)
+        self.vectors = None


### PR DESCRIPTION
@tinabe - this means that the x/y coordinates of the vectors used to generate a VDFImage object are now stored as an attribute of the VDFImage as discussed earlier.