### PR TITLE
Kinematic intensity non cubic

### DIFF
--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -196,12 +196,13 @@ def get_kinematical_intensities(structure,
         fss.append(fs)
     fss = np.array(fss)
 
+    # Change the coordinate system of fcoords to align with that of g_indices
+    fcoords = np.dot(fcoords, np.linalg.inv(np.dot(structure.lattice.stdbase, structure.lattice.recbase)))
+
     # Calculate structure factors for all excited g-vectors.
     f_hkls = []
     for n in np.arange(len(g_indices)):
         g = g_indices[n]
-        q3 = mat2quat(structure.lattice.baserot)
-        g = rotate_vector(g, q3)
         fs = fss[n]
         dw_correction = np.exp(-dwfactors * s2s[n])
         f_hkl = np.sum(fs * occus * np.exp(2j * np.pi * np.dot(fcoords, g))

--- a/tests/test_physical/test_orientation_mapping_phys.py
+++ b/tests/test_physical/test_orientation_mapping_phys.py
@@ -22,9 +22,11 @@ import pyxem as pxm
 import hyperspy.api as hs
 import diffpy.structure
 
+from transforms3d.euler import euler2mat
+
 from pyxem.generators.indexation_generator import IndexationGenerator
 from pyxem.libraries.structure_library import StructureLibrary
-from pyxem.utils.sim_utils import peaks_from_best_template
+from pyxem.utils.sim_utils import peaks_from_best_template, get_kinematical_intensities
 
 """
 The test are designed to make sure orientation mapping works when actual
@@ -49,6 +51,28 @@ def create_Hex():
     latt = diffpy.structure.lattice.Lattice(3, 3, 5, 90, 90, 120)
     atom = diffpy.structure.atom.Atom(atype='Ni', xyz=[0, 0, 0], lattice=latt)
     return diffpy.structure.Structure(atoms=[atom], lattice=latt)
+
+
+def create_wurtzite(rotation=None):
+    """Construct a hexagonal P63mc GaAs Wurtzite structure. """
+    if rotation is None:
+        rotation = np.eye(3)
+    a = 4.053
+    c = 6.680
+    lattice = diffpy.structure.lattice.Lattice(a, a, c, 90, 90, 120)
+    atom_list = []
+    for x, y, z in [(1 / 3, 2 / 3, 0), (2 / 3, 1 / 3, 1 / 2)]:
+        atom_list.append(
+            diffpy.structure.atom.Atom(
+                atype='Ga',
+                xyz=[x, y, z],
+                lattice=lattice))
+        atom_list.append(
+            diffpy.structure.atom.Atom(
+                atype='As',
+                xyz=[x + 3 / 8, y + 3 / 8, z + 3 / 8],
+                lattice=lattice))
+    return diffpy.structure.Structure(atoms=atom_list, lattice=lattice)
 
 
 @pytest.fixture
@@ -116,3 +140,24 @@ def test_generate_peaks_from_best_template():
     peaks = M.map(peaks_from_best_template,
                   phase=["A"], library=library, inplace=False)
     assert peaks.inav[0, 0] == library["A"][(0, 0, 0)]['Sim'].coordinates[:, :2]
+
+
+@pytest.mark.parametrize("structure, rotation", [(create_wurtzite(), euler2mat(0, np.pi / 2, 0, 'rzxz'))])
+def test_kinematic_intensities_rotation(structure, rotation):
+    """Test that kinematically forbidden diffraction spots gets zero intensity also after rotation."""
+    rotated_lattice = diffpy.structure.lattice.Lattice(structure.lattice)
+    rotated_lattice.setLatPar(baserot=rotation)
+    structure.placeInLattice(rotated_lattice)
+    reciprocal_lattice = structure.lattice.reciprocal()
+    g_indices = [(0, 0, 1)]
+    g_hkls = np.array([reciprocal_lattice.dist(g_indices, [0, 0, 0])])
+
+    intensities = get_kinematical_intensities(
+        structure,
+        g_indices,
+        g_hkls,
+        excitation_error=0,
+        maximum_excitation_error=1,
+        debye_waller_factors={})
+
+    np.testing.assert_almost_equal(intensities, [0])

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -20,8 +20,6 @@ import pytest
 import numpy as np
 import diffpy
 
-from transforms3d.euler import euler2mat
-
 from pyxem.signals.electron_diffraction import ElectronDiffraction
 from pyxem.utils.sim_utils import *
 
@@ -58,47 +56,6 @@ def test_get_points_in_sphere():
     assert len(ind) == len(cord)
     assert len(ind) == len(dist)
     assert len(dist) == 1 + 6
-
-
-def make_structure_hexagonal(rotation=None):
-    """Construct a hexagonal P63mc GaAs Wurtzite structure. """
-    if rotation is None:
-        rotation = np.eye(3)
-    a = 4.053
-    c = 6.680
-    lattice = diffpy.structure.lattice.Lattice(a, a, c, 90, 90, 120)
-    atom_list = []
-    for x, y, z in [(1/3, 2/3, 0), (2/3, 1/3, 1/2)]:
-        atom_list.append(
-                diffpy.structure.atom.Atom(
-                    atype='Ga',
-                    xyz=[x, y, z],
-                    lattice=lattice))
-        atom_list.append(
-                diffpy.structure.atom.Atom(
-                    atype='As',
-                    xyz=[x + 3/8, y + 3/8, z + 3/8],
-                    lattice=lattice))
-    return diffpy.structure.Structure(atoms=atom_list, lattice=lattice)
-
-
-def test_kinematic_intensities_rotation():
-    """Test that kinematically forbidden diffraction spots gets zero intensity also after rotation."""
-    rotation = euler2mat(0, np.pi/2, 0, 'rzxz')
-    structure = make_structure_hexagonal(rotation)
-    reciprocal_lattice = structure.lattice.reciprocal()
-    g_indices = [(0, 0, 1)]
-    g_hkls = np.array([reciprocal_lattice.dist(g_indices, [0, 0, 0])])
-
-    intensities = get_kinematical_intensities(
-            structure,
-            g_indices,
-            g_hkls,
-            excitation_error=0,
-            maximum_excitation_error=1,
-            debye_waller_factors={})
-
-    np.testing.assert_almost_equal(intensities, [0])
 
 
 def test_kinematic_simulator_plane_wave():

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -20,6 +20,8 @@ import pytest
 import numpy as np
 import diffpy
 
+from transforms3d.euler import euler2mat
+
 from pyxem.signals.electron_diffraction import ElectronDiffraction
 from pyxem.utils.sim_utils import *
 
@@ -56,6 +58,47 @@ def test_get_points_in_sphere():
     assert len(ind) == len(cord)
     assert len(ind) == len(dist)
     assert len(dist) == 1 + 6
+
+
+def make_structure_hexagonal(rotation=None):
+    """Construct a hexagonal P63mc GaAs Wurtzite structure. """
+    if rotation is None:
+        rotation = np.eye(3)
+    a = 4.053
+    c = 6.680
+    lattice = diffpy.structure.lattice.Lattice(a, a, c, 90, 90, 120)
+    atom_list = []
+    for x, y, z in [(1/3, 2/3, 0), (2/3, 1/3, 1/2)]:
+        atom_list.append(
+                diffpy.structure.atom.Atom(
+                    atype='Ga',
+                    xyz=[x, y, z],
+                    lattice=lattice))
+        atom_list.append(
+                diffpy.structure.atom.Atom(
+                    atype='As',
+                    xyz=[x + 3/8, y + 3/8, z + 3/8],
+                    lattice=lattice))
+    return diffpy.structure.Structure(atoms=atom_list, lattice=lattice)
+
+
+def test_kinematic_intensities_rotation():
+    """Test that kinematically forbidden diffraction spots gets zero intensity also after rotation."""
+    rotation = euler2mat(0, np.pi/2, 0, 'rzxz')
+    structure = make_structure_hexagonal(rotation)
+    reciprocal_lattice = structure.lattice.reciprocal()
+    g_indices = [(0, 0, 1)]
+    g_hkls = np.array([reciprocal_lattice.dist(g_indices, [0, 0, 0])])
+
+    intensities = get_kinematical_intensities(
+            structure,
+            g_indices,
+            g_hkls,
+            excitation_error=0,
+            maximum_excitation_error=1,
+            debye_waller_factors={})
+
+    np.testing.assert_almost_equal(intensities, [0])
 
 
 def test_kinematic_simulator_plane_wave():


### PR DESCRIPTION
---
name: Kinematic intensity calculation
about: Fix the calculation of diffraction spot intensities for rotated, non-cubic crystal structures.

---

**What does this PR do? Please describe or link to an open issue.**
In `get_kinematic_intensities`, rotation of the structure is currently handled by applying the same rotation to g-vectors before intensity calculation. This only works for orthogonal coordinate systems. See #311.

This change fixes the problem by transforming `fcoords` back to an un-rotated state by applying the inverse transform that has been applied to the atom coordinates. The transform includes the `lattice.stdbase` to handle non-orthonormal coordinate systems and `lattice.recbase` for the rotation.

This fixes #311.

**Are there any known issues? Do you need help?**
Any structure with a kinematically extinct spot should do for the testing, so a simpler structure could be used. The wurtzite is just what I happen to be working on currently.
