### PR TITLE
Add windows batch version of pepstorm autopep8

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -80,12 +80,22 @@ consistency that you can read all about in the `Python Style Guide
 <https://www.python.org/dev/peps/pep-0008/>`_.
 
 To enforce this, we require that the following auto correction is applied at the end of pull request. The simplest
-option is to run (from the home directory of pyxem) 
+option is to run (from the home directory of pyxem)
+
+Linux:
 
 .. code:: bash
 
     chmod +x pepstorm.sh	
     ./pepstorm.sh
+    git add .
+    git commit -m "autopep8 corrections"
+
+Windows:
+
+.. code:: batch
+
+    pepstorm.bat
     git add .
     git commit -m "autopep8 corrections"
 

--- a/pepstorm.bat
+++ b/pepstorm.bat
@@ -1,0 +1,16 @@
+@echo off
+set root_dir=%~dp0
+pushd %root_dir%
+cd tests
+for /D %%G in ("test_*") do (
+    cd %%G
+	for /R %%G in ("*.py") do autopep8 --aggressive --in-place --max-line-length 130 %%G
+	cd ..
+)
+cd ../pyxem
+for %%G in (components generators libraries signals utils) do (
+	cd %%G
+	for /R %%G in ("*.py") do autopep8 --aggressive --in-place --max-line-length 130 %%G
+	cd ..
+)
+popd


### PR DESCRIPTION
---
name: Windows pepstorm
about: Add `pepstorm.bat` to run autopep8 on all python files.

---

**What does this PR do? Please describe or link to an open issue.**
This is a direct conversion of `pepstorm.sh` for Windows. The `CONTRIBUTING.rst` is also updated.