### PR TITLE
Correlate speedup

### DIFF
--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -59,6 +59,7 @@ def correlate_library(image, library, n_largest, mask, keys=[]):
     if mask == 1:
         for phase_index, key in enumerate(library.keys()):
             correlations = np.empty((len(library[key]), 4))
+            # Use enumerate to index, i, each (orientation, diffraction_pattern) in list
             for i, (orientation, diffraction_pattern) in enumerate(library[key].items()):
                 correlation = correlate(image, diffraction_pattern)
                 correlations[i, :] = *orientation, correlation


### PR DESCRIPTION
---
name: Speedup of `indexation_generator::correlate_library`
about: Major speedup of the correlate library function by fixing a bug and rewriting to numpy

---

**What does this PR do? Please describe or link to an open issue.**
`correlate_library` is calling `nlargest` in the inner loop, while it is only necessary in the outer loop. Here, I have moved the sorting to the outer loop, once per phase. Only changing this (two lines with indent changes) gives a large speedup, 20x for an arbitrary test case I had (40 min -> 2 min, ~1 it/s -> ~20 it/s). I also rewrote the sorting to use numpy, which also helps the speed, although less compared to the initial speedup. The algorithm is still the same, but it requires a larger change. 90% of the time is now spent in the actual correlation function.

This change has to be merged with the changes in #315, but only the function body should have to change. I mostly copied the new docstring from that PR. Also: The keys parameter is not used, but should possibly be kept for API consistency. Do you have a plan for deprecation notices?

Comparisons with and without numpy implementation:

With heapq.nlargest (moved outside the inner loop):

    Total time: 36.3351 s
    File: ..\test_code\template_profiling.py
    Function: correlate_library_old at line 56

    Line #      Hits         Time  Per Hit   % Time  Line Contents
    ==============================================================
        56                                           @profile
        57                                           def correlate_library(image, library, n_largest, mask, keys=[]):
        58       600       1388.0      2.3      0.0      i = 0
        59       600       5559.0      9.3      0.0      out_arr = np.zeros((n_largest * len(library), 5))
        60       600       3169.0      5.3      0.0      if mask == 1:
        61      1800       5700.0      3.2      0.0          for key in library.keys():
        62      1200      40765.0     34.0      0.0              correlations = dict()
        63   2315400    4065112.0      1.8      4.8              for orientation, diffraction_pattern in library[key].items():
        64   2314200   65265126.0     28.2     76.8                  correlation = correlate(image, diffraction_pattern)
        65   2314200    5401660.0      2.3      6.4                  correlations[orientation] = correlation
        66      1200       6178.0      5.1      0.0              res = nlargest(n_largest, correlations.items(),
        67      1200   10020137.0   8350.1     11.8                             key=itemgetter(1))
        68      6000      52180.0      8.7      0.1              for j in np.arange(n_largest):
        69      4800      29745.0      6.2      0.0                  out_arr[j + i * n_largest][0] = i
        70      4800      18210.0      3.8      0.0                  out_arr[j + i * n_largest][1] = res[j][0][0]
        71      4800      15447.0      3.2      0.0                  out_arr[j + i * n_largest][2] = res[j][0][1]
        72      4800      15645.0      3.3      0.0                  out_arr[j + i * n_largest][3] = res[j][0][2]
        73      4800      14843.0      3.1      0.0                  out_arr[j + i * n_largest][4] = res[j][1]
        74      1200       2314.0      1.9      0.0              i = i + 1
        75
        76                                               else:
        77                                                   for j in np.arange(n_largest):
        78                                                       for k in [0, 1, 2, 3, 4]:
        79                                                           out_arr[j + i * n_largest][k] = np.nan
        80                                                   i = i + 1
        81       600        815.0      1.4      0.0      return out_arr

With numpy.argpartition:
    Total time: 31.9971 s
    File: ..\test_code\template_profiling.py
    Function: correlate_library_new at line 83
    
    Line #      Hits         Time  Per Hit   % Time  Line Contents
    ==============================================================
        83                                           @profile
        84                                           def correlate_library(image, library, n_largest, mask, keys=[]):
        85       600       6018.0     10.0      0.0      out_arr = np.zeros((len(library), n_largest, 5))
        86       600       5458.0      9.1      0.0      if mask == 1:
        87      1800       8599.0      4.8      0.0          for phase_index, key in enumerate(library.keys()):
        88      1200      17572.0     14.6      0.0              correlations = np.empty((len(library[key]), 4))
        89      1200    2696645.0   2247.2      3.6              correlations[:, 0:3] = np.asarray([*library[key].keys()])
        90   2315400    4680219.0      2.0      6.3              for i, (orientation, diffraction_pattern) in enumerate(library[key].items()):
        91   2314200   67251157.0     29.1     89.9                  correlations[i, 3] = correlate(image, diffraction_pattern)
        92      1200     108223.0     90.2      0.1              res = correlations[correlations[:, 3].argpartition(-n_largest)[-n_largest:]]
        93      1200      20812.0     17.3      0.0              res = res[res[:, 3].argsort()][::-1]
        94      1200       9062.0      7.6      0.0              out_arr[phase_index, :, 0] = phase_index
        95      1200       8874.0      7.4      0.0              out_arr[phase_index, :, 1:] = res
        96                                               else:
        97                                                   out_arr.fill(np.nan)
        98       600       7686.0     12.8      0.0      return out_arr.reshape((len(library) * n_largest, 5))

**Describe the new behaviour**
No change in behaviour, the output of the old and new implementations are identical.