### PR TITLE
Structure library generator and rotation lists

### DIFF
--- a/pyxem/generators/structure_library_generator.py
+++ b/pyxem/generators/structure_library_generator.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyxem.libraries.structure_library import StructureLibrary
+from pyxem.utils.sim_utils import rotation_list_stereographic
+
+"""Generating structure libraries."""
+
+# Inverse pole figure corners for crystal systems
+stereographic_corners = {
+        'cubic': [ (0, 0, 1), (1, 0, 1), (1, 1, 1) ],
+        'hexagonal': [ (0, 0, 0, 1), (1, 0, -1, 0), (1, 1, -2, 0) ],
+        'orthorombic': [ (0, 0, 1), (1, 0, 0), (0, 1, 0) ],
+        'tetragonal': [ (0, 0, 1), (1, 0, 0), (1, 1, 0) ],
+        'trigonal': [ (0, 0, 0, 1), (0, -1, 1, 0), (1, -1, 0, 0) ],
+        'monoclinic': [ (0, 0, 1), (0, 1, 0), (0, -1, 0) ]
+}
+
+
+class StructureLibraryGenerator:
+    def __init__(self, phases):
+        self.phase_names = [phase[0] for phase in phases]
+        self.structures = [phase[1] for phase in phases]
+        self.systems = [phase[2] for phase in phases]
+
+
+    def get_orientations_from_list(self, rotation_lists):
+        return StructureLibrary(self.phase_names, self.structures, rotation_lists)
+
+
+    def get_orientations_from_stereographic_triangle(self, inplane_rotations, resolution):
+        rotation_lists = [
+                rotation_list_stereographic(structure, *stereographic_corners[system], inplane_rotation, resolution)
+                    for phase_name, structure, system, inplane_rotation in
+                        zip(self.phase_names, self.structures, self.systems, inplane_rotations)]
+        return StructureLibrary(self.phase_names, self.structures, rotation_lists)

--- a/pyxem/generators/structure_library_generator.py
+++ b/pyxem/generators/structure_library_generator.py
@@ -33,17 +33,74 @@ stereographic_corners = {
 
 
 class StructureLibraryGenerator:
+    """Generates a structure library for the given phases
+
+    Parameters
+    ----------
+    phases : list
+        Array of three-component phase descriptions, where the phase
+        description is [<phase name> : string, <structure> :
+        diffpy.structure.Structure, <crystal system> : string], and crystal
+        system is one of 'cubic', 'hexagonal', 'orthorombic', 'tetragonal',
+        'trigonal', 'monoclinic'.
+
+    Attributes
+    ----------
+    phase_names : list of string
+        List of phase names.
+    structures : list of diffpy.structure.Structure
+        List of structures.
+    systems : list of string
+        List of crystal systems.
+
+    Examples
+    --------
+    >>> gen = StructureLibraryGenerator([
+    ...     ('ZB', structure_zb, 'cubic'),
+    ...     ('WZ', structure_wz, 'hexagonal')])
+    """
+
     def __init__(self, phases):
         self.phase_names = [phase[0] for phase in phases]
         self.structures = [phase[1] for phase in phases]
         self.systems = [phase[2] for phase in phases]
 
 
-    def get_orientations_from_list(self, rotation_lists):
-        return StructureLibrary(self.phase_names, self.structures, rotation_lists)
+    def get_orientations_from_list(self, orientations):
+        """Create a structure library from a list of rotations.
+
+        Parameters
+        ----------
+        orientations : list
+            A list over identifiers of lists of euler angles (as tuples) in the rzxz
+            convention and in degrees.
+
+        Returns
+        -------
+        structure_library : StructureLibrary
+            Structure library for the given phase names, structures and orientations.
+        """
+        return StructureLibrary(self.phase_names, self.structures, orientations)
 
 
     def get_orientations_from_stereographic_triangle(self, inplane_rotations, resolution):
+        """
+        Create a structure library from the stereographic triangles of the
+        given crystal systems.
+
+        Parameters
+        ----------
+        inplane_rotations : list
+            List over identifiers of lists of inplane rotations of the
+            diffraction patterns, in degrees.
+        resolution : float
+            Rotation list resolution in degrees.
+
+        Returns
+        -------
+        structure_library : StructureLibrary
+            Structure library for the given phase names, structures and crystal system.
+        """
         rotation_lists = [
                 rotation_list_stereographic(structure, *stereographic_corners[system], inplane_rotation, resolution)
                     for phase_name, structure, system, inplane_rotation in

--- a/pyxem/generators/structure_library_generator.py
+++ b/pyxem/generators/structure_library_generator.py
@@ -23,12 +23,12 @@ from pyxem.utils.sim_utils import rotation_list_stereographic
 
 # Inverse pole figure corners for crystal systems
 stereographic_corners = {
-        'cubic': [ (0, 0, 1), (1, 0, 1), (1, 1, 1) ],
-        'hexagonal': [ (0, 0, 0, 1), (1, 0, -1, 0), (1, 1, -2, 0) ],
-        'orthorombic': [ (0, 0, 1), (1, 0, 0), (0, 1, 0) ],
-        'tetragonal': [ (0, 0, 1), (1, 0, 0), (1, 1, 0) ],
-        'trigonal': [ (0, 0, 0, 1), (0, -1, 1, 0), (1, -1, 0, 0) ],
-        'monoclinic': [ (0, 0, 1), (0, 1, 0), (0, -1, 0) ]
+    'cubic': [(0, 0, 1), (1, 0, 1), (1, 1, 1)],
+    'hexagonal': [(0, 0, 0, 1), (1, 0, -1, 0), (1, 1, -2, 0)],
+    'orthorombic': [(0, 0, 1), (1, 0, 0), (0, 1, 0)],
+    'tetragonal': [(0, 0, 1), (1, 0, 0), (1, 1, 0)],
+    'trigonal': [(0, 0, 0, 1), (0, -1, 1, 0), (1, -1, 0, 0)],
+    'monoclinic': [(0, 0, 1), (0, 1, 0), (0, -1, 0)]
 }
 
 
@@ -65,7 +65,6 @@ class StructureLibraryGenerator:
         self.structures = [phase[1] for phase in phases]
         self.systems = [phase[2] for phase in phases]
 
-
     def get_orientations_from_list(self, orientations):
         """Create a structure library from a list of rotations.
 
@@ -81,7 +80,6 @@ class StructureLibraryGenerator:
             Structure library for the given phase names, structures and orientations.
         """
         return StructureLibrary(self.phase_names, self.structures, orientations)
-
 
     def get_orientations_from_stereographic_triangle(self, inplane_rotations, resolution):
         """
@@ -102,7 +100,7 @@ class StructureLibraryGenerator:
             Structure library for the given phase names, structures and crystal system.
         """
         rotation_lists = [
-                rotation_list_stereographic(structure, *stereographic_corners[system], inplane_rotation, resolution)
-                    for phase_name, structure, system, inplane_rotation in
-                        zip(self.phase_names, self.structures, self.systems, inplane_rotations)]
+            rotation_list_stereographic(structure, *stereographic_corners[system], inplane_rotation, resolution)
+            for phase_name, structure, system, inplane_rotation in
+            zip(self.phase_names, self.structures, self.systems, inplane_rotations)]
         return StructureLibrary(self.phase_names, self.structures, rotation_lists)

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -428,9 +428,9 @@ def uvtw_to_uvw(uvtw):
     uvw : tuple of 4 floats
     """
     u, v, t, w = uvtw
-    u, v, w = 2*u + v, 2*v + u, w
+    u, v, w = 2 * u + v, 2 * v + u, w
     common_factor = math.gcd(math.gcd(u, v), w)
-    return tuple((int(x/common_factor)) for x in (u, v, w))
+    return tuple((int(x / common_factor)) for x in (u, v, w))
 
 
 def angle_between_cartesian(a, b):
@@ -446,7 +446,7 @@ def angle_between_cartesian(a, b):
     angle : float
         Angle between `a` and `b` in radians.
     """
-    return math.acos(min(1.0, np.dot(a, b)/(np.linalg.norm(a)*np.linalg.norm(b))))
+    return math.acos(min(1.0, np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))))
 
 
 def rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution):

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -477,7 +477,7 @@ def rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane
         Rotations covering the inverse pole figure given as a of Euler
             angles in degress. This `np.array` can be passed directly to pyxem.
     """
-    # Convert the crystal directions to cartesian vectors
+    # Convert the crystal directions to cartesian vectors and normalize
     if len(corner_a) == 4:
         corner_a = uvtw_to_uvw(corner_a)
     if len(corner_b) == 4:
@@ -487,18 +487,9 @@ def rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane
 
     lattice = structure.lattice
 
-    corner_a = corner_a @ lattice.stdbase
-    corner_b = corner_b @ lattice.stdbase
-    corner_c = corner_c @ lattice.stdbase
-
-    # Rotate the list such that corner_a parallel (0, 0, 1)
-    angle_corner_a = angle_between_cartesian(corner_a, (0, 0, 1))
-    if not np.allclose(angle_corner_a, 0):
-        axis_corner_a_to_up = np.cross(corner_a, (0, 0, 1))
-        rotation_corner_a_to_up = axangle2mat(axis_corner_a_to_up, angle_corner_a)
-        corner_a = rotation_corner_a_to_up @ corner_a
-        corner_b = rotation_corner_a_to_up @ corner_b
-        corner_c = rotation_corner_a_to_up @ corner_c
+    corner_a = np.dot(corner_a, lattice.stdbase)
+    corner_b = np.dot(corner_b, lattice.stdbase)
+    corner_c = np.dot(corner_c, lattice.stdbase)
 
     corner_a /= np.linalg.norm(corner_a)
     corner_b /= np.linalg.norm(corner_b)

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -446,7 +446,7 @@ def angle_between_cartesian(a, b):
     angle : float
         Angle between `a` and `b` in radians.
     """
-    return math.acos(min(1.0, np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))))
+    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))))
 
 
 def rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution):

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -488,9 +488,9 @@ def rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane
 
     lattice = structure.lattice
 
-    corner_a = np.dot(lattice.stdbase, corner_a)
-    corner_b = np.dot(lattice.stdbase, corner_b)
-    corner_c = np.dot(lattice.stdbase, corner_c)
+    corner_a = corner_a @ lattice.stdbase
+    corner_b = corner_b @ lattice.stdbase
+    corner_c = corner_c @ lattice.stdbase
 
     corner_a /= np.linalg.norm(corner_a)
     corner_b /= np.linalg.norm(corner_b)

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -24,6 +24,8 @@ import collections
 
 from .atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
 from pyxem.signals.electron_diffraction import ElectronDiffraction
+from transforms3d.axangles import axangle2mat
+from transforms3d.euler import mat2euler
 from transforms3d.quaternions import mat2quat, rotate_vector
 
 
@@ -412,3 +414,143 @@ def carry_through_navigation_calibration(new_signal, old_signal):
         pass
 
     return new_signal
+
+
+def uvtw_to_uvw(uvtw):
+    """Convert 4-index direction to a 3-index direction.
+
+    Parameters
+    ----------
+    uvtw : array-like with 4 floats
+
+    Returns
+    -------
+    uvw : tuple of 4 floats
+    """
+    u, v, t, w = uvtw
+    u, v, w = 2*u + v, 2*v + u, w
+    common_factor = math.gcd(math.gcd(u, v), w)
+    return tuple((int(x/common_factor)) for x in (u, v, w))
+
+
+def angle_between_cartesian(a, b):
+    """Compute the angle between two vectors in a cartesian coordinate system.
+
+    Parameters
+    ----------
+    a, b : array-like with 3 floats
+        The two directions to compute the angle between.
+
+    Returns
+    -------
+    angle : float
+        Angle between `a` and `b` in radians.
+    """
+    return math.acos(min(1.0, np.dot(a, b)/(np.linalg.norm(a)*np.linalg.norm(b))))
+
+
+def rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution):
+    """Generate a rotation list covering the inverse pole figure specified by three
+        corners in cartesian coordinates.
+
+    Parameters
+    ----------
+    structure : diffpy.structure.Structure
+        Structure for which to calculate the rotation list
+    corner_a, corner_b, corner_c : tuple
+        The three corners of the inverse pole figure, each given by three
+        coordinates. The coordinate system is given by the structure lattice.
+    resolution : float
+        Angular resolution in radians of the generated rotation list.
+    inplane_rotations : list
+        List of angles in degrees for in-plane rotation of the diffraction
+        pattern. This corresponds to the third Euler angle rotation. The
+        rotation list will be generated for each of these angles, and combined.
+        This should be done automatically, but by including all possible
+        rotations in the rotation list, it becomes too large.
+
+        To cover all inplane rotations, use e.g. np.linspace(0, 2*np.pi, 360)
+
+    Returns
+    -------
+    rotation_list : numpy.array
+        Rotations covering the inverse pole figure given as a of Euler
+            angles in degress. This `np.array` can be passed directly to pyxem.
+    """
+    # Convert the crystal directions to cartesian vectors, and then normalize
+    # to get the directions.
+    if len(corner_a) == 4:
+        corner_a = uvtw_to_uvw(corner_a)
+    if len(corner_b) == 4:
+        corner_b = uvtw_to_uvw(corner_b)
+    if len(corner_c) == 4:
+        corner_c = uvtw_to_uvw(corner_c)
+
+    lattice = structure.lattice
+
+    corner_a = np.dot(lattice.stdbase, corner_a)
+    corner_b = np.dot(lattice.stdbase, corner_b)
+    corner_c = np.dot(lattice.stdbase, corner_c)
+
+    corner_a /= np.linalg.norm(corner_a)
+    corner_b /= np.linalg.norm(corner_b)
+    corner_c /= np.linalg.norm(corner_c)
+
+    angle_a_to_b = angle_between_cartesian(corner_a, corner_b)
+    angle_a_to_c = angle_between_cartesian(corner_a, corner_c)
+    angle_b_to_c = angle_between_cartesian(corner_b, corner_c)
+    axis_a_to_b = np.cross(corner_a, corner_b)
+    axis_a_to_c = np.cross(corner_a, corner_c)
+
+    # Input validation. The corners have to define a non-degenerate triangle
+    if np.count_nonzero(axis_a_to_b) == 0:
+        raise ValueError('Directions a and b are parallel')
+    if np.count_nonzero(axis_a_to_c) == 0:
+        raise ValueError('Directions a and c are parallel')
+
+    # Ensure that we keep the resolution also along the direction to the corner
+    # b or c farthest away from a.
+    theta_count = math.ceil(max(angle_a_to_b, angle_a_to_c) / resolution)
+    rotations = []
+
+    # Generate a list of theta_count evenly spaced angles theta_b in the range
+    # [0, angle_a_to_b] and an equally long list of evenly spaced angles
+    # theta_c in the range[0, angle_a_to_c].
+    for i, (theta_b, theta_c) in enumerate(
+            zip(np.linspace(0, angle_a_to_b, theta_count),
+                np.linspace(0, angle_a_to_c, theta_count))):
+        # Define the corner local_b at a rotation theta_b from corner_a toward
+        # corner_b on the circle surface. Similarly, define the corner local_c
+        # at a rotation theta_c from corner_a toward corner_c.
+
+        rotation_a_to_b = axangle2mat(axis_a_to_b, theta_b)
+        rotation_a_to_c = axangle2mat(axis_a_to_c, theta_c)
+        local_b = np.dot(rotation_a_to_b, corner_a)
+        local_c = np.dot(rotation_a_to_c, corner_a)
+
+        # Then define an axis and a maximum rotation to create a great cicle
+        # arc between local_b and local_c. Ensure that this is not a degenerate
+        # case where local_b and local_c are coincident.
+        angle_local_b_to_c = angle_between_cartesian(local_b, local_c)
+        axis_local_b_to_c = np.cross(local_b, local_c)
+        if np.count_nonzero(axis_local_b_to_c) == 0:
+            # Theta rotation ended at the same position. First position, might
+            # be other cases?
+            axis_local_b_to_c = corner_a
+        axis_local_b_to_c /= np.linalg.norm(axis_local_b_to_c)
+
+        # Generate points along the great circle arc with a distance defined by
+        # resolution.
+        phi_count_local = max(math.ceil(angle_local_b_to_c / resolution), 1)
+        for j, phi in enumerate(
+                np.linspace(0, angle_local_b_to_c, phi_count_local)):
+            rotation_phi = axangle2mat(axis_local_b_to_c, phi)
+
+            for k, psi in enumerate(inplane_rotations):
+                # Combine the rotations. Order is important. The matrix is
+                # applied from the left, and we rotate by theta first toward
+                # local_b, then across the triangle toward local_c
+                rotation = list(mat2euler(rotation_phi @ rotation_a_to_b, 'rzxz'))
+                rotations.append(np.rad2deg([rotation[0], rotation[1], psi]))
+
+    return np.unique(rotations, axis=0)

--- a/tests/test_generators/test_structure_library_generator.py
+++ b/tests/test_generators/test_structure_library_generator.py
@@ -22,6 +22,7 @@ import numpy as np
 from pyxem.generators.structure_library_generator import StructureLibraryGenerator
 from tests.test_utils.test_sim_utils import create_structure_cubic
 
+
 def test_orientations_from_list():
     expected_orientations = [(0, 0, 0), (0, 90, 0)]
     structure_library_generator = StructureLibraryGenerator([('a', None, 'cubic')])
@@ -35,7 +36,7 @@ def test_orientations_from_stereographic_triangle():
     expected_orientations = []
     structure_cubic = create_structure_cubic()
     structure_library_generator = StructureLibraryGenerator([('a', structure_cubic, 'cubic')])
-    structure_library = structure_library_generator.get_orientations_from_stereographic_triangle([[0]], np.pi/8)
+    structure_library = structure_library_generator.get_orientations_from_stereographic_triangle([[0]], np.pi / 8)
     assert structure_library.identifiers == ['a']
     assert structure_library.structures == [structure_cubic]
     # Tests for rotation_list_stereographic checks correctness of list content

--- a/tests/test_generators/test_structure_library_generator.py
+++ b/tests/test_generators/test_structure_library_generator.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import numpy as np
+
+from pyxem.generators.structure_library_generator import StructureLibraryGenerator
+from tests.test_utils.test_sim_utils import create_structure_cubic
+
+def test_orientations_from_list():
+    expected_orientations = [(0, 0, 0), (0, 90, 0)]
+    structure_library_generator = StructureLibraryGenerator([('a', None, 'cubic')])
+    structure_library = structure_library_generator.get_orientations_from_list(expected_orientations)
+    assert structure_library.identifiers == ['a']
+    assert structure_library.structures == [None]
+    np.testing.assert_almost_equal(structure_library.orientations, expected_orientations)
+
+
+def test_orientations_from_stereographic_triangle():
+    expected_orientations = []
+    structure_cubic = create_structure_cubic()
+    structure_library_generator = StructureLibraryGenerator([('a', structure_cubic, 'cubic')])
+    structure_library = structure_library_generator.get_orientations_from_stereographic_triangle([[0]], np.pi/8)
+    assert structure_library.identifiers == ['a']
+    assert structure_library.structures == [structure_cubic]
+    # Tests for rotation_list_stereographic checks correctness of list content
+    assert len(structure_library.orientations) == 1

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -24,16 +24,34 @@ from pyxem.signals.electron_diffraction import ElectronDiffraction
 from pyxem.utils.sim_utils import *
 
 
-def create_structure_cubic():
-    lattice = diffpy.structure.lattice.Lattice(1, 1, 1, 90, 90, 90)
+def create_lattice_structure(a, b, c, alpha, beta, gamma):
+    lattice = diffpy.structure.lattice.Lattice(a, b, c, alpha, beta, gamma)
     atom = diffpy.structure.atom.Atom(atype='Si', xyz=[0, 0, 0], lattice=lattice)
     return diffpy.structure.Structure(atoms=[atom], lattice=lattice)
+
+
+def create_structure_cubic():
+    return create_lattice_structure(1, 1, 1, 90, 90, 90)
 
 
 def create_structure_hexagonal():
-    lattice = diffpy.structure.lattice.Lattice(1, 1, 1, 90, 90, 120)
-    atom = diffpy.structure.atom.Atom(atype='Si', xyz=[0, 0, 0], lattice=lattice)
-    return diffpy.structure.Structure(atoms=[atom], lattice=lattice)
+    return create_lattice_structure(1, 1, 1, 90, 90, 120)
+
+
+def create_structure_orthorombic():
+    return create_lattice_structure(1, 2, 3, 90, 90, 90)
+
+
+def create_structure_tetragonal():
+    return create_lattice_structure(1, 1, 2, 90, 90, 90)
+
+
+def create_structure_trigonal():
+    return create_lattice_structure(1, 1, 1, 100, 100, 100)
+
+
+def create_structure_monoclinic():
+    return create_lattice_structure(1, 2, 3, 90, 100, 90)
 
 
 @pytest.mark.parametrize('accelerating_voltage, wavelength', [
@@ -113,20 +131,46 @@ structure_cubic_rotations = [
 
 structure_hexagonal_rotations = [
     [0, 0, 0],
-    [129.06467839, 90, 0],
-    [159.89609064, 90, 0],
+    [90, 90, 0],
+    [120, 90, 0]
+]
+
+structure_orthogonal_rotations = [
+    [0, 0, 0],
+    [90, 90, 0],
+    [180, 90, 0]
+]
+
+structure_tetragonal_rotations = [
+    [0, 0, 0],
+    [90, 90, 0],
+    [135, 90, 0]
+]
+
+structure_trigonal_rotations = [
+    [0, 0, 0],
+    [-28.64458044, 75.45951959, 0],
+    [ 38.93477108, 90, 0]
+]
+
+structure_monoclinic_rotations = [
+    [0, 0, 0],
+    [0, 90, 0],
+    [180, 90, 0]
 ]
 
 
-@pytest.mark.parametrize('structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list', [
-    (create_structure_cubic(), (0, 0, 1), (1, 0, 1), (1, 1, 1), [0], np.deg2rad(10), structure_cubic_rotations),
-    (create_structure_hexagonal(), (0, 0, 0, 1), (1, 1, -2, 0), (1, 0, -1, 0), [0], np.deg2rad(10), structure_hexagonal_rotations)
+@pytest.mark.parametrize('structure, corner_a, corner_b, corner_c, rotation_list', [
+    (create_structure_cubic(), (0, 0, 1), (1, 0, 1), (1, 1, 1), structure_cubic_rotations),
+    (create_structure_hexagonal(), (0, 0, 0, 1), (1, 0, -1, 0), (1, 1, -2, 0), structure_hexagonal_rotations),
+    (create_structure_orthorombic(), (0, 0, 1), (1, 0, 0), (0, 1, 0), structure_orthogonal_rotations),
+    (create_structure_tetragonal(), (0, 0, 1), (1, 0, 0), (1, 1, 0), structure_tetragonal_rotations),
+    (create_structure_trigonal(), (0, 0, 0, 1), (0, -1, 1, 0), (1, -1, 0, 0), structure_trigonal_rotations),
+    (create_structure_monoclinic(), (0, 0, 1), (0, 1, 0), (0, -1, 0), structure_monoclinic_rotations),
 ])
-def test_rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list):
-    val = rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution)
-    print(val)
+def test_rotation_list_stereographic(structure, corner_a, corner_b, corner_c, rotation_list):
+    val = rotation_list_stereographic(structure, corner_a, corner_b, corner_c, [0], np.deg2rad(10))
     for expected in rotation_list:
-        print(expected)
         assert any((np.allclose(expected, actual) for actual in val))
 
 

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -150,7 +150,7 @@ structure_tetragonal_rotations = [
 structure_trigonal_rotations = [
     [0, 0, 0],
     [-28.64458044, 75.45951959, 0],
-    [ 38.93477108, 90, 0]
+    [38.93477108, 90, 0]
 ]
 
 structure_monoclinic_rotations = [

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -127,3 +127,12 @@ def test_rotation_list_stereographic(structure, corner_a, corner_b, corner_c, in
     for expected in rotation_list:
         print(expected)
         assert any((np.allclose(expected, actual) for actual in val))
+
+
+@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.parametrize('structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list', [
+    (create_structure_cubic(), (0, 0, 1), (0, 0, 1), (1, 1, 1), [0], np.deg2rad(10), structure_cubic_rotations),
+    (create_structure_cubic(), (0, 0, 1), (1, 0, 1), (0, 0, 1), [0], np.deg2rad(10), structure_cubic_rotations)
+])
+def test_rotation_list_stereographic_raises_invalid_corners(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list):
+    rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution)

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -117,6 +117,7 @@ structure_hexagonal_rotations = [
     [159.89609064, 90, 0],
 ]
 
+
 @pytest.mark.parametrize('structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list', [
     (create_structure_cubic(), (0, 0, 1), (1, 0, 1), (1, 1, 1), [0], np.deg2rad(10), structure_cubic_rotations),
     (create_structure_hexagonal(), (0, 0, 0, 1), (1, 1, -2, 0), (1, 0, -1, 0), [0], np.deg2rad(10), structure_hexagonal_rotations)
@@ -134,5 +135,6 @@ def test_rotation_list_stereographic(structure, corner_a, corner_b, corner_c, in
     (create_structure_cubic(), (0, 0, 1), (0, 0, 1), (1, 1, 1), [0], np.deg2rad(10), structure_cubic_rotations),
     (create_structure_cubic(), (0, 0, 1), (1, 0, 1), (0, 0, 1), [0], np.deg2rad(10), structure_cubic_rotations)
 ])
-def test_rotation_list_stereographic_raises_invalid_corners(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list):
+def test_rotation_list_stereographic_raises_invalid_corners(
+        structure, corner_a, corner_b, corner_c, inplane_rotations, resolution, rotation_list):
     rotation_list_stereographic(structure, corner_a, corner_b, corner_c, inplane_rotations, resolution)


### PR DESCRIPTION
---
name: Structure library generator and rotation lists
about: Add `StructureLibraryGenerator` to generate `StructureLibrary` from a user-specified list of orientations, or from an even distribution on a spherical triangle.

---

**What does this PR do? Please describe or link to an open issue.**
See #304 for a discussion leading to this PR.

**Describe the new behaviour**
`StructureLibraryGenerator` is mainly a wrapper for creating `StructureLibrary`. The bulk of this PR is `rotation_list_stereographic` in `sim_utils.py` with associated helpers. It creates rotations to the spherical triangle corresponding to the symmetry reduced stereographic projection. The corners of the spherical triangle for each of the seven crystal systems are defined in `stereographic_library_generator.py`.

**Are there any known issues? Do you need help?**
I'm thinking about adding a function to `StructureLibraryGenerator` to generate a rotation list for dense sampling around a specific direction, but I want some feedback on the structure of what I have done so far compared to what we discussed in #304.
 
I also don't have a strong case for the choice of spherical triangle for each of the crystal systems. They are in the positive octant. Is there any standard for this that I am not aware of?

**Usage example**
See docstring of `StructureLibraryGenerator`.
