### PR TITLE
Bugfix xy error in get_experimental_square

### DIFF
--- a/pyxem/utils/subpixel_refinements_utils.py
+++ b/pyxem/utils/subpixel_refinements_utils.py
@@ -47,7 +47,8 @@ def get_experimental_square(z, vector, square_size):
     """
 
     cx, cy, half_ss = vector[0], vector[1], int(square_size / 2)
-    _z = z[cx - half_ss:cx + half_ss, cy - half_ss:cy + half_ss]
+    # select square with correct x,y see PR for details
+    _z = z[cy - half_ss:cy + half_ss, cx - half_ss:cx + half_ss]
     return _z
 
 

--- a/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/tests/test_generators/test_subpixelrefinement_generator.py
@@ -29,7 +29,7 @@ def create_spot():
     z = np.zeros((128, 128))
 
     for r in [4, 3, 2]:
-        rr, cc = draw.circle(90, 30, radius=r, shape=z.shape)
+        rr, cc = draw.circle(30, 90,radius=r, shape=z.shape)
         z[rr, cc] = 1 / r
 
     dp = pxm.ElectronDiffraction(np.asarray([[z, z], [z, z]]))  # this needs to be in 2x2


### PR DESCRIPTION
---

about: This function (`get_experiemental_square`) previously read x,y incorrectly (correct is x runs from left to right, y from top to bottom), this corrects that error.

---

**What does this PR do? Please describe or link to an open issue.**
The following snippet illustrates the issue
```

z = np.zeros((2,2))
x,y = 0,1 #bottom left
z[x,y] = 1
z
Out[18]: 
array([[0., 1.],
       [0., 0.]])
```
**Describe the new behaviour**
Bug fixed.