### PR TITLE
Corrections coming to light in the construction of a strain mapping notebook

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -113,6 +113,12 @@ class SubpixelrefinementGenerator():
         This will work poorly on disks with strong dynamic contrast
         """
 
+        def _center_of_mass_hs(z):
+            t = center_of_mass(z)
+            x = t[1]
+            y = t[0]
+            return (x,y)
+
         self.vectors_out = np.zeros(
             (self.dp.data.shape[0],
              self.dp.data.shape[1],
@@ -125,7 +131,7 @@ class SubpixelrefinementGenerator():
                 vector=vect,
                 square_size=square_size,
                 inplace=False)
-            shifts = expt_disc.map(center_of_mass, inplace=False) - (square_size / 2)
+            shifts = expt_disc.map(_center_of_mass_hs, inplace=False) - (square_size / 2)
             self.vectors_out[:, :, i, :] = (((vect + shifts.data) - self.center) * self.calibration)
 
         self.last_method = "center_of_mass_method"

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -119,6 +119,17 @@ class SubpixelrefinementGenerator():
             y = t[0]
             return (x,y)
 
+        def _com_experimental_square(z,vector,square_size):
+            """
+            Wrapper for get_experimental_square that makes the non-zero elements
+            symmettrical around the 'unsubpixeled' peak symmetrical by zeroing a
+            'spare' row and column (top and left)
+            """
+            z_adpt = np.copy(get_experimental_square(z,vector=vect,square_size=square_size)) # to make sure we don't change the dp
+            z_adpt[:,0] = 0
+            z_adpt[0,:] = 0
+            return z_adpt
+
         self.vectors_out = np.zeros(
             (self.dp.data.shape[0],
              self.dp.data.shape[1],
@@ -127,7 +138,7 @@ class SubpixelrefinementGenerator():
         for i in np.arange(0, len(self.vectors_init)):
             vect = self.vectors_pixels[i]
             expt_disc = self.dp.map(
-                get_experimental_square,
+                _com_experimental_square,
                 vector=vect,
                 square_size=square_size,
                 inplace=False)

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -114,6 +114,19 @@ class SubpixelrefinementGenerator():
         """
 
         def _center_of_mass_hs(z):
+            """
+            Return the center of mass of an array with coordinates in the hyperspy convention
+
+            Parameters
+            ----------
+            z : np.array
+
+            Returns
+            -------
+            (x,y) : tuple of floats
+                The x and y locations of the center of mass of the parsed square
+            """
+
             t = center_of_mass(z)
             x = t[1]
             y = t[0]
@@ -121,9 +134,21 @@ class SubpixelrefinementGenerator():
 
         def _com_experimental_square(z,vector,square_size):
             """
-            Wrapper for get_experimental_square that makes the non-zero elements
-            symmettrical around the 'unsubpixeled' peak symmetrical by zeroing a
-            'spare' row and column (top and left)
+            Wrapper for get_experimental_square that makes the non-zero elements symmetrical
+            around the 'unsubpixeled' peak by zeroing a 'spare' row and column (top and left)
+
+            Parameters
+            ----------
+            z : np.array
+
+            vector : np.array([x,y])
+
+            square_size : int (even)
+
+            Returns
+            -------
+            z_adpt : np.array
+                z, but with row and column zero set to 0
             """
             z_adpt = np.copy(get_experimental_square(z,vector=vect,square_size=square_size)) # to make sure we don't change the dp
             z_adpt[:,0] = 0

--- a/pyxem/utils/subpixel_refinements_utils.py
+++ b/pyxem/utils/subpixel_refinements_utils.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2018 The pyXem developers
+# -*- coding: utf-8 -*-
 #
 # This file is part of pyXem.
 #
@@ -45,6 +45,8 @@ def get_experimental_square(z, vector, square_size):
         Of size (L,L) where L = square_size
 
     """
+    if square_size %2 != 0:
+        raise ValueError("'square_size' must be an even number")
 
     cx, cy, half_ss = vector[0], vector[1], int(square_size / 2)
     # select square with correct x,y see PR for details
@@ -70,6 +72,9 @@ def get_simulated_disc(square_size, disc_radius):
         Upsampled copy of the simulated disc as a numpy array
 
     """
+
+    if square_size %2 != 0:
+        raise ValueError("'square_size' must be an even number")
 
     ss = int(square_size)
     arr = np.zeros((ss, ss))

--- a/tests/test_utils/test_subpixel_utils.py
+++ b/tests/test_utils/test_subpixel_utils.py
@@ -24,7 +24,6 @@ from pyxem.utils.subpixel_refinements_utils import _conventional_xc
 
 from skimage.transform import rescale
 
-
 @pytest.fixture()
 def exp_disc():
     ss, disc_radius, upsample_factor = int(60), 6, 10
@@ -59,3 +58,12 @@ def test_get_experimental_square(exp_disc):
     square = get_experimental_square(exp_disc, [17, 19], 6)
     assert square.shape[0] == int(6)
     assert square.shape[1] == int(6)
+
+
+@pytest.mark.xfail(strict=True)
+class Test_even_sized_squares():
+    def test_non_even_errors_get_simulated_disc():
+        get_simulated_disc(61,5)
+
+    def test_non_even_errors_get_experimental_errors(exp_disc):
+        square = get_experimental_square(exp_disc, [17, 19], 7)

--- a/tests/test_utils/test_subpixel_utils.py
+++ b/tests/test_utils/test_subpixel_utils.py
@@ -61,9 +61,9 @@ def test_get_experimental_square(exp_disc):
 
 
 @pytest.mark.xfail(strict=True)
-class Test_even_sized_squares():
-    def test_non_even_errors_get_simulated_disc():
-        disc = get_simulated_disc(61,5)
+def test_non_even_errors_get_simulated_disc():
+    disc = get_simulated_disc(61,5)
 
-    def test_non_even_errors_get_experimental_errors(exp_disc):
-        square = get_experimental_square(exp_disc, [17, 19], 7)
+@pytest.mark.xfail(strict=True)
+def test_non_even_errors_get_experimental_errors(exp_disc):
+    square = get_experimental_square(exp_disc, [17, 19], 7)

--- a/tests/test_utils/test_subpixel_utils.py
+++ b/tests/test_utils/test_subpixel_utils.py
@@ -63,7 +63,7 @@ def test_get_experimental_square(exp_disc):
 @pytest.mark.xfail(strict=True)
 class Test_even_sized_squares():
     def test_non_even_errors_get_simulated_disc():
-        get_simulated_disc(61,5)
+        disc = get_simulated_disc(61,5)
 
     def test_non_even_errors_get_experimental_errors(exp_disc):
         square = get_experimental_square(exp_disc, [17, 19], 7)


### PR DESCRIPTION
---

about: Trying to make strain mapping (specifically the subpixel com version) a couple of errors were found. This PR address them, details below:

---

**What does this PR do? Please describe or link to an open issue.**
The easy bit is an x,y switch from the skimage com library.

The harder bit is deciding how `get_experimental_square()` should behave. In the end it was decided that an even sides square should be returned (with the center vector at the bottom right of the central four pixels), and when doing COM mapping the far left and top rows should be set to zero such that the scheme is symmetrical around `vector`, and not led astray by `r * noise` terms on the left hand (top-side) end

**Describe the new behaviour**
External behaviour is the same except the code now throws and error for non even selection to `get_experimental_square`

**Describe alternatives you've considered**
Odd numbered squares wouldn't need the 0 setting hack, but for cross correlation even and specifically powers of 2 - of which 8 and 16 are most likely - length sides are most efficient. Throwing away easy speed (user) for a little extra work (developer) seemed needless. Hence even sided squares. 

**Are there any known issues? Do you need help?**
I believe that this is good to go (@dnjohnstone to merge) - stronger testing could help in future, but that's for another PR