### PR TITLE
New DiffractionPeaks and extended DiffractionProfiles and DiffractionVectors

### DIFF
--- a/pyxem/__init__.py
+++ b/pyxem/__init__.py
@@ -44,6 +44,7 @@ from .signals.diffraction_profile import ElectronDiffractionProfile
 from .signals.electron_diffraction import ElectronDiffraction
 from .signals.diffraction_simulation import DiffractionSimulation
 from .signals.diffraction_vectors import DiffractionVectors
+from .signals.diffraction_peaks import DiffractionPeaks
 from .signals.vdf_image import VDFImage
 
 from .io_plugins import io_plugins, default_write_ext

--- a/pyxem/signals/diffraction_peaks.py
+++ b/pyxem/signals/diffraction_peaks.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from hyperspy.signals import BaseSignal
+
+"""
+Signal class for diffraction peaks.
+
+These are the 1D equivalent class of a DiffracionVectors class.
+
+They are a list of diffraction peak values in 1D, with dimensions < n | 1 >.
+They also contain the attribute "intensity", with the respective peak intensities and dimensions < n | 1 >.
+"""
+
+
+class DiffractionPeaks(BaseSignal):
+    """Crystallographic peak finding at each navigation position.
+
+    Attributes
+    ----------
+    intensity : float
+        Intensity associated with each diffraction peak, in the original navigation axes.
+    hkls : np.array()
+        Array of Miller indices associated with each diffraction vector
+        following indexation.
+    """
+    _signal_type = "diffraction_peaks"
+
+    def __init__(self, *args, **kwargs):
+        BaseSignal.__init__(self, *args, **kwargs)
+        self.intensity = None
+        self.hkls = None

--- a/pyxem/signals/diffraction_profile.py
+++ b/pyxem/signals/diffraction_profile.py
@@ -19,7 +19,9 @@
 
 """
 
+import numpy as np
 from hyperspy.signals import Signal1D
+from pyxem.signals.diffraction_peaks import DiffractionPeaks
 
 
 class ElectronDiffractionProfile(Signal1D):
@@ -27,3 +29,44 @@ class ElectronDiffractionProfile(Signal1D):
 
     def __init__(self, *args, **kwargs):
         Signal1D.__init__(self, *args, **kwargs)
+
+    def find_peaks_1D(self, *args, **kwargs):
+        """Find peaks in a DiffractionProfile using the O-Haver function (Hyperspy). It returns the DiffractionPeaks class.
+        Parameters
+        ----------
+            slope threshold : float 
+                Higher values will neglect broader features
+            amp/intensity threshold: float
+                Intensity below which peaks are ignored
+            *args
+                Inherited parameters from Hyperspy find_peaks1D_ohaver
+        Returns
+        ----------
+            peaks: DiffractionPeaks
+                A DiffractionPeaks object with navigation dimensions identical to the original ElectronDiffraction object.
+                Each signal is a BaseSignal object contiaining the diffraction peak "position" found at each navigation position, the "intensity" and the "height" of each peak.
+                
+                TO DO: The intensity of each peak is stored in the "intensity" attribute, with navigation dimensions identical to the original object.
+        """
+        peaks = self.find_peaks1D_ohaver(*args, **kwargs)
+        #Create a DiffractionPeaks object
+        peaks = DiffractionPeaks(peaks)
+        peaks.axes_manager.set_signal_dimension(0)
+
+        # Set calibration to same as signal
+        x = peaks.axes_manager.navigation_axes[0]
+        y = peaks.axes_manager.navigation_axes[1]
+
+        x.name = 'x'
+        x.scale = self.axes_manager.navigation_axes[0].scale
+        x.units = 'nm'
+
+        y.name = 'y'
+        y.scale = self.axes_manager.navigation_axes[1].scale
+        y.units = 'nm'
+        """
+        TO DO:
+            1. Extract the intensity value from each peak in each navigation axis, and store it in peak.intensity attribute.
+            2. Only store peak "position" in the BaseSignal data, instead of the three returns from the find_peaks1D_ohaver function.
+        """
+        return peaks

--- a/pyxem/signals/diffraction_profile.py
+++ b/pyxem/signals/diffraction_profile.py
@@ -30,6 +30,39 @@ class ElectronDiffractionProfile(Signal1D):
     def __init__(self, *args, **kwargs):
         Signal1D.__init__(self, *args, **kwargs)
 
+    def detector_axes_to_1D_kspace(self, beam_wavelen, det2sample_len, pixel_len):
+        """Converts the detector 1D coordinates in px, to the respective 1D coordinates in the kspace, in Angstom^-1, using purely geometrical arguments. 
+        Only use for DiffractionProfile class. 2D version of the detector_to_3D_kspace from the class DiffractionVectors.
+        Args:
+        -------
+            beam_wavelen (float):
+                Wavelength of the scanning beam, in Amstrong.
+            det2sample_len (float): 
+                Distance from detector to sample, in Amstrong. IMPORTANT: Exact distance obtained from the calibration file.
+            pixel_len (float):
+                Length of the pixel in the detector, in micrometres
+        Returns:
+        -------
+            self:
+                DiffractionProfile has been modified from px cordinates to angstrom^-1
+        """
+        #Extract the pixel-coordinates as an array
+        px = np.array(self.axes_manager['k'].axis)
+        #Convert each pixel to the actual disctance in Angstrom
+        x = px*10000*pixel_len
+        # Get the theta angle (in 1D Edwald circunference it is arctan(px/d)) for each x:
+        theta = np.arctan(x/(det2sample_len))
+        #Convert each x to the respective gx value:
+        gx = (1/beam_wavelen)*np.sin(theta)
+        #Convert each x to the respective gy value:
+        gy = (1/beam_wavelen)*(1-np.cos(theta))
+        #Get the diffraction vector g magnitude:
+        g = np.sqrt(gx**2 + gy**2)
+
+        # Replace pixel coordinates in the ElectronDiffractionProfile to the kx values:
+        self.axes_manager['k'].axis = g
+        self.axes_manager['k'].name = '$\mid g \mid$'
+
     def find_peaks_1D(self, *args, **kwargs):
         """Find peaks in a DiffractionProfile using the O-Haver function (Hyperspy). It returns the DiffractionPeaks class.
         Parameters

--- a/pyxem/signals/diffraction_profile.py
+++ b/pyxem/signals/diffraction_profile.py
@@ -22,6 +22,7 @@
 import numpy as np
 from hyperspy.signals import Signal1D
 from pyxem.signals.diffraction_peaks import DiffractionPeaks
+from pyxem.utils.peak_utils import mapping_indeces_dictionary
 
 
 class ElectronDiffractionProfile(Signal1D):
@@ -30,16 +31,16 @@ class ElectronDiffractionProfile(Signal1D):
     def __init__(self, *args, **kwargs):
         Signal1D.__init__(self, *args, **kwargs)
 
-    def detector_px_to_1D_kspace(self, beam_wavelen, det2sample_len, pixel_len):
+    def detector_px_to_1D_kspace(self, wavelength, det2sample_len, px_size):
         """Converts the detector 1D coordinates in px, to the respective 1D coordinates in the kspace, in Angstom^-1, using purely geometrical arguments. 
         Only use for DiffractionProfile class. 2D version of the detector_to_3D_kspace from the class DiffractionVectors.
         Args:
         -------
-            beam_wavelen (float):
+            wavelength (float):
                 Wavelength of the scanning beam, in Amstrong.
             det2sample_len (float): 
                 Distance from detector to sample, in Amstrong. IMPORTANT: Distance obtained from the calibration file.
-            pixel_len (float):
+            px_size (float):
                 Length of the pixel in the detector, in micrometres
         Returns:
         -------
@@ -49,15 +50,17 @@ class ElectronDiffractionProfile(Signal1D):
         #Extract the pixel-coordinates as an array
         px = np.array(self.axes_manager['k'].axis)
         #Convert each pixel to the actual disctance in Angstrom
-        x = px*10000*pixel_len
-        # Get the theta angle (in 1D Edwald circunference it is arctan(px/d)) for each x:
-        theta = np.arctan(x/(det2sample_len))
-        #Convert each x to the respective gx value:
-        gx = (1/beam_wavelen)*np.sin(theta)
-        #Convert each x to the respective gy value:
-        gy = (1/beam_wavelen)*(1-np.cos(theta))
-        #Get the diffraction vector g magnitude:
-        g = np.sqrt(gx**2 + gy**2)
+        x = px*1e4*px_size
+        # Get the two_theta angle (in 1D Edwald circunference it is arctan(px/d)) for each x:
+        two_theta = np.arctan2(x,det2sample_len)
+        # #Convert each x to the respective gx value:
+        # gx = (1/wavelength)*np.sin(two_theta)
+        # #Convert each x to the respective gy value:
+        # gy = (1/wavelength)*(1-np.cos(two_theta))
+        # #Get the diffraction vector g magnitude:
+        # g = np.sqrt(gx**2 + gy**2)
+
+        g = 2 * (1/wavelength) * np.sin(two_theta/2)
 
         # Replace pixel coordinates in the ElectronDiffractionProfile to the kx values:
         self.axes_manager['k'].axis = g
@@ -77,29 +80,30 @@ class ElectronDiffractionProfile(Signal1D):
         ----------
             peaks: DiffractionPeaks
                 A DiffractionPeaks object with navigation dimensions identical to the original ElectronDiffraction object.
-                Each signal is a BaseSignal object contiaining the diffraction peak "position" found at each navigation position, the "intensity" and the "height" of each peak.
-                
-                TO DO: The intensity of each peak is stored in the "intensity" attribute, with navigation dimensions identical to the original object.
+                Each datapoint is an array of the position/magnitude of the diffraction peaks. The intensity of each peak is stored in the "intensity" attribute, with navigation dimensions identical to the original object.
         """
+        #Find peaks using the o'Haver function from Hyperspy. It returns a BaseSignal object, in which each data point is a dictionary containing "position" and "height" of each peak.
         peaks = self.find_peaks1D_ohaver(*args, **kwargs)
-        #Create a DiffractionPeaks object
+        #Create a DiffractionPeaks object.
         peaks = DiffractionPeaks(peaks)
         peaks.axes_manager.set_signal_dimension(0)
 
-        # Set calibration to same as signal
-        x = peaks.axes_manager.navigation_axes[0]
-        y = peaks.axes_manager.navigation_axes[1]
+        #Extract the intensity and store it as an attribute.
+        peaks.intensity = peaks.map(mapping_indeces_dictionary, key='height', inplace=False)
+        #Extract the peak position. Replace each data point (a dictionary) for a peak position/magnitude array.
+        peaks.map(mapping_indeces_dictionary, key='position', inplace=True)
 
-        x.name = 'x'
-        x.scale = self.axes_manager.navigation_axes[0].scale
-        x.units = 'nm'
+        # For diffraction profiles with navigation axes, transfer them to the DiffractionPeaks object:
+        if self.axes_manager.navigation_axes != ():
+            x = peaks.axes_manager.navigation_axes[0]
+            y = peaks.axes_manager.navigation_axes[1]
 
-        y.name = 'y'
-        y.scale = self.axes_manager.navigation_axes[1].scale
-        y.units = 'nm'
-        """
-        TO DO:
-            1. Extract the intensity value from each peak in each navigation axis, and store it in peak.intensity attribute.
-            2. Only store peak "position" in the BaseSignal data, instead of the three returns from the find_peaks1D_ohaver function.
-        """
+            x.name = 'x'
+            x.scale = self.axes_manager.navigation_axes[0].scale
+            x.units = 'nm'
+
+            y.name = 'y'
+            y.scale = self.axes_manager.navigation_axes[1].scale
+            y.units = 'nm'
+        
         return peaks

--- a/pyxem/signals/diffraction_profile.py
+++ b/pyxem/signals/diffraction_profile.py
@@ -30,7 +30,7 @@ class ElectronDiffractionProfile(Signal1D):
     def __init__(self, *args, **kwargs):
         Signal1D.__init__(self, *args, **kwargs)
 
-    def detector_axes_to_1D_kspace(self, beam_wavelen, det2sample_len, pixel_len):
+    def detector_px_to_1D_kspace(self, beam_wavelen, det2sample_len, pixel_len):
         """Converts the detector 1D coordinates in px, to the respective 1D coordinates in the kspace, in Angstom^-1, using purely geometrical arguments. 
         Only use for DiffractionProfile class. 2D version of the detector_to_3D_kspace from the class DiffractionVectors.
         Args:
@@ -38,7 +38,7 @@ class ElectronDiffractionProfile(Signal1D):
             beam_wavelen (float):
                 Wavelength of the scanning beam, in Amstrong.
             det2sample_len (float): 
-                Distance from detector to sample, in Amstrong. IMPORTANT: Exact distance obtained from the calibration file.
+                Distance from detector to sample, in Amstrong. IMPORTANT: Distance obtained from the calibration file.
             pixel_len (float):
                 Length of the pixel in the detector, in micrometres
         Returns:

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 from scipy.spatial import distance_matrix
 
 from pyxem.utils.sim_utils import transfer_navigation_axes
-from pyxem.utils.vector_utils import detector_to_fourier
+from pyxem.utils.vector_utils import detector_to_fourier, detector_px_to_3D_kspace
 from pyxem.utils.vector_utils import calculate_norms, calculate_norms_ragged
 from pyxem.utils.vector_utils import get_indices_from_distance_matrix
 from pyxem.utils.vector_utils import get_npeaks
@@ -285,8 +285,8 @@ class DiffractionVectors(BaseSignal):
         transfer_navigation_axes(self.cartesian, self)
 
     def calculate_detector_px_to_cartesian_diffraction_coordinates(self, beam_wavelen, det2sample_len, pixel_len, *args, **kwargs):
-        """It takes a DiffractionVector object with peaks expressed in pixels in the detector. It maps the function detector_px_to_3D_kspace along the pixels of the DiffractionVector class.
-        It stores in the DiffractionVector.cartesian attribute, the gx, gy and gz cartesian coordinates of the diffraction vector, in Angstoms^-1, using purely geometrical arguments..
+        """It takes a DiffractionVector object with peaks expressed in pixels in the detector. It maps the function detector_px_to_3D_kspace along the scanning pixels of the DiffractionVector class.
+        It stores in the DiffractionVector.cartesian attribute, the gx, gy and gz cartesian coordinates of the diffraction vector, in Angstoms^-1, using purely geometrical arguments.
         Args:
         ----------
         self :DiffractionVector
@@ -302,52 +302,6 @@ class DiffractionVectors(BaseSignal):
         self: DiffractionVector
             DiffractionProfile.cartesian attribute has stored the respective transformed px cordinates to angstrom^-1, in the form of an array containing [g_x, g_y, g_z] for each scanning coordinate.
         """
-        def detector_px_to_3D_kspace(peak_coord, beam_wavelen, det2sample_len, pixel_len):
-            """Converts the detector 2d coordinate, in px, to the respective 3D coordinate in the kspace
-            Args:
-            ----------
-            peak_coord: np.array
-                An array with the diffraction vectors of a single scanning coordinate, in pixel units of the detector.
-            beam_wavelen: float
-                Wavelength of the scanning beam, in Amstrong.
-            det2sample_len: float
-                Distance from detector to sample, in Amstrong. IMPORTANT: Distance obtained from the calibration file.
-            pixel_len: float
-                Length of the pixel in the detector, in micrometres.
-            Returns
-            ----------
-            g_xyz: np.array
-                Array composed of [g_x, g_y, g_z] values for the peaks in the scanning coordinate, changed from px to angstrom^-1.
-
-            """
-            #Convert each pixel to the actual disctance in Angstrom
-            if peak_coord.shape == (1,) and peak_coord.dtype == 'object':
-                # From ragged array
-                peak_coord = peak_coord[0]
-
-            xy = peak_coord*pixel_len*10000
-
-            #Extract the pixel-coordinates of x and y axes as an array
-            x = xy[:,0]
-            y = xy[:,1]
-
-            #Get the polar coordinate angles, in a 3D Edwald circunference:
-            #Vector moduli 'r' from the beam centre to the coordinate at the detector for each peak.
-            r = np.sqrt(x**2 + y**2)
-            #Phi angles (from z axis) for each peak:
-            phi = np.arctan(r/det2sample_len)
-            #Theta angles (between x and y axis) for each peak:
-            theta = np.arctan(y/x)
-
-            #Convert each x and y to the respective gx, gy and gz values, using 3D geometry:
-            gx = (1/beam_wavelen)*np.sin(phi)*np.cos(theta)
-            gy = (1/beam_wavelen)*np.sin(phi)*np.sin(theta)
-            gz = (1/beam_wavelen)*(1-np.cos(phi))
-
-            #Append the reciprocal vectors in one single array, while flipping the vector form, resembling the input array:
-            g_xyz = np.hstack((gx[:,np.newaxis], gy[:,np.newaxis], gz[:,np.newaxis]))
-
-            return g_xyz
 
         self.cartesian = self.map(detector_px_to_3D_kspace, 
                                   beam_wavelen=beam_wavelen, 

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -284,7 +284,7 @@ class DiffractionVectors(BaseSignal):
                                   *args, **kwargs)
         transfer_navigation_axes(self.cartesian, self)
 
-    def calculate_detector_px_to_cartesian_diffraction_coordinates(self, beam_wavelen, det2sample_len, pixel_len, *args, **kwargs):
+    def calculate_detector_px_to_cartesian_diffraction_coordinates(self, beam_wavelen, det2sample_len, pixel_size, *args, **kwargs):
         """It takes a DiffractionVector object with peaks expressed in pixels in the detector. It maps the function detector_px_to_3D_kspace along the scanning pixels of the DiffractionVector class.
         It stores in the DiffractionVector.cartesian attribute, the gx, gy and gz cartesian coordinates of the diffraction vector, in Angstoms^-1, using purely geometrical arguments.
         Args:
@@ -295,7 +295,7 @@ class DiffractionVectors(BaseSignal):
             Wavelength of the scanning beam, in Amstrong.
         det2sample_len: float
             Distance from detector to sample, in Amstrong. IMPORTANT: Distance obtained from the calibration file.
-        pixel_len: float
+        pixel_size: float
             Length of the pixel in the detector, in micrometres.
         Returns
         ----------
@@ -306,5 +306,5 @@ class DiffractionVectors(BaseSignal):
         self.cartesian = self.map(detector_px_to_3D_kspace, 
                                   beam_wavelen=beam_wavelen, 
                                   det2sample_len=det2sample_len, 
-                                  pixel_len= pixel_len, 
+                                  pixel_size= pixel_size, 
                                   inplace=False, parallel=False)

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -283,3 +283,74 @@ class DiffractionVectors(BaseSignal):
                                   parallel=False,  # TODO: For testing
                                   *args, **kwargs)
         transfer_navigation_axes(self.cartesian, self)
+
+    def calculate_detector_px_to_cartesian_diffraction_coordinates(self, beam_wavelen, det2sample_len, pixel_len, *args, **kwargs):
+        """It takes a DiffractionVector object with peaks expressed in pixels in the detector. It maps the function detector_px_to_3D_kspace along the pixels of the DiffractionVector class.
+        It stores in the DiffractionVector.cartesian attribute, the gx, gy and gz cartesian coordinates of the diffraction vector, in Angstoms^-1, using purely geometrical arguments..
+        Args:
+        ----------
+        self :DiffractionVector
+            A DiffractionVector object with the diffraction vectors in pixel units of the detector.
+        beam_wavelen: float
+            Wavelength of the scanning beam, in Amstrong.
+        det2sample_len: float
+            Distance from detector to sample, in Amstrong. IMPORTANT: Distance obtained from the calibration file.
+        pixel_len: float
+            Length of the pixel in the detector, in micrometres.
+        Returns
+        ----------
+        self: DiffractionVector
+            DiffractionProfile.cartesian attribute has stored the respective transformed px cordinates to angstrom^-1, in the form of an array containing [g_x, g_y, g_z] for each scanning coordinate.
+        """
+        def detector_px_to_3D_kspace(peak_coord, beam_wavelen, det2sample_len, pixel_len):
+            """Converts the detector 2d coordinate, in px, to the respective 3D coordinate in the kspace
+            Args:
+            ----------
+            peak_coord: np.array
+                An array with the diffraction vectors of a single scanning coordinate, in pixel units of the detector.
+            beam_wavelen: float
+                Wavelength of the scanning beam, in Amstrong.
+            det2sample_len: float
+                Distance from detector to sample, in Amstrong. IMPORTANT: Distance obtained from the calibration file.
+            pixel_len: float
+                Length of the pixel in the detector, in micrometres.
+            Returns
+            ----------
+            g_xyz: np.array
+                Array composed of [g_x, g_y, g_z] values for the peaks in the scanning coordinate, changed from px to angstrom^-1.
+
+            """
+            #Convert each pixel to the actual disctance in Angstrom
+            if peak_coord.shape == (1,) and peak_coord.dtype == 'object':
+                # From ragged array
+                peak_coord = peak_coord[0]
+
+            xy = peak_coord*pixel_len*10000
+
+            #Extract the pixel-coordinates of x and y axes as an array
+            x = xy[:,0]
+            y = xy[:,1]
+
+            #Get the polar coordinate angles, in a 3D Edwald circunference:
+            #Vector moduli 'r' from the beam centre to the coordinate at the detector for each peak.
+            r = np.sqrt(x**2 + y**2)
+            #Phi angles (from z axis) for each peak:
+            phi = np.arctan(r/det2sample_len)
+            #Theta angles (between x and y axis) for each peak:
+            theta = np.arctan(y/x)
+
+            #Convert each x and y to the respective gx, gy and gz values, using 3D geometry:
+            gx = (1/beam_wavelen)*np.sin(phi)*np.cos(theta)
+            gy = (1/beam_wavelen)*np.sin(phi)*np.sin(theta)
+            gz = (1/beam_wavelen)*(1-np.cos(phi))
+
+            #Append the reciprocal vectors in one single array, while flipping the vector form, resembling the input array:
+            g_xyz = np.hstack((gx[:,np.newaxis], gy[:,np.newaxis], gz[:,np.newaxis]))
+
+            return g_xyz
+
+        self.cartesian = self.map(detector_px_to_3D_kspace, 
+                                  beam_wavelen=beam_wavelen, 
+                                  det2sample_len=det2sample_len, 
+                                  pixel_len= pixel_len, 
+                                  inplace=False, parallel=False)

--- a/pyxem/utils/peak_utils.py
+++ b/pyxem/utils/peak_utils.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import math
+
+def mapping_indeces_dictionary(dictionary, key):
+    """It allows to index through dictionaries as BaseSignal data.
+    Parameters
+    ----------
+    dictionary : np.array([dictionary])
+        A BaseSignal data point, containing a dictionary.
+    key: string
+        The dictionary key to be indexed.
+    Returns
+    -------
+    norms : np.array([indexed dictionary])
+        An BaseSignal data point, containg the indexed value from the dictionary.
+    """
+    return dictionary[0][key]

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -95,13 +95,13 @@ def detector_px_to_3D_kspace(peak_coord, beam_wavelen, det2sample_len, pixel_len
     r = np.sqrt(x**2 + y**2)
     #Phi angles (from z axis) for each peak:
     phi = np.arctan(r/det2sample_len)
-    #Theta angles (between x and y axis) for each peak:
-    theta = np.arctan(y/x)
-
-    #Convert each x and y to the respective gx, gy and gz values, using 3D geometry:
-    gx = (1/beam_wavelen)*np.sin(phi)*np.cos(theta)
-    gy = (1/beam_wavelen)*np.sin(phi)*np.sin(theta)
-    gz = (1/beam_wavelen)*(1-np.cos(phi))
+    #Theta angles (between x and y axis) for each peak. Use arctan2 to get the right quadrant sign:
+    theta = np.arctan2(y,x)
+    #Convert each x and y to the respective gx, gy and gz values, using 3D geometry. Multiply by the pixel sign:
+    sin_phi = np.sin(phi) #For memory saving
+    gx = (1/beam_wavelen)*sin_phi*np.cos(theta)
+    gy = (1/beam_wavelen)*sin_phi*np.sin(theta)
+    gz = (1/beam_wavelen)*(np.cos(phi) - 1)
 
     #Append the reciprocal vectors in one single array, while flipping the vector form, resembling the input array:
     g_xyz = np.hstack((gx[:,np.newaxis], gy[:,np.newaxis], gz[:,np.newaxis]))

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -84,7 +84,7 @@ def detector_px_to_3D_kspace(peak_coord, beam_wavelen, det2sample_len, pixel_siz
         # From ragged array
         peak_coord = peak_coord[0]
 
-    xy = peak_coord*pixel_size*10000
+    xy = peak_coord*pixel_size*1e4
 
     #Extract the pixel-coordinates of x and y axes as an array
     x = xy[:,0]
@@ -249,27 +249,34 @@ def get_angle_cartesian(a, b):
         return 0.0
     return math.acos(max(-1.0, min(1.0, np.dot(a, b) / determinant)))
 
-def get_detector_to_sample_calibrated_distance(d_hkl_calc, actual_px_len, beam_wavelen, pixel_size):
+def get_detector_to_sample_calibrated_distance(d_hkl_calc, peak_distance,
+                                               wavelength, pixel_size):
     """
-    Get the calibrated detector to sample distance from a basic geometrical transformation, using a d_hkl_calc diffraction vector length and the actual pixel length. The center of
-    the data array is assumed to be the center of the pattern.
+    Get the calibrated detector to sample distance from a basic geometrical 
+    transformation, using a d_hkl_calc diffraction vector length and the actual 
+    pixel length. The center of the data array is assumed to be the center of the 
+    pattern.
+
     Parameters
     ----------
     d_hkl_calc : float
         Calculated diffraction vector (hkl) magnitude in reciprocal Angstroms.
-    actual_px_len
-        The actual pixel detecting the diffraction event (hkl), from the calibration standard, in pixel units.
-    beam_wavelen: float
-        Wavelength of the scanning beam, in Angstroms.
-    pixel_size: float
+    peak_distance : int
+        The measured distance from the direct beam to the peak used for calibration, in pixel units.
+    wavelength : float
+        Wavelength radiation used as probe, in Angstroms.
+    pixel_size : float
         Size of each pixel in the detector, in micrometres.
+    
     Returns
     -------
     sample2det_len : float
         Calibrated sample to detector distance, in Angstroms.
     """
+
     #Calculate the diffraction theta angle from the calculated diffraction vector magnitude.
-    theta = 2*np.arcsin(d_hkl_calc / (2* 1 / beam_wavelen))
+    two_theta = 2 * np.arcsin( (d_hkl_calc * wavelength) / 2 )
     #Calculate, using basic trigonometry, the det2sample_len from the theta angle and the actual pixel detected length:
-    det2sample_len = (actual_px_len * pixel_size * 10000) / np.tan(theta)
+    det2sample_len = (peak_distance * pixel_size * 1e4) / np.tan(two_theta)
+
     return det2sample_len

--- a/tests/test_utils/test_vector_utils.py
+++ b/tests/test_utils/test_vector_utils.py
@@ -22,8 +22,8 @@ import pytest
 from transforms3d.euler import euler2mat
 
 from pyxem.utils.vector_utils import calculate_norms, calculate_norms_ragged, \
-    detector_to_fourier, get_rotation_matrix_between_vectors, \
-    get_angle_cartesian
+    detector_to_fourier, detector_px_to_3D_kspace, get_rotation_matrix_between_vectors, \
+    get_angle_cartesian, get_detector_to_sample_calibrated_distance
 
 
 def test_calculate_norms():
@@ -57,6 +57,25 @@ def test_detector_to_fourier(wavelength,
     k = detector_to_fourier(detector_coords, wavelength, camera_length)
     np.testing.assert_allclose(k, k_expected)
 
+@pytest.mark.parametrize('beam_wavelen, det2sample_len, pixel_size, peak_coord, k_expected', [
+    (0.5, 2e9, 10, 
+        np.array([
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1]
+        ]),
+        np.array([
+            [0, 0, 0],
+            [0, (1/0.5)*np.sin(np.arctan(1e5/2e9)), (1/0.5)*(np.cos(np.arctan(1e5/2e9)) - 1)],
+            [(1/0.5)*np.sin(np.arctan(1e5/2e9)), 0, (1/0.5)*(np.cos(np.arctan(1e5/2e9)) - 1)],
+            [(1/0.5)*np.sin(np.arctan(np.sqrt(1e5**2 + 1e5**2)/2e9))*np.sqrt(2/4), (1/0.5)*np.sin(np.arctan(np.sqrt(1e5**2 + 1e5**2)/2e9))*np.sqrt(2/4), (1/0.5)*(np.cos(np.arctan(np.sqrt(1e5**2 + 1e5**2)/2e9)) - 1)]
+        ])
+     )
+])
+def test_detector_px_to_3D_kspace(beam_wavelen, det2sample_len, pixel_size, peak_coord, k_expected):
+    k = detector_px_to_3D_kspace(peak_coord, beam_wavelen, det2sample_len, pixel_size)
+    np.testing.assert_allclose(k, k_expected,atol = 1e-20)
 
 @pytest.mark.parametrize('k1, k2, ref_k1, ref_k2, expected_rotation', [
     ([0, 0, 1], [0, 0, 2], [1, 0, 0], [0, 1, 0], np.identity(3)),  # Degenerate
@@ -77,3 +96,12 @@ def test_get_rotation_matrix_between_vectors(k1, k2, ref_k1, ref_k2,
 def test_get_angle_cartesian(vec_a, vec_b, expected_angle):
     angle = get_angle_cartesian(vec_a, vec_b)
     assert np.isclose(angle, expected_angle)
+
+@pytest.mark.parametrize('distance_hkl, actual_px_len, beam_wavelen, pixel_size, d_expected', [
+    (1, 1, 0.5, 10,
+     1e5/np.tan(2*np.arcsin(0.5/2))
+    )
+])
+def test_get_detector_to_sample_calibrated_distance(distance_hkl, actual_px_len, beam_wavelen, pixel_size, d_expected):
+    d = get_detector_to_sample_calibrated_distance(distance_hkl, actual_px_len, beam_wavelen, pixel_size)
+    np.testing.assert_allclose(d, d_expected)


### PR DESCRIPTION
---
New DiffractionPeaks + Extended DiffractionProfiles & DiffractionVectors 
---

**What does this PR do? Please describe or link to an open issue.**
It creates the new DiffractionPeaks class and extends functionalities in the DiffractionProfiles and DiffractionVectors classes.

**Describe the new behaviour**
- A find_peaks_1D() function has been created in the DiffractionProfiles class, which returns the peaks in each 1D spectra in the scanning coordinates as a DiffractionPeaks class object, the 1D equivalent of a DiffracionVectors class.
- A purely-geometrical function to transform the 1D detector pixel units (in a DiffractionProfile object) to the diffraction vector magnitude g has been added: detector_axes_to_1D_kspace().
- A purely-geometrical function to transform the detector pixel units to the diffraction vector Cartesian coordinates [gx, gy, gz] has been added: calculate_detector_px_to_cartesian_diffraction_coordinates().

**Describe alternatives you've considered**
The use of these functions is to be able to also calibrate XRD data, where the Ewald sphere curvature is not negligible.
Peaks in a 2D diffraction signal are first found in pixel units and later transformed to the reciprocal 3D space.

**Are there any known issues? Do you need help?**
Test functions need to be created for the 3 new functions and the 1 new class.

**Work in progress?**
- [ ] Expand DiffractionProfile class, to calibrate the axes to reciprocal space.
- [ ] Store the intensity of each peak in the "intensity" attribute, with navigation dimensions identical to the original object.

**Additional context**
Schemes for the 1D and the 3D detector pixel units to k-space vectors are attached, to clarify the geometry used.
**1D scheme**
![1d_calibration](https://user-images.githubusercontent.com/9082687/53086394-ef239400-34fc-11e9-8c13-b77586d1e69c.png)
**3D scheme**
![3d_calibration](https://user-images.githubusercontent.com/9082687/53086395-ef239400-34fc-11e9-84b2-12ad82d83a0d.png)