### PR TITLE
Add windows and macos testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,47 @@
 language: python
-python:
-  - "3.6"
+
+env:
+  global:
+    - DEPS="hyperspy-base transforms3d diffpy.structure"
+    - TEST_DEPS="pytest pytest-cov coveralls"
+    - DOC_DEPS="sphinx sphinx_bootstrap_theme"
+
+matrix:
+  include:
+  - env: export PYTHON=3.7
+  - env: export PYTHON=3.6
+  - env: export PYTHON=3.7
+    os: osx
+    language: generic
 
 sudo: True #for Miniconda 
 
 before_install:
-  # https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  # Install miniconda
+  - if [ $TRAVIS_OS_NAME = osx ]; then
+      curl "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -o miniconda.sh;
+    else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - chmod +x miniconda.sh;
+    ./miniconda.sh -b -p $HOME/miniconda;
+    hash -r;
+  # setup environment
+  - source $HOME/miniconda/bin/activate root;
+    conda update -y conda;
+    conda config --append channels conda-forge;
+    conda create -n testenv --yes python=$PYTHON;
+    source activate testenv;
   - conda info -a
-  - conda create -q -n test-environment 
-  - source activate test-environment
-  - conda install -c diffpy/label/dev diffpy.structure
-  - conda install pip 
 
 install:
-  - pip install . -r requirements.txt
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
+  - conda install -y $DEPS $TEST_DEPS $DOC_DEPS;
+  - pip install .
 
 script:
-  - timeout 2m pytest --cov=pyxem
+  - pytest --cov=pyxem
   - sphinx-apidoc -fo docs/source pyxem
   - sphinx-build -b html docs/source docs/build
+
 after_success:
   - coveralls
 
@@ -40,4 +52,3 @@ deploy:
   local_dir: docs/build
   on:
     branch: master
-

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,6 @@ pyXem requires python 3 and conda - we suggest using the python 3 version of `Mi
 Download the `source code <https://github.com/pyxem/pyxem>`__ and put it in a directory on your computer. The following commands will then install everything you need if entered into the anaconda promt (or terminal) when located in the pyxem directory:::
 
       $ conda install -c conda-forge diffpy.structure
-      $ conda install -c anaconda cython
-      $ conda install -c conda-forge spglib
-      $ conda install -c conda-forge traits
       $ pip install . -r requirements.txt
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+# environment variables
+environment:
+
+  global:
+    DEPS: "hyperspy-base transforms3d diffpy.structure"
+    TEST_DEPS: "pytest"
+
+  matrix:
+    - PY_VERSION: 3.6
+    - PY_VERSION: 3.7
+
+# scripts that run after cloning repository
+install:
+  # Workaround for https://github.com/conda/conda/issues/7144
+  # see https://github.com/appveyor/ci/issues/2270
+  - set PATH=C:\Miniconda37-x64;C:\Miniconda37-x64\Scripts;%PATH%
+
+  # Activate miniconda root environment
+  - "C:\\Miniconda37-x64\\Scripts\\activate.bat"
+
+  # Setup miniconda environment.
+  - ps: Add-AppveyorMessage "Setup miniconda environment..."
+  - "conda update -y -n base conda"
+  - 'conda config --add channels conda-forge'
+  - "conda create -y -n testenv python=%PY_VERSION%"
+  - "conda activate testenv"
+
+  # Install the dependencies of pyxem.
+  - 'conda install -yq %DEPS% %TEST_DEPS%'
+
+  # Install our package
+  - 'pip install -e .'
+
+build: off
+
+test_script:
+  - 'pytest'
+
+after_test:
+  - 'python setup.py bdist_wheel'
+
+artifacts:
+  - path: dist\*.whl
+    name: wheel


### PR DESCRIPTION
This PR add testing for macos and windows for python36 and python37. I haven't added python36 on macos because travis have limited ressources for this platform and usually there are queues for the macos build to start.

Unlike this is currently, this PR doesn't use the version of libraries as defined in `requirement.txt` in order to  avoid mixing pypi wheels with conda packages. It also has the advantage to make `pyxem` future proof and "distribution ready".

The appveyor builds can be found at:
https://ci.appveyor.com/project/ericpre/pyxem/builds/23261941

All the builds (linux, macos and windows) fail and reproduce the failure reported in #353. As a bonus, another test is also failing. :/