### PR TITLE
pyFAI integration into pyXem

### DIFF
--- a/pyxem/generators/diffraction_generator.py
+++ b/pyxem/generators/diffraction_generator.py
@@ -27,7 +27,7 @@ from pyxem.signals.diffraction_simulation import DiffractionSimulation
 from pyxem.signals.diffraction_simulation import ProfileSimulation
 
 from pyxem.utils.atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
-from pyxem.utils.sim_utils import get_electron_wavelength,\
+from pyxem.utils.sim_utils import get_wavelength,\
     get_kinematical_intensities, get_unique_families, get_points_in_sphere, \
     get_vectorized_list_for_atomic_scattering_factors, is_lattice_hexagonal
 
@@ -55,6 +55,9 @@ class DiffractionGenerator(object):
         equal to 1/{specimen thickness}.
     debye_waller_factors : dict of str : float
         Maps element names to their temperature-dependent Debye-Waller factors.
+    xray: boolean
+        If True, it calculates the wavelength for an x-ray (EM wave).
+        If False, it calculates the wavelength for a relativistic electron.
 
     """
     # TODO: Refactor the excitation error to a structure property.
@@ -63,8 +66,9 @@ class DiffractionGenerator(object):
                  accelerating_voltage,
                  max_excitation_error,
                  debye_waller_factors=None,
-                 scattering_params='lobato'):
-        self.wavelength = get_electron_wavelength(accelerating_voltage)
+                 scattering_params='lobato',
+                 xray=False):
+        self.wavelength = get_wavelength(accelerating_voltage, xray=xray)
         self.max_excitation_error = max_excitation_error
         self.debye_waller_factors = debye_waller_factors or {}
 

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -274,7 +274,7 @@ class DiffractionVectors(BaseSignal):
 
         return crystim
 
-    def calculate_cartesian_coordinates(self, accelerating_voltage, camera_length,
+    def calculate_cartesian_coordinates(self, accelerating_voltage, camera_length, xray=False,
                                         *args, **kwargs):
         """Get cartesian coordinates of the diffraction vectors.
 
@@ -284,10 +284,13 @@ class DiffractionVectors(BaseSignal):
             The acceleration voltage with which the data was acquired.
         camera_length : float
             The camera length in meters.
+        xray: boolean
+            If True, it calculates the wavelength for an x-ray (EM wave).
+            If False, it calculates the wavelength for a relativistic electron.
         """
         # Imported here to avoid circular dependency
-        from pyxem.utils.sim_utils import get_electron_wavelength
-        wavelength = get_electron_wavelength(accelerating_voltage)
+        from pyxem.utils.sim_utils import get_wavelength
+        wavelength = get_wavelength(accelerating_voltage, xray=xray)
         self.cartesian = self.map(detector_to_fourier,
                                   wavelength=wavelength,
                                   camera_length=camera_length * 1e10,

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -66,7 +66,7 @@ class DiffractionVectors(BaseSignal):
         self.cartesian = None
         self.hkls = None
 
-    def plot_diffraction_vectors(self, xlim, ylim, distance_threshold):
+    def plot_diffraction_vectors(self, xlim, ylim, distance_threshold, center = True):
         """Plot the unique diffraction vectors.
 
         Parameters
@@ -78,6 +78,9 @@ class DiffractionVectors(BaseSignal):
         distance_threshold : float
             The minimum distance between diffraction vectors to be passed to
             get_unique_vectors.
+        center: bool
+            If True (default), the centre of the detector is set as origin.
+            If False, no centering applied.
 
         Returns
         -------
@@ -90,10 +93,19 @@ class DiffractionVectors(BaseSignal):
         # Plot the gvector positions
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(unique_vectors.data.T[0], -unique_vectors.data.T[1], 'ro')
-        ax.set_xlim(-xlim, xlim)
-        ax.set_ylim(-ylim, ylim)
-        ax.set_aspect('equal')
+        if center == True:
+            ax.plot(unique_vectors.data.T[0], -unique_vectors.data.T[1], 'ro')
+            ax.set_xlim(-xlim, xlim)
+            ax.set_ylim(-ylim, ylim)
+            ax.set_aspect('equal')
+        else:
+            ax.plot(unique_vectors.data.T[0], unique_vectors.data.T[1], 'ro')
+            ax.set_xlim(0, xlim)
+            ax.set_ylim(0, ylim)
+            #Invert the y-axis so it goes from top->bottom
+            ax = plt.gca()
+            ax.invert_yaxis()
+
         return fig
 
     def plot_diffraction_vectors_on_signal(self, signal, *args, **kwargs):
@@ -302,3 +314,4 @@ class DiffractionVectors(BaseSignal):
         self.cartesian = self.map(detector_px_to_3D_kspace,
             ai=azimuthal_integrator, 
             show_progressbar=True, inplace=False, parallel=False)
+        transfer_navigation_axes(self.cartesian, self)

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 from scipy.spatial import distance_matrix
 
 from pyxem.utils.sim_utils import transfer_navigation_axes
-from pyxem.utils.vector_utils import detector_to_fourier
+from pyxem.utils.vector_utils import detector_to_fourier, detector_px_to_3D_kspace
 from pyxem.utils.vector_utils import calculate_norms, calculate_norms_ragged
 from pyxem.utils.vector_utils import get_indices_from_distance_matrix
 from pyxem.utils.vector_utils import get_npeaks
@@ -283,3 +283,22 @@ class DiffractionVectors(BaseSignal):
                                   parallel=False,  # TODO: For testing
                                   *args, **kwargs)
         transfer_navigation_axes(self.cartesian, self)
+
+    def calculate_detector_px_to_cartesian_diffraction_coordinates(self, azimuthal_integrator, *args, **kwargs):
+        """It takes a DiffractionVector object with peaks expressed in pixels in the detector. It maps the function detector_px_to_3D_kspace along the scanning pixels of the DiffractionVector class.
+        It stores in the DiffractionVector.cartesian attribute, the gx, gy and gz cartesian coordinates of the diffraction vector, in Angstoms^-1, using purely geometrical arguments.
+        Args:
+        ----------
+        self :DiffractionVector
+            A DiffractionVector object with the diffraction vectors in pixel units of the detector.
+        azimuthal_integrator: pyFAI.azimuthalIntegrator.AzimuthalIntegrator object
+            A pyFAI Geometry object, containing all the detector geometry parameters.
+        Returns
+        ----------
+        self: DiffractionVector
+            DiffractionProfile.cartesian attribute has stored the respective transformed px cordinates to angstrom^-1, in the form of an array containing [g_x, g_y, g_z] for each scanning coordinate.
+        """
+
+        self.cartesian = self.map(detector_px_to_3D_kspace,
+            ai=azimuthal_integrator, 
+            show_progressbar=True, inplace=False, parallel=False)

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -771,9 +771,17 @@ class ElectronDiffraction(Signal2D):
                                       "implementations.".format(method))
 
         peaks = self.map(method, *args, **kwargs, inplace=False, ragged=True)
-        peaks.map(peaks_as_gvectors,
-                  center=np.array(self.axes_manager.signal_shape) / 2 - 0.5,
-                  calibration=self.axes_manager.signal_axes[0].scale)
+
+        #If signal_axes units are pixels, do NOT centre the peaks:
+        if self.axes_manager.signal_axes[0].units == 'px':
+            peaks.map(peaks_as_gvectors, 
+                center=np.array([0,0]),
+                calibration=self.axes_manager.signal_axes[0].scale)
+        else:
+            peaks.map(peaks_as_gvectors, 
+                center=np.array(self.axes_manager.signal_shape) / 2 - 0.5,
+                calibration=self.axes_manager.signal_axes[0].scale)
+
         peaks = DiffractionVectors(peaks)
         peaks.axes_manager.set_signal_dimension(0)
 

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -31,14 +31,17 @@ from transforms3d.euler import mat2euler
 from transforms3d.quaternions import mat2quat, rotate_vector
 
 
-def get_electron_wavelength(accelerating_voltage):
+def get_wavelength(accelerating_voltage, xray=False):
     """Calculates the (relativistic) electron wavelength in Angstroms for a
-    given accelerating voltage in kV.
+    given accelerating voltage in kV, or for an x-ray.
 
     Parameters
     ----------
     accelerating_voltage : float
         The accelerating voltage in kV.
+    xray: boolean
+        If True, it calculates the wavelength for an x-ray (EM wave).
+        If False, it calculates the wavelength for a relativistic electron.
 
     Returns
     -------
@@ -47,12 +50,15 @@ def get_electron_wavelength(accelerating_voltage):
 
     """
     E = accelerating_voltage * 1e3
-    wavelength = h / math.sqrt(2 * m_e * e * E *
-                               (1 + (e / (2 * m_e * c * c)) * E)) * 1e10
+    if xray == False:
+        wavelength = h / math.sqrt(2 * m_e * e * E *
+            (1 + (e / (2 * m_e * c * c)) * E)) * 1e10
+    else:
+        wavelength = (h * c) / (E * e) * 1e10
     return wavelength
 
 
-def get_interaction_constant(accelerating_voltage):
+def get_interaction_constant(accelerating_voltage, xray=False):
     """Calculates the interaction constant, sigma, for a given
     acelerating voltage.
 
@@ -60,6 +66,9 @@ def get_interaction_constant(accelerating_voltage):
     ----------
     accelerating_voltage : float
         The accelerating voltage in V.
+    xray: boolean
+        If True, it calculates the wavelength for an x-ray (EM wave).
+        If False, it calculates the wavelength for a relativistic electron.
 
     Returns
     -------
@@ -68,7 +77,7 @@ def get_interaction_constant(accelerating_voltage):
 
     """
     E = accelerating_voltage
-    wavelength = get_electron_wavelength(accelerating_voltage)
+    wavelength = get_wavelength(accelerating_voltage, xray=xray)
     sigma = (2 * pi * (m_e + e * E))
 
     return sigma
@@ -249,7 +258,8 @@ def simulate_kinematic_scattering(atomic_coordinates,
                                   max_k=1.5,
                                   illumination='plane_wave',
                                   sigma=20,
-                                  scattering_params='lobato'):
+                                  scattering_params='lobato',
+                                  xray=False):
     """Simulate electron scattering from arrangement of atoms comprising one
     elemental species.
 
@@ -287,7 +297,7 @@ def simulate_kinematic_scattering(atomic_coordinates,
                                   "See documentation for available "
                                   "implementations.".format(scattering_params))
     # Calculate electron wavelength for given keV.
-    wavelength = get_electron_wavelength(accelerating_voltage)
+    wavelength = get_wavelength(accelerating_voltage, xray=xray)
 
     # Define a 2D array of k-vectors at which to evaluate scattering.
     l = np.linspace(-max_k, max_k, simulation_size)

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -60,6 +60,52 @@ def detector_to_fourier(k_xy, wavelength, camera_length):
     k = np.hstack((k_xy, k_z[:, np.newaxis]))
     return k
 
+def detector_px_to_3D_kspace(peak_coord, ai):
+    """Converts the detector 2d coordinate, in pixel units, to the respective 3D coordinate in the kspace, using the pyFAI Geometry object.
+    Args:
+    ----------
+    peak_coord: np.array
+        An array with the diffraction vectors of a single scanning coordinate, in pixel units of the detector.
+    ai: pyFAI.azimuthalIntegrator.AzimuthalIntegrator object
+        A pyFAI Geometry object, containing all the detector geometry parameters.
+    Returns
+    ----------
+    g_xyz: np.array
+        Array composed of [g_x, g_y, g_z] values for the peaks in the scanning coordinate, changed from pixel units to Angstrom^-1.
+    """
+    #Get the geometry parameters necessary for this transormation (all in metres)
+    det2sample_dist = ai.dist
+    wavelength = ai.wavelength
+    
+    #Transform each pixel unit to the actual disctance in metres, using the pyFAI module function
+    if peak_coord.shape == (1,) and peak_coord.dtype == 'object':
+        # From ragged array
+        peak_coord = peak_coord[0]
+    #x= peak_coord[:,0]
+    #y= peak_coord[:,1]
+    zyx =  ai.calc_pos_zyx(d1=peak_coord[:,1], d2=peak_coord[:,0])
+    
+    #Get the polar coordinate angles, in a 3D Edwald circunference:
+    #Note: zyx[2]==x, zyx[1]==y
+    #Vector moduli 'r' from the beam centre to the coordinate at the detector for each peak.
+    r = np.sqrt(zyx[2]**2 + zyx[1]**2)
+    #Phi angles (from z axis) for each peak:
+    phi = np.arctan(r/det2sample_dist)
+    #2 Theta angles (between x and y axis) for each peak. Use arctan2 to get the right quadrant sign:
+    two_theta = np.arctan2(np.sqrt(zyx[1]**2), zyx[2])
+    #TODO:
+    #Account for slight difference in the z-axis when computing angles (stored in the zyx[0])
+    
+    #Convert each x and y to the respective gx, gy and gz values, using 3D geometry. Multiply by the pixel sign:
+    sin_phi = np.sin(phi) #For memory saving
+    gx = (1/wavelength)*sin_phi*np.cos(two_theta)
+    gy = (1/wavelength)*sin_phi*np.sin(two_theta)
+    gz = (1/wavelength)*(np.cos(phi) - 1)
+
+    #Append the reciprocal vectors in one single array, while flipping the vector form, resembling the input array:
+    g_xyz = np.hstack((gx[:,np.newaxis], gy[:,np.newaxis], gz[:,np.newaxis]))
+
+    return g_xyz
 
 def calculate_norms(z):
     """Calculates the norm of an array of cartesian vectors. For use with map().

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -102,8 +102,8 @@ def detector_px_to_3D_kspace(peak_coord, ai):
     gy = (1/wavelength)*sin_phi*np.sin(two_theta)
     gz = (1/wavelength)*(np.cos(phi) - 1)
 
-    #Append the reciprocal vectors in one single array, while flipping the vector form, resembling the input array:
-    g_xyz = np.hstack((gx[:,np.newaxis], gy[:,np.newaxis], gz[:,np.newaxis]))
+    #Append the reciprocal vectors in one single array, while flipping the vector form, resembling the input array. Convert from m-1 to A-1:
+    g_xyz = np.hstack((gx[:,np.newaxis], gy[:,np.newaxis], gz[:,np.newaxis])) * 1e-10
 
     return g_xyz
 

--- a/tests/test_utils/test_sim_utils.py
+++ b/tests/test_utils/test_sim_utils.py
@@ -21,7 +21,7 @@ import numpy as np
 import diffpy
 
 from pyxem.signals.electron_diffraction import ElectronDiffraction
-from pyxem.utils.sim_utils import get_electron_wavelength, \
+from pyxem.utils.sim_utils import get_wavelength, \
     get_interaction_constant, get_unique_families, get_kinematical_intensities,\
     get_vectorized_list_for_atomic_scattering_factors, get_points_in_sphere, \
     simulate_kinematic_scattering, peaks_from_best_template, \
@@ -64,8 +64,8 @@ def create_structure_monoclinic():
     (200, 0.0250793403),
     (300, 0.0196874888),
 ])
-def test_get_electron_wavelength(accelerating_voltage, wavelength):
-    val = get_electron_wavelength(accelerating_voltage=accelerating_voltage)
+def test_get_wavelength(accelerating_voltage, wavelength):
+    val = get_wavelength(accelerating_voltage=accelerating_voltage)
     np.testing.assert_almost_equal(val, wavelength)
 
 


### PR DESCRIPTION
---
## Integration of the package `pyFAI` into `pyXem` 
### Adds functionalities when working with more complex geometries and X-ray diffraction

---

This pull request follows from #351, taking a simpler approach.

**Working in pixel units**
This is a first step to start working in pixel unit coordinates for as long as possible. No calibration is needed before peak transformation to diffraction vectors.

**The `pyFAI` package***
The `pyFAI` package is used to store the detector geometry and to convert from pixel coordinates to real detector distances (accounting for detector tilts, rotations and translations , see [here](https://pyfai.readthedocs.io/en/latest/geometry.html)). 

- It performs beam alignment and pixel to real-distance transformation, based on a Nexus detector geometry file (.nxs). 
- The `align_2d` function is no longer necessary, as the `pyFAI` geometry accounts for it.

**Working with X-rays**
Some functions have been adapted to work with X-rays, apart from electrons only:

- The `get_wavelength` function now includes an extra parameter to select between electrons or X-rays.
- A `calculate_detector_px_to_cartesian_diffraction_coordinates` function transforms the peaks, in pixel units, into the Cartesian reciprocal vector coordinates. **[𝑝𝑥_𝑥,𝑝𝑥_𝑦]→[𝑔_𝑥,𝑔_𝑦,𝑔_𝑧]** It takes a `DiffractionVector` and a geometry `pyFAI` object as the only arguments. It returns the same `DiffractionVector` object, storing the cartesian coordinates of the diffraction vector in the `.cartesian` attribute, in  𝐴−1 .

**Describe alternatives you've considered**
Initially, I attempted the same transformation without an external package. It can be done, but to a lesser accuracy (recall #351).

**Do you need help?**
Test functions need to be written.

**Future additions**
The `pyFAI` package was created to integrate radially. It would be nice to incorporate it in the `get_radial_profile` function in pyXem.