### PR TITLE
Handle `phase_entry['orientations']` being an ndarray

### DIFF
--- a/pyxem/libraries/diffraction_library.py
+++ b/pyxem/libraries/diffraction_library.py
@@ -132,8 +132,11 @@ class DiffractionLibrary(dict):
         if phase is not None:
             phase_entry = self[phase]
             if angle is not None:
-                if angle in phase_entry['orientations']:
-                    orientation_index = phase_entry['orientations'].index(angle)
+                orientations = phase_entry['orientations']
+                if isinstance(orientations, np.ndarray):
+                    orientations = orientations.tolist()
+                if angle in orientations:
+                    orientation_index = orientations.index(angle)
                 else:
                     orientation_index = _get_library_entry_from_angles(self, phase, angle)
             else:

--- a/tests/test_library/test_diffraction_library.py
+++ b/tests/test_library/test_diffraction_library.py
@@ -33,7 +33,7 @@ def get_library(default_structure):
     dfl = pxm.DiffractionLibraryGenerator(diffraction_calculator)
     structure_library = StructureLibrary(['Phase'],
                                          [default_structure],
-                                         [[(0, 0, 0), (0, 0.2, 0)]])
+                                         [np.array([(0, 0, 0), (0, 0.2, 0)])])
 
     return dfl.get_diffraction_library(structure_library,
                                        0.017, 2.4, (72, 72))
@@ -43,6 +43,8 @@ def test_get_library_entry_assertionless(get_library):
     assert isinstance(get_library.get_library_entry()['Sim'],
                       DiffractionSimulation)
     assert isinstance(get_library.get_library_entry(phase='Phase')['Sim'],
+                      DiffractionSimulation)
+    assert isinstance(get_library.get_library_entry(phase='Phase', angle=(0, 0, 0))['Sim'],
                       DiffractionSimulation)
 
 


### PR DESCRIPTION
---
Fix get_library_entry
---
This is a patch to the changes made in #352. `StructureLibraryGenerator` generates the orientations as a numpy ndarray. This caused `get_library_entry` to fail. This was not caused by the tests since all tests calling `get_library_entry` used handmade structure libraries with orientations stored as a list. To reproduce the error in the tests, I changed one of the tests (`test_orientation_mapping_nonphys`) to use a `ndarray` instead.