### PR TITLE
Speed up kinematic intensity calculation

### DIFF
--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -111,6 +111,30 @@ def get_unique_families(hkls):
     return pretty_unique
 
 
+def get_scattering_params_dict(scattering_params):
+    """Get scattering parameter dictionary from name.
+
+    Parameters
+    ----------
+    scattering_params : string
+        Name of scattering factors. One of 'lobato', 'xtables'.
+
+    Returns
+    -------
+    scattering_params_dict : dict
+        Dictionary of scattering parameters mapping from element name.
+    """
+    if scattering_params == 'lobato':
+        scattering_params_dict = ATOMIC_SCATTERING_PARAMS_LOBATO
+    elif scattering_params == 'xtables':
+        scattering_params_dict = ATOMIC_SCATTERING_PARAMS
+    else:
+        raise NotImplementedError("The scattering parameters `{}` are not implemented. "
+                                  "See documentation for available "
+                                  "implementations.".format(scattering_params))
+    return scattering_params_dict
+
+
 def get_vectorized_list_for_atomic_scattering_factors(structure,
                                                       debye_waller_factors,
                                                       scattering_params):
@@ -141,30 +165,46 @@ def get_vectorized_list_for_atomic_scattering_factors(structure,
         Debye-Waller factors for each atom in the structure.
     """
 
-    coeffs, fcoords, occus, dwfactors = [], [], [], []
+    scattering_params_dict = get_scattering_params_dict(scattering_params)
 
-    if scattering_params == 'lobato':
-        scattering_params_dict = ATOMIC_SCATTERING_PARAMS_LOBATO
-    elif scattering_params == 'xtables':
-        scattering_params_dict = ATOMIC_SCATTERING_PARAMS
-    else:
-        raise NotImplementedError("The scattering parameters `{}` are not implemented. "
-                                  "See documentation for available "
-                                  "implementations.".format(scattering_params))
+    n_structures = len(structure)
+    coeffs = np.empty((n_structures, 5, 2))
+    fcoords = np.empty((n_structures, 3))
+    occus = np.empty(n_structures)
+    dwfactors = np.empty(n_structures)
 
-    for site in structure:
-        c = scattering_params_dict[site.element]
-        coeffs.append(c)
-        dwfactors.append(debye_waller_factors.get(site.element, 0))
-        fcoords.append(site.xyz)
-        occus.append(site.occupancy)
-
-    coeffs = np.array(coeffs)
-    fcoords = np.array(fcoords)
-    occus = np.array(occus)
-    dwfactors = np.array(dwfactors)
+    for i, site in enumerate(structure):
+        coeffs[i] = scattering_params_dict[site.element]
+        dwfactors[i] = debye_waller_factors.get(site.element, 0)
+        fcoords[i] = site.xyz
+        occus[i] = site.occupancy
 
     return coeffs, fcoords, occus, dwfactors
+
+
+def get_atomic_scattering_factors(g_hkl_sq, coeffs, scattering_params):
+    """Calculate atomic scattering factors for n atoms.
+
+    Parameters
+    ----------
+    g_hkl_sq : ndarray
+        One-dimensional array of g-vector lengths squared.
+    coeffs : ndarray
+        Three-dimensional array [n, 5, 2] of coefficients corresponding to the n atoms.
+    scattering_params : string
+        Type of scattering factor calculation to use. One of 'lobato', 'xtables'.
+
+    Returns
+    -------
+    scattering_factors : ndarray
+        The calculated atomic scattering parameters.
+    """
+    g_sq_coeff_1 = np.outer(g_hkl_sq, coeffs[:, :, 1]).reshape(g_hkl_sq.shape + coeffs[:, :, 1].shape)
+    if scattering_params == 'lobato':
+        f = (2 + g_sq_coeff_1) * (1 / np.square(1 + g_sq_coeff_1))
+    elif scattering_params == 'xtables':
+        f = np.exp(-0.25 * g_sq_coeff_1)
+    return np.sum(coeffs[:, :, 0] * f, axis=-1)
 
 
 def get_kinematical_intensities(structure,
@@ -188,7 +228,7 @@ def get_kinematical_intensities(structure,
         The fractional coordinates of the peaks for which to calculate the
         structure factor.
     proximities : array-like
-        The distances between the Ewald sphere and the peak centres.
+        The distances between the Ewald sphere and the peak centers.
 
     Returns
     -------
@@ -200,37 +240,21 @@ def get_kinematical_intensities(structure,
         structure=structure, debye_waller_factors=debye_waller_factors,
         scattering_params=scattering_params)
 
-    # Store array of s^2 values since used multiple times.
-    s2s = (g_hkls / 2) ** 2
+    # Store array of g_hkls^2 values since used multiple times.
+    g_hkls_sq = g_hkls**2
 
     # Create array containing atomic scattering factors.
-    fss = []
-    if scattering_params == 'lobato':
-        for g in g_hkls:
-            fs = np.sum((coeffs[:, :, 0] * (2 + coeffs[:, :, 1] * g**2) *
-                         np.divide(1, np.square(1 + coeffs[:, :, 1] * g**2))), axis=1)
-            fss.append(fs)
-        fss = np.array(fss)
-    elif scattering_params == 'xtables':
-        for s2 in s2s:
-            fs = np.sum(coeffs[:, :, 0] * np.exp(-coeffs[:, :, 1] * s2), axis=1)
-            fss.append(fs)
-        fss = np.array(fss)
+    fs = get_atomic_scattering_factors(g_hkls_sq, coeffs, scattering_params)
 
     # Change the coordinate system of fcoords to align with that of g_indices
     fcoords = np.dot(fcoords, np.linalg.inv(np.dot(structure.lattice.stdbase,
                                                    structure.lattice.recbase)))
 
     # Calculate structure factors for all excited g-vectors.
-    f_hkls = []
-    for n in np.arange(len(g_indices)):
-        g = g_indices[n]
-        fs = fss[n]
-        dw_correction = np.exp(-dwfactors * s2s[n])
-        f_hkl = np.sum(fs * occus * np.exp(2j * np.pi * np.dot(fcoords, g))
-                       * dw_correction)
-        f_hkls.append(f_hkl)
-    f_hkls = np.array(f_hkls)
+    f_hkls = np.sum(fs * occus * np.exp(
+        2j * np.pi * np.dot(g_indices, fcoords.T) -
+        0.25 * np.outer(g_hkls_sq, dwfactors)),
+        axis=-1)
 
     # Define an intensity scaling that is linear with distance from Ewald sphere
     # along the beam direction.
@@ -266,8 +290,12 @@ def simulate_kinematic_scattering(atomic_coordinates,
         the simulation calculation.
     max_k : float
         Maximum scattering vector magnitude in reciprocal angstroms.
-    illumination = string
+    illumination : string
         Either 'plane_wave' or 'gaussian_probe' illumination
+    sigma : float
+        Gaussian probe standard deviation, used when illumination == 'gaussian_probe'
+    scattering_params : string
+        Type of scattering factor calculation to use. One of 'lobato', 'xtables'.
 
     Returns
     -------
@@ -278,14 +306,8 @@ def simulate_kinematic_scattering(atomic_coordinates,
     from pyxem.signals.electron_diffraction import ElectronDiffraction
 
     # Get atomic scattering parameters for specified element.
-    if scattering_params == 'lobato':
-        c = np.array(ATOMIC_SCATTERING_PARAMS_LOBATO[element])
-    elif scattering_params == 'xtables':
-        c = np.array(ATOMIC_SCATTERING_PARAMS[element])
-    else:
-        raise NotImplementedError("The scattering parameters `{}` are not implemented. "
-                                  "See documentation for available "
-                                  "implementations.".format(scattering_params))
+    coeffs = np.array(get_scattering_params_dict(scattering_params)[element])
+
     # Calculate electron wavelength for given keV.
     wavelength = get_electron_wavelength(accelerating_voltage)
 
@@ -296,23 +318,14 @@ def simulate_kinematic_scattering(atomic_coordinates,
     # Convert 2D k-vectors into 3D k-vectors accounting for Ewald sphere.
     k = np.array((kx, ky, (wavelength / 2) * (kx ** 2 + ky ** 2)))
 
-    # Calculate scatering angle squared for each k-vector.
-    s2s = (np.linalg.norm(k, axis=0) / 2) ** 2
-    gs = (np.linalg.norm(k, axis=0))
+    # Calculate scattering vector squared for each k-vector.
+    gs_sq = np.linalg.norm(k, axis=0)**2
 
-    # Evaluate atomic scattering factor.
-    if scattering_params == 'lobato':
-        fs = np.zeros_like(s2s)
-        for i in np.arange(5):
-            fs = (fs + c[i, 0] * (2 + c[i, 1] * gs**2) *
-                  np.divide(1, np.square(1 + c[i, 1] * gs**2)))
-    elif scattering_params == 'xtables':
-        fs = np.zeros_like(s2s)
-        for i in np.arange(5):
-            fs = fs + (c[i][0] * np.exp(-c[i][1] * s2s))
+    # Get the scattering factors for this element.
+    fs = get_atomic_scattering_factors(gs_sq, coeffs[np.newaxis, :], scattering_params)
 
     # Evaluate scattering from all atoms
-    scattering = np.zeros_like(s2s)
+    scattering = np.zeros_like(gs_sq)
     if illumination == 'plane_wave':
         for r in atomic_coordinates:
             scattering = scattering + (fs * np.exp(np.dot(k.T, r) * np.pi * 2j))
@@ -322,7 +335,7 @@ def simulate_kinematic_scattering(atomic_coordinates,
                 np.exp((-np.abs(((r[0]**2) - (r[1]**2)))) / (4 * sigma**2))
             scattering = scattering + (probe * fs * np.exp(np.dot(k.T, r) * np.pi * 2j))
     else:
-        raise ValueError("User specified illumination not defined.")
+        raise ValueError("User specified illumination '{}' not defined.".format(illumination))
 
     # Calculate intensity
     intensity = (scattering * scattering.conjugate()).real

--- a/tests/test_physical/test_orientation_mapping_phys.py
+++ b/tests/test_physical/test_orientation_mapping_phys.py
@@ -148,6 +148,7 @@ def get_vector_match_results(structure, rot_list, edc):
         keys=['A'])
     return diffraction_library, indexation
 
+
 @pytest.mark.parametrize("structure", [create_Ortho(), create_Hex()])
 def test_orientation_mapping_physical(structure, rot_list, pattern_list, edc):
     M = get_template_match_results(structure, pattern_list, edc, rot_list)
@@ -231,7 +232,7 @@ def test_kinematic_intensities_rotation(structure, rotation):
     structure.placeInLattice(rotated_lattice)
     reciprocal_lattice = structure.lattice.reciprocal()
     g_indices = [(0, 0, 1)]
-    g_hkls = np.array([reciprocal_lattice.dist(g_indices, [0, 0, 0])])
+    g_hkls = reciprocal_lattice.dist(g_indices, [0, 0, 0])
 
     scattering_params_list = ['lobato', 'xtables']
     for scattering_params in scattering_params_list:
@@ -256,7 +257,7 @@ def test_kinematic_intensities_error_raise(structure, rotation):
     structure.placeInLattice(rotated_lattice)
     reciprocal_lattice = structure.lattice.reciprocal()
     g_indices = [(0, 0, 1)]
-    g_hkls = np.array([reciprocal_lattice.dist(g_indices, [0, 0, 0])])
+    g_hkls = reciprocal_lattice.dist(g_indices, [0, 0, 0])
 
     intensities = get_kinematical_intensities(
         structure,


### PR DESCRIPTION
---
Speed up kinematic intensity calculations
---

Standard transformation from loops to numpy vector calculations. As usual, numpy vector calculations are a lot faster than Python loops. Also some refactoring to remove some duplicated code in `simulate_kinematic_scattering`. There should be no changes in external API or results.