### PR TITLE
refactor apply affine transformation - improves speed

### DIFF
--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -199,7 +199,7 @@ def remove_dead(z, deadpixels, deadvalue="average", d=1):
     return z_bar
 
 
-def affine_transformation(z, matrix, order, *args, **kwargs):
+def affine_transformation(z, transformation, order, *args, **kwargs):
     """Apply an affine transformation to a 2-dimensional array.
 
     Parameters
@@ -220,19 +220,8 @@ def affine_transformation(z, matrix, order, *args, **kwargs):
     trans : array
         Affine transformed diffraction pattern.
     """
-    # These three lines account for the transformation center not being (0,0)
-    shift_y, shift_x = np.array(z.shape[:2]) / 2.
-    tf_shift = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
-    tf_shift_inv = tf.SimilarityTransform(translation=[shift_x, shift_y])
-
-    # This defines the transform you want to perform
-    transformation = tf.AffineTransform(matrix=matrix)
-
-    # skimage transforms can be added like this, actually matrix multiplication,
-    # hence the need for the brackets. (Note tf.warp takes the inverse)
-    trans = tf.warp(z, (tf_shift + (transformation + tf_shift_inv)).inverse,
+    trans = tf.warp(z, transformation,
                     order=order, *args, **kwargs)
-
     return trans
 
 


### PR DESCRIPTION
The apply_affine_tranformation() method is currently very slow - this small refactoring to calculate the transformation outside of the map() function seems to improve speed quite significantly.

It might be possible to achieve further gains by using scipy.ndimage.map_coordinates directly rather than the wrapper from skimage.