### PR TITLE
Subpixelrefinement diffractionvector map

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -23,6 +23,7 @@ Generating subpixel resolution on diffraction vectors.
 import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 
+from pyxem.signals.diffraction_vectors import DiffractionVectors
 from pyxem.utils.expt_utils import peaks_as_gvectors
 from pyxem.utils.subpixel_refinements_utils import _conventional_xc
 from pyxem.utils.subpixel_refinements_utils import get_experimental_square
@@ -36,9 +37,12 @@ class SubpixelrefinementGenerator():
     ----------
     dp : ElectronDiffraction
         The electron diffraction patterns to be refined
-    vectors : numpy.array()
-        An array containing the vectors (in calibrated units) to the locations
-        of the spots to be refined.
+    vectors : DiffractionVectors | ndarray
+        Vectors (in calibrated units) to the locations of the spots to be
+        refined. If given as DiffractionVectors, it must have the same
+        navigation shape as the electron diffraction patterns. If an ndarray,
+        the same set of vectors is mapped over all electron diffraction
+        patterns.
 
     References
     ----------
@@ -50,10 +54,25 @@ class SubpixelrefinementGenerator():
         self.dp = dp
         self.vectors_init = vectors
         self.last_method = None
-        # this hard codes the squareness of patterns
-        self.calibration = dp.axes_manager.signal_axes[0].scale
-        self.center = (dp.axes_manager.signal_axes[0].size) / 2
-        self.vectors_pixels = ((vectors / self.calibration) + self.center).astype(int)
+        sig_ax = dp.axes_manager.signal_axes
+        self.calibration = [sig_ax[0].scale, sig_ax[1].scale]
+        self.center = [sig_ax[0].size / 2, sig_ax[1].size / 2]
+
+        def _floor(vectors, calibration, center):
+            if vectors.shape == (1,) and vectors.dtype == np.object:
+                vectors = vectors[0]
+            return np.floor((vectors.astype(np.float64) / calibration) + center).astype(np.int)
+        if isinstance(vectors, DiffractionVectors):
+            if vectors.axes_manager.navigation_shape != dp.axes_manager.navigation_shape:
+                raise ValueError('Vectors with shape {} must have the same navigation shape '
+                                 'as the diffraction patterns which has shape {}.'.format(
+                                     vectors.axes_manager.navigation_shape, dp.axes_manager.navigation_shape))
+            self.vector_pixels = vectors.map(_floor,
+                                             calibration=self.calibration,
+                                             center=self.center,
+                                             inplace=False)
+        else:
+            self.vector_pixels = _floor(vectors, self.calibration, self.center)
 
     def conventional_xc(self, square_size, disc_radius, upsample_factor):
         """Refines the peaks using (phase) cross correlation.
@@ -70,30 +89,28 @@ class SubpixelrefinementGenerator():
 
         Returns
         -------
-        vector_out: np.array()
-            array containing the refined vectors in calibrated units
+        vector_out: DiffractionVectors
+            DiffractionVectors containing the refined vectors in calibrated
+            units with the same navigation shape as the diffraction patterns.
 
         """
-        self.vectors_out = np.zeros(
-            (self.dp.data.shape[0],
-             self.dp.data.shape[1],
-             self.vectors_init.shape[0],
-             self.vectors_init.shape[1]))
-        sim_disc = get_simulated_disc(square_size, disc_radius)
-        for i in np.arange(0, len(self.vectors_init)):
-            vect = self.vectors_pixels[i]
-            expt_disc = self.dp.map(
-                get_experimental_square,
-                vector=vect,
-                square_size=square_size,
-                inplace=False)
-            shifts = expt_disc.map(
-                _conventional_xc,
-                sim_disc=sim_disc,
-                upsample_factor=upsample_factor,
-                inplace=False)
-            self.vectors_out[:, :, i, :] = (((vect + shifts.data) - self.center) * self.calibration)
+        def _conventional_xc_map(dp, vectors, sim_disc, upsample_factor, center, calibration):
+            shifts = np.zeros_like(vectors, dtype=np.float64)
+            for i, vector in enumerate(vectors):
+                expt_disc = get_experimental_square(dp, vector, square_size)
+                shifts[i] = _conventional_xc(expt_disc, sim_disc, upsample_factor)
+            return (((vectors + shifts) - center) * calibration)
 
+        sim_disc = get_simulated_disc(square_size, disc_radius)
+        self.vectors_out = DiffractionVectors(
+            self.dp.map(_conventional_xc_map,
+                        vectors=self.vector_pixels,
+                        sim_disc=sim_disc,
+                        upsample_factor=upsample_factor,
+                        center=self.center,
+                        calibration=self.calibration,
+                        inplace=False))
+        self.vectors_out.axes_manager.set_signal_dimension(0)
         self.last_method = "conventional_xc"
         return self.vectors_out
 
@@ -127,9 +144,7 @@ class SubpixelrefinementGenerator():
                 The x and y locations of the center of mass of the parsed square
             """
 
-            t = center_of_mass(z)
-            x = t[1]
-            y = t[0]
+            y, x = center_of_mass(z)
             return (x, y)
 
         def _com_experimental_square(z, vector, square_size):
@@ -150,26 +165,27 @@ class SubpixelrefinementGenerator():
             z_adpt : np.array
                 z, but with row and column zero set to 0
             """
-            z_adpt = np.copy(get_experimental_square(z, vector=vect, square_size=square_size)
-                             )  # to make sure we don't change the dp
+            # Copy to make sure we don't change the dp
+            z_adpt = np.copy(get_experimental_square(z, vector=vector, square_size=square_size))
             z_adpt[:, 0] = 0
             z_adpt[0, :] = 0
             return z_adpt
 
-        self.vectors_out = np.zeros(
-            (self.dp.data.shape[0],
-             self.dp.data.shape[1],
-             self.vectors_init.shape[0],
-             self.vectors_init.shape[1]))
-        for i in np.arange(0, len(self.vectors_init)):
-            vect = self.vectors_pixels[i]
-            expt_disc = self.dp.map(
-                _com_experimental_square,
-                vector=vect,
-                square_size=square_size,
-                inplace=False)
-            shifts = expt_disc.map(_center_of_mass_hs, inplace=False) - (square_size / 2)
-            self.vectors_out[:, :, i, :] = (((vect + shifts.data) - self.center) * self.calibration)
+        def _center_of_mass_map(dp, vectors, square_size, center, calibration):
+            shifts = np.zeros_like(vectors, dtype=np.float64)
+            for i, vector in enumerate(vectors):
+                expt_disc = _com_experimental_square(dp, vector, square_size)
+                shifts[i] = [a - square_size / 2 for a in _center_of_mass_hs(expt_disc)]
+            return ((vectors + shifts) - center) * calibration
+
+        self.vectors_out = DiffractionVectors(
+            self.dp.map(_center_of_mass_map,
+                        vectors=self.vector_pixels,
+                        square_size=square_size,
+                        center=self.center,
+                        calibration=self.calibration,
+                        inplace=False))
+        self.vectors_out.axes_manager.set_signal_dimension(0)
 
         self.last_method = "center_of_mass_method"
         return self.vectors_out

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -145,7 +145,9 @@ class SubpixelrefinementGenerator():
                 The x and y locations of the center of mass of the parsed square
             """
 
-            z *= 1 / np.sum(z)
+            s = np.sum(z)
+            if s != 0:
+                z *= 1 / s
             dx = np.sum(z, axis=0)
             dy = np.sum(z, axis=1)
             h, w = z.shape

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -149,8 +149,8 @@ class SubpixelrefinementGenerator():
             dx = np.sum(z, axis=0)
             dy = np.sum(z, axis=1)
             h, w = z.shape
-            cx = np.sum(dx * np.arange(h))
-            cy = np.sum(dy * np.arange(w))
+            cx = np.sum(dx * np.arange(w))
+            cy = np.sum(dy * np.arange(h))
             return cx, cy
                     
 

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -21,7 +21,6 @@ Generating subpixel resolution on diffraction vectors.
 """
 
 import numpy as np
-from scipy.ndimage.measurements import center_of_mass
 
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 from pyxem.utils.expt_utils import peaks_as_gvectors
@@ -144,8 +143,14 @@ class SubpixelrefinementGenerator():
                 The x and y locations of the center of mass of the parsed square
             """
 
-            y, x = center_of_mass(z)
-            return (x, y)
+            z *= 1 / np.sum(z)
+            dx = np.sum(z, axis=0)
+            dy = np.sum(z, axis=1)
+            h, w = z.shape
+            cx = np.sum(dx * np.arange(h))
+            cy = np.sum(dy * np.arange(w))
+            return cx, cy
+                    
 
         def _com_experimental_square(z, vector, square_size):
             """Wrapper for get_experimental_square that makes the non-zero

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -125,8 +125,10 @@ class SubpixelrefinementGenerator():
 
         Returns
         -------
-        vector_out: np.array()
-            array containing the refined vectors in calibrated units
+        vector_out: DiffractionVectors
+            DiffractionVectors containing the refined vectors in calibrated
+            units with the same navigation shape as the diffraction patterns.
+
         """
 
         def _center_of_mass_hs(z):


### PR DESCRIPTION
---
Subpixelrefinement diffractionvector map
---

This PR changes the interface for the `SubpixelrefinementGenerator` as discussed in #357 to allow refining a separate set of diffraction vectors at each navigation position.

`SubpixelrefinementGenerator` constructor has changed to allow either a numpy array or a `DiffractionVectors` instance to be passed as diffraction vectors. If a numpy array, the same set of vectors is refined across all navigation positions of the `ElectronDiffraction`, mirroring the old behaviour and saving some memory. If a `DiffractionVectors` instance (which must have the same navigation shape as the diffraction patterns), a separate set of vectors is refined at each position. The `center_of_mass_method` and the `conventional_xc` method are changed accordingly. Also, the return types are changed to `DiffractionVectors`, instead of the raw 4D numpy array.

I have run the old and the new implementation on a test dataset (varying number of vectors, random perturbation of the peak positions before refinement), comparing the outputs. They are the same (`np.testing.assert_allclose`), but it would be useful if anyone has a proper test dataset with known results.