### PR TITLE
Adding "Gaussian Like" Subpixel Peakfinder

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -211,9 +211,9 @@ class SubpixelrefinementGenerator():
 
         Returns
         -------
-            vector_out : DiffractionVectors
-                DiffractionVectors containing the refined vectors in calibrated
-                units with the same navigation shape as the diffraction patterns.
+        vector_out : DiffractionVectors
+            DiffractionVectors containing the refined vectors in calibrated
+            units with the same navigation shape as the diffraction patterns.
 
         Notes
         -----

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -155,7 +155,6 @@ class SubpixelrefinementGenerator():
             cy = np.sum(dy * np.arange(h))
             return cx, cy
 
-
         def _com_experimental_square(z, vector, square_size):
             """Wrapper for get_experimental_square that makes the non-zero
             elements symmetrical around the 'unsubpixeled' peak by zeroing a
@@ -199,7 +198,7 @@ class SubpixelrefinementGenerator():
         self.last_method = "center_of_mass_method"
         return self.vectors_out
 
-        def local_gaussian_method(self,square_size):
+    def local_gaussian_method(self,square_size):
         """ Refinement based on the mathematics of a local maxima on a
         continious region, using the (discrete) maxima pixel as a starting point.
         See Notes.
@@ -224,47 +223,46 @@ class SubpixelrefinementGenerator():
         which are then returned.
         """
 
-            self.vectors_out = np.zeros(
+        self.vectors_out = np.zeros(
                 (self.dp.data.shape[0],
                 self.dp.data.shape[1],
                 self.vectors_init.shape[0],
                 self.vectors_init.shape[1]))
 
-                def _new_lg_idea(z):
-                    """ Internal function providing the algebra for the local_gaussian_method,
-                    see docstring of that function for details
+        def _new_lg_idea(z):
+                """ Internal function providing the algebra for the local_gaussian_method,
+                see docstring of that function for details
 
-                    Parameters
-                    ----------
-                    z : np.array
-                        subsquare containing the peak to be localised
+                Parameters
+                ----------
+                z : np.array
+                    subsquare containing the peak to be localised
 
-                    Returns
-                    -------
-                    (x,y) : tuple
-                        Containing subpixel resolved values for the center
-                    """
-                    si = np.unravel_index(np.argmax(z),z.shape)
-                    z_ref = z[si[0]-1:si[0]+2,si[1]-1:si[1]+2]
-                    if z_ref.shape != (3,3):
-                        raise ValueError("The local maxima needs to have 4 adjacent pixels")
-                    M = z_ref[1,1]
-                    LX,RX = z_ref[1,0],z_ref[1,2]
-                    UY,DY = z_ref[0,1],z_ref[2,1]
-
-                    x_ans = 0.5 * (LX-RX) / (LX + RX - 2*M)
-                    y_ans = 0.5 * (UY-DY) / (UY + DY - 2*M)
-                    return (si[1]+x_ans,si[0]+y_ans)
+                Returns
+                -------
+                (x,y) : tuple
+                    Containing subpixel resolved values for the center
+                """
+                si = np.unravel_index(np.argmax(z),z.shape)
+                z_ref = z[si[0]-1:si[0]+2,si[1]-1:si[1]+2]
+                if z_ref.shape != (3,3):
+                    raise ValueError("The local maxima needs to have 4 adjacent pixels")
+                M = z_ref[1,1]
+                LX,RX = z_ref[1,0],z_ref[1,2]
+                UY,DY = z_ref[0,1],z_ref[2,1]
+                x_ans = 0.5 * (LX-RX) / (LX + RX - 2*M)
+                y_ans = 0.5 * (UY-DY) / (UY + DY - 2*M)
+                return (si[1]+x_ans,si[0]+y_ans)
 
         for i in np.arange(0, len(self.vectors_init)):
             vect = self.vectors_pixels[i]
             expt_disc = self.dp.map(
-                get_experimental_square,
-                vector=vect,
-                square_size=square_size,
-                inplace=False)
+            get_experimental_square,
+            vector=vect,
+            square_size=square_size,
+            inplace=False)
             shifts = expt_disc.map(_new_lg_idea,inplace=False)
-            self.vectors_out[:, :, i, :] = (((vect - (square_size/2) + shifts.data) - self.center) * self.calibration)
 
+        self.vectors_out[:, :, i, :] = (((vect - (square_size/2) + shifts.data) - self.center) * self.calibration)
         self.last_method = "new_lg_idea"
         return self.vectors_out

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -154,7 +154,7 @@ class SubpixelrefinementGenerator():
             cx = np.sum(dx * np.arange(w))
             cy = np.sum(dy * np.arange(h))
             return cx, cy
-                    
+
 
         def _com_experimental_square(z, vector, square_size):
             """Wrapper for get_experimental_square that makes the non-zero
@@ -197,4 +197,74 @@ class SubpixelrefinementGenerator():
         self.vectors_out.axes_manager.set_signal_dimension(0)
 
         self.last_method = "center_of_mass_method"
+        return self.vectors_out
+
+        def local_gaussian_method(self,square_size):
+        """ Refinement based on the mathematics of a local maxima on a
+        continious region, using the (discrete) maxima pixel as a starting point.
+        See Notes.
+
+        Parameters
+        ----------
+        square_size : int
+            Length (in pixels) of one side of a square the contains the peak to
+            be refined.
+
+        Returns
+        -------
+            vector_out : DiffractionVectors
+                DiffractionVectors containing the refined vectors in calibrated
+                units with the same navigation shape as the diffraction patterns.
+
+        Notes
+        -----
+        This method works by first locating the maximum intenisty value within teh square.
+        The four adjacent pixels are then considered and used to form two independant
+        quadratic equations. Solving these gives the x_center and y_center coordinates,
+        which are then returned.
+        """
+
+            self.vectors_out = np.zeros(
+                (self.dp.data.shape[0],
+                self.dp.data.shape[1],
+                self.vectors_init.shape[0],
+                self.vectors_init.shape[1]))
+
+                def _new_lg_idea(z):
+                    """ Internal function providing the algebra for the local_gaussian_method,
+                    see docstring of that function for details
+
+                    Parameters
+                    ----------
+                    z : np.array
+                        subsquare containing the peak to be localised
+
+                    Returns
+                    -------
+                    (x,y) : tuple
+                        Containing subpixel resolved values for the center
+                    """
+                    si = np.unravel_index(np.argmax(z),z.shape)
+                    z_ref = z[si[0]-1:si[0]+2,si[1]-1:si[1]+2]
+                    if z_ref.shape != (3,3):
+                        raise ValueError("The local maxima needs to have 4 adjacent pixels")
+                    M = z_ref[1,1]
+                    LX,RX = z_ref[1,0],z_ref[1,2]
+                    UY,DY = z_ref[0,1],z_ref[2,1]
+
+                    x_ans = 0.5 * (LX-RX) / (LX + RX - 2*M)
+                    y_ans = 0.5 * (UY-DY) / (UY + DY - 2*M)
+                    return (si[1]+x_ans,si[0]+y_ans)
+
+        for i in np.arange(0, len(self.vectors_init)):
+            vect = self.vectors_pixels[i]
+            expt_disc = self.dp.map(
+                get_experimental_square,
+                vector=vect,
+                square_size=square_size,
+                inplace=False)
+            shifts = expt_disc.map(_new_lg_idea,inplace=False)
+            self.vectors_out[:, :, i, :] = (((vect - (square_size/2) + shifts.data) - self.center) * self.calibration)
+
+        self.last_method = "new_lg_idea"
         return self.vectors_out

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -92,3 +92,31 @@ def test_assertioned_com(dp, diffraction_vectors):
     error = s.data[0, 0] - np.asarray([[90 - 64, 30 - 64]])
     rms_error = np.sqrt(error[0, 0]**2 + error[0, 1]**2)
     assert rms_error < 1e-5  # perfect detection for this trivial case
+
+@pytest.mark.parametrize('dp, diffraction_vectors', [
+    (create_spot(), np.array([[90 - 64, 30 - 64]])),
+])
+def test_local_gaussian_method_dull(dp,diffraction_vectors):
+    """
+    This aims to test that our x/y convention is correct. The peak shape for
+    these tests is unsuitable for this method.
+    """
+    spr = SubpixelrefinementGenerator(dp, diffraction_vectors)
+    s = spr.local_gaussian_method(8)
+    error = s.data[0, 0] - np.asarray([[90 - 64, 30 - 64]])
+    assert np.all(error < 5)
+
+@pytest.mark.parametrize('dp, diffraction_vectors', [
+    (create_spot(), create_vectors())
+])
+
+@pytest.mark.xfail(raises=ValueError)
+def test_local_gaussian_method_exciting(dp,diffraction_vectors):
+    """
+    This aims to test that our x/y convention is correct. The peak shape for
+    these tests is unsuitable for this method.
+    """
+    spr = SubpixelrefinementGenerator(dp, diffraction_vectors)
+    s = spr.local_gaussian_method(8)
+    error = s.data[0, 0] - np.asarray([[90 - 64, 30 - 64]])
+    assert np.all(error < 5)

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -31,7 +31,7 @@ def create_spot():
 
     for r in [4, 3, 2]:
         c = 1 / r
-        rr, cc = draw.circle(30, 90, radius=r, shape=z1.shape)
+        rr, cc = draw.circle(30, 90, radius=r, shape=z1.shape) #30 is y!
         z1[rr, cc] = c
         z2[rr, cc] = c
         rr2, cc2 = draw.circle(100, 60, radius=r, shape=z2.shape)

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -118,5 +118,3 @@ def test_local_gaussian_method_exciting(dp,diffraction_vectors):
     """
     spr = SubpixelrefinementGenerator(dp, diffraction_vectors)
     s = spr.local_gaussian_method(8)
-    error = s.data[0, 0] - np.asarray([[90 - 64, 30 - 64]])
-    assert np.all(error < 5)

--- a/pyxem/utils/subpixel_refinements_utils.py
+++ b/pyxem/utils/subpixel_refinements_utils.py
@@ -104,6 +104,4 @@ def _conventional_xc(exp_disc, sim_disc, upsample_factor):
     """
 
     shifts, error, _ = register_translation(exp_disc, sim_disc, upsample_factor)
-    x = shifts[1]
-    y = shifts[0]
-    return (x,y)
+    return shifts

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,6 @@ tqdm==4.24.0
 traitlets==4.3.2
 traits==4.6.0
 transforms3d==0.3.1
-urllib3==1.23
+urllib3>=1.24.2
 wcwidth==0.1.7
 wheel==0.31.1


### PR DESCRIPTION
---
name: Adding "Gaussian Like" Subpixel Peakfinder 
about: Adds a 3rd, deterministic subpixel peakfinder to complement those that exist in the repo already.

---

**What does this PR do? Please describe or link to an open issue.**
Solve the 2D subpixel peak finder problem as follows.
Treating x,y independently, we find (within a selected square - from the architecture above) the global maxima. We then select the adjacent pixels. Working in 1D we then have a 3 item list:

[X - delta, X, X - epsilon] 

for delta, epsilon small and positive. From Taylor expanding we would expect a function of the form
a*(y)**2 + b*y + c

to (with y = -1,0,1 in normalised units) be equal to [X-delta,X,X-epsilon] - then we complete the square and find the center.

**Work in progress?**
Should be speedy, and I'll be doing it, but it does need
- [x] docstrings
- [x] tests
- [x] cleanup

NB) Made some github mistakes, the main bundle of functionality will be copy pasted from https://github.com/pyxem/pyxem/pull/368/commits/2db396006ecb6b53c5509a36be7731385cd59f14