### PR TITLE
BUGFIX: Forcing spg to take sensible (with diffraction pattern) vectors

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -61,6 +61,7 @@ class SubpixelrefinementGenerator():
             if vectors.shape == (1,) and vectors.dtype == np.object:
                 vectors = vectors[0]
             return np.floor((vectors.astype(np.float64) / calibration) + center).astype(np.int)
+
         if isinstance(vectors, DiffractionVectors):
             if vectors.axes_manager.navigation_shape != dp.axes_manager.navigation_shape:
                 raise ValueError('Vectors with shape {} must have the same navigation shape '
@@ -72,6 +73,13 @@ class SubpixelrefinementGenerator():
                                              inplace=False)
         else:
             self.vector_pixels = _floor(vectors, self.calibration, self.center)
+
+        if isinstance(self.vector_pixels,DiffractionVectors):
+            if np.any(self.vector_pixels.data > (np.max(dp.data.shape) - 1)) or (np.any(self.vector_pixels.data < 0)):
+                raise ValueError('Some of your vectors do not lie within your diffraction pattern, check your calibration')
+        elif isinstance(self.vector_pixels,np.ndarray):
+            if np.any((self.vector_pixels > np.max(dp.data.shape) - 1)) or (np.any(self.vector_pixels < 0)):
+                raise ValueError('Some of your vectors do not lie within your diffraction pattern, check your calibration')
 
     def conventional_xc(self, square_size, disc_radius, upsample_factor):
         """Refines the peaks using (phase) cross correlation.

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -49,6 +49,22 @@ def create_vectors():
     vectors.axes_manager.set_signal_dimension(0)
     return vectors
 
+@pytest.mark.xfail(raises=ValueError)
+def test_bad_vectors_numpy():
+    """ tests that putting bad vectors in causes an error to be thrown when
+    you initiate the geneartor
+    """
+    v = np.array([[1,-100]])
+    dp = ElectronDiffraction(np.ones((20,20)))
+    sprg = SubpixelrefinementGenerator(dp,v)
+
+@pytest.mark.xfail(raises=ValueError)
+def test_bad_vectors_DiffractionVectors():
+    v = np.array([[1,-100]])
+    dv = DiffractionVectors(v)
+    dp = ElectronDiffraction(np.ones((20,20)))
+    sprg = SubpixelrefinementGenerator(dp,dv)
+
 
 @pytest.mark.filterwarnings('ignore::UserWarning')  # various skimage warnings
 def test_conventional_xc(diffraction_pattern):


### PR DESCRIPTION
---

name: BUGFIX: Forcing spg to take sensible (with diffraction pattern) vectors
about: closing #350.

---

**What does this PR do? Please describe or link to an open issue.**
Previously, one could put any vector into an spg (SubPixelrefinementGenerator) and the code wouldn't warn you. eg) One of length 100 in the y direction (calibrated units) on a 10 by 10 diffraction pattern. This now raises a `ValueError`

**Are there any known issues? Do you need help?**
The testing suite hangs on my local machine at the moment, but if it clears the travis + appveyor I wouldn't be too concerned.