### PR TITLE
Use Euler angles in degrees

### DIFF
--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -48,7 +48,7 @@ def test_crystal_from_vector_matching_sp(sp_vector_match_result):
     # branch single phase
     cmap = crystal_from_vector_matching(sp_vector_match_result)
     assert cmap[0] == 0
-    np.testing.assert_allclose(cmap[1], np.deg2rad([0, 0, 90]))
+    np.testing.assert_allclose(cmap[1], [0, 0, 90])
     np.testing.assert_allclose(cmap[2]['match_rate'], 0.5)
     np.testing.assert_allclose(cmap[2]['ehkls'], np.array([0.1, 0.05, 0.2]))
     np.testing.assert_allclose(cmap[2]['total_error'], 0.1)
@@ -61,7 +61,7 @@ def test_crystal_from_vector_matching_dp(dp_vector_match_result):
     r_or = 100 * (1 - (0.1 / 0.2))
     r_ph = 100 * (1 - (0.1 / 0.3))
     assert cmap[0] == 1
-    np.testing.assert_allclose(cmap[1], np.deg2rad([0, 45, 45]))
+    np.testing.assert_allclose(cmap[1], [0, 45, 45])
     np.testing.assert_allclose(cmap[2]['match_rate'], 0.8)
     np.testing.assert_allclose(cmap[2]['ehkls'], np.array([0.1, 0.3, 0.2]))
     np.testing.assert_allclose(cmap[2]['total_error'], 0.1)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -430,7 +430,7 @@ def crystal_from_vector_matching(z_matches):
         # get best matching phase (there is only one here)
         results_array[0] = z_matches[0, 0]
         # get best matching orientation Euler angles
-        results_array[1] = mat2euler(z_matches[0, 1], 'rzxz')
+        results_array[1] = np.rad2deg(mat2euler(z_matches[0, 1], 'rzxz'))
         # get template matching metrics
         metrics = dict()
         metrics['match_rate'] = z_matches[0, 2]
@@ -445,7 +445,7 @@ def crystal_from_vector_matching(z_matches):
         # get best matching phase
         results_array[0] = z_matches[index_best_match, 0]
         # get best matching orientation Euler angles.
-        results_array[1] = mat2euler(z_matches[index_best_match, 1], 'rzxz')
+        results_array[1] = np.rad2deg(mat2euler(z_matches[index_best_match, 1], 'rzxz'))
 
         # get second smallest total error for orientation_reliability
         z = z_matches[z_matches[:, 0] == results_array[0]]


### PR DESCRIPTION
Vector indexation results Euler angle convention
---

Change the conversion from vector indexation results to a crystallographic map to correctly return Euler angles in degrees instead of radians.