### PR TITLE
Making the (deprecated) website not build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,3 @@ script:
 after_success:
   - coveralls
 
-deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  local_dir: docs/build
-  on:
-    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   global:
     - DEPS="hyperspy-base transforms3d diffpy.structure"
     - TEST_DEPS="pytest pytest-cov coveralls"
-    - DOC_DEPS="sphinx sphinx_bootstrap_theme"
 
 matrix:
   include:
@@ -35,13 +34,11 @@ before_install:
   - df -h
 
 install:
-  - conda install -y $DEPS $TEST_DEPS $DOC_DEPS;
+  - conda install -y $DEPS $TEST_DEPS;
   - pip install .
 
 script:
   - pytest --pyargs pyxem --cov=pyxem
-  - sphinx-apidoc -fo docs/source pyxem
-  - sphinx-build -b html docs/source docs/build
 
 after_success:
   - coveralls

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,7 +148,7 @@ html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {'bootstrap_version': "3", 
-                      'bootswatch_theme': "sandstone",
+                      'bootswatch_theme': "minty",
                       'source_link_position': False,
                       'nosidebar': True}
 


### PR DESCRIPTION
---
name: Making the (deprecated) website not build
about: Stage 2 of pulling the website offline, this PR removes the `sphinx` installs from the travis, and stops travis from deploying the site, ideally freezing it at the point it built b33a992028205ccaeb62b13ad5a207abaa234dab

---

MOD NOTE: to be merged in after the website has been built and displayed in minty!