### PR TITLE
Fix vector library generator

### DIFF
--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -84,7 +84,7 @@ def test_match_vectors(vector_match_peaks, vector_library):
     assert len(matches) == 1
     np.testing.assert_allclose(matches[0][2], 1.0)  # match rate
     np.testing.assert_allclose(matches[0][1], np.identity(3), atol=0.1)
-    np.testing.assert_allclose(matches[0][4], 0.05, atol=0.01)  # error mean
+    np.testing.assert_allclose(matches[0][4], 0.03, atol=0.01)  # error mean
 
     np.testing.assert_allclose(rhkls[0][0], [1, 0, 0])
     np.testing.assert_allclose(rhkls[0][1], [0, 2, 0])

--- a/pyxem/tests/test_utils/test_vector_utils.py
+++ b/pyxem/tests/test_utils/test_vector_utils.py
@@ -21,9 +21,12 @@ import pytest
 
 from transforms3d.euler import euler2mat
 
-from pyxem.utils.vector_utils import calculate_norms, calculate_norms_ragged, \
-    detector_to_fourier, get_rotation_matrix_between_vectors, \
-    get_angle_cartesian
+from pyxem.utils.vector_utils import calculate_norms
+from pyxem.utils.vector_utils import calculate_norms_ragged
+from pyxem.utils.vector_utils import detector_to_fourier
+from pyxem.utils.vector_utils import get_rotation_matrix_between_vectors
+from pyxem.utils.vector_utils import get_angle_cartesian
+from pyxem.utils.vector_utils import get_angle_cartesian_vec
 
 
 def test_calculate_norms():
@@ -76,4 +79,17 @@ def test_get_rotation_matrix_between_vectors(k1, k2, ref_k1, ref_k2,
 ])
 def test_get_angle_cartesian(vec_a, vec_b, expected_angle):
     angle = get_angle_cartesian(vec_a, vec_b)
-    assert np.isclose(angle, expected_angle)
+    np.testing.assert_allclose(angle, expected_angle)
+
+
+@pytest.mark.parametrize('a, b, expected_angles', [
+    (np.array([[0, 0, 1], [0, 0, 0]]), np.array([[0, 1, 0], [0, 0, 1]]), [np.deg2rad(90), 0])
+])
+def test_get_angle_cartesian_vec(a, b, expected_angles):
+    angles = get_angle_cartesian_vec(a, b)
+    np.testing.assert_allclose(angles, expected_angles)
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_get_angle_cartesian_vec_input_validation():
+    get_angle_cartesian_vec(np.empty((2, 3)), np.empty((5, 3)))

--- a/pyxem/tests/test_utils/test_vector_utils.py
+++ b/pyxem/tests/test_utils/test_vector_utils.py
@@ -61,16 +61,20 @@ def test_detector_to_fourier(wavelength,
     np.testing.assert_allclose(k, k_expected)
 
 
-@pytest.mark.parametrize('k1, k2, ref_k1, ref_k2, expected_rotation', [
-    ([0, 0, 1], [0, 0, 2], [1, 0, 0], [0, 1, 0], np.identity(3)),  # Degenerate
-    ([0, 0, 1], [0, 1, 0], [0, 0, 1], [1, 0, 0], euler2mat(np.deg2rad(90), 0, 0, 'rzxz')),
-    ([0.5, -0.5, 1 / np.sqrt(2)], [1 / np.sqrt(2), 1 / np.sqrt(2), 0], [0, 0, 1], [1, 0, 0],
-        euler2mat(np.deg2rad(45), np.deg2rad(45), 0, 'rzxz'))
+@pytest.mark.parametrize('from_v1, from_v2, to_v1, to_v2, expected_rotation', [
+    # v2 from x to y
+    ([0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], euler2mat(*np.deg2rad([90, 0, 0]), 'rzxz')),
+    # Degenerate to-vectors gives half-way rotation (about y-axis)
+    ([0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], euler2mat(*np.deg2rad([90, 45, -90]), 'rzxz')),
+    # Edges to body diagonals
+    ([0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.5, -0.5, 1 / np.sqrt(2)], [1 / np.sqrt(2), 1 / np.sqrt(2), 0],
+        euler2mat(*np.deg2rad([45, 45, 0]), 'rzxz'))
 ])
-def test_get_rotation_matrix_between_vectors(k1, k2, ref_k1, ref_k2,
-                                             expected_rotation):
-    rotation_matrix = get_rotation_matrix_between_vectors(k1, k2, ref_k1, ref_k2)
-    assert np.allclose(rotation_matrix, expected_rotation)
+def test_get_rotation_matrix_between_vectors(from_v1, from_v2, to_v1, to_v2, expected_rotation):
+    rotation_matrix = get_rotation_matrix_between_vectors(
+        np.array(from_v1), np.array(from_v2),
+        np.array([to_v1]), np.array([to_v2]))
+    np.testing.assert_allclose(rotation_matrix, np.array([expected_rotation]), atol=1e-15)
 
 
 @pytest.mark.parametrize('vec_a, vec_b, expected_angle', [

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -24,6 +24,7 @@ from operator import itemgetter
 
 import numpy as np
 
+from pyxem.utils.expt_utils import _cart2polar
 from pyxem.utils.vector_utils import get_rotation_matrix_between_vectors
 from pyxem.utils.vector_utils import get_angle_cartesian
 
@@ -150,9 +151,8 @@ def index_magnitudes(z, simulation, tolerance):
 def _choose_peak_ids(peaks, n_peaks_to_index):
     """Choose `n_peaks_to_index` indices from `peaks`.
 
-    This implementation returns the indices of the
-    :math:`ceil(n_peaks_to_index / 2)` furthest from the center and the rest
-    closest to the center.
+    This implementation sorts by angle and then picks every
+    len(peaks)/n_peaks_to_index element to get an even distribution of angles.
 
     Parameters
     ----------
@@ -166,14 +166,8 @@ def _choose_peak_ids(peaks, n_peaks_to_index):
     peak_ids : numpy.array
         Array of indices of the chosen peaks.
     """
-    n_peaks_to_index = min(peaks.shape[0], n_peaks_to_index)
-    n_long_peaks = int(math.ceil(n_peaks_to_index / 2))
-    n_short_peaks = n_peaks_to_index - n_long_peaks
-    peak_lengths = np.linalg.norm(peaks, axis=1)
-    peak_ids = np.empty(n_peaks_to_index, dtype=np.int)
-    peak_ids[:n_long_peaks] = peak_lengths.argpartition(-n_long_peaks)[-n_long_peaks:]
-    peak_ids[n_long_peaks:] = peak_lengths.argpartition(n_short_peaks)[:n_short_peaks]
-    return peak_ids
+    r, angles = _cart2polar(peaks[:, 0], peaks[:, 1])
+    return angles.argsort()[np.linspace(0, angles.shape[0] - 1, n_peaks_to_index, dtype=np.int)]
 
 
 def _sort_solutions(solutions, n_solutions):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -306,9 +306,10 @@ def match_vectors(peaks,
                     ehkls,  # TODO: Needed?
                     error_mean,
                     vector_pair_index
-                ] for R, match_rate, error_mean in zip(
+                ] for R, match_rate, ehkls, error_mean in zip(
                     rotations[possible_solution_mask],
                     match_rates[possible_solution_mask],
+                    ehklss[possible_solution_mask],
                     error_means[possible_solution_mask])]
                 res_rhkls += rhklss[possible_solution_mask].tolist()
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -373,7 +373,7 @@ def crystal_from_template_matching(z_matches):
         # get template matching metrics
         metrics = dict()
         metrics['correlation'] = z_matches[0, 2]
-        metrics['orientation_reliability'] = 100 * (1 - z_matches[1, 2] / z_matches[0, 2])
+        metrics['orientation_reliability'] = 100 * (1 - z_matches[1, 2] / z_matches[0, 2]) if z_matches[0, 2] > 0 else 100
         results_array[2] = metrics
     else:
         # get best matching result
@@ -423,13 +423,16 @@ def crystal_from_vector_matching(z_matches):
         # get best matching phase (there is only one here)
         results_array[0] = z_matches[0, 0]
         # get best matching orientation Euler angles
-        results_array[1] = np.rad2deg(mat2euler(z_matches[0, 1], 'rzxz'))
-        # get template matching metrics
+        if isinstance(z_matches[0, 1], int) and z_matches[0, 1] == 0:
+            results_array[1] = np.array([0.0, 0.0, 0.0])  # TODO: Temporary, bad data fix
+        else:
+            results_array[1] = np.rad2deg(mat2euler(z_matches[0, 1], 'rzxz'))
+        # get vector matching metrics
         metrics = dict()
         metrics['match_rate'] = z_matches[0, 2]
         metrics['ehkls'] = z_matches[0, 3]
         metrics['total_error'] = z_matches[0, 4]
-        metrics['orientation_reliability'] = 100 * (1 - z_matches[0, 4] / z_matches[1, 4])
+        metrics['orientation_reliability'] = 100 * (1 - z_matches[0, 4] / (z_matches[1, 4] or 1.0))
         results_array[2] = metrics
 
     else:

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -303,7 +303,7 @@ def match_vectors(peaks,
                 solutions += [[
                     R,
                     match_rate,
-                    [],  # ehkls,  # TODO: Needed?
+                    ehkls,  # TODO: Needed?
                     error_mean,
                     vector_pair_index
                 ] for R, match_rate, error_mean in zip(

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -423,10 +423,7 @@ def crystal_from_vector_matching(z_matches):
         # get best matching phase (there is only one here)
         results_array[0] = z_matches[0, 0]
         # get best matching orientation Euler angles
-        if isinstance(z_matches[0, 1], int) and z_matches[0, 1] == 0:
-            results_array[1] = np.array([0.0, 0.0, 0.0])  # TODO: Temporary, bad data fix
-        else:
-            results_array[1] = np.rad2deg(mat2euler(z_matches[0, 1], 'rzxz'))
+        results_array[1] = np.rad2deg(mat2euler(z_matches[0, 1], 'rzxz'))
         # get vector matching metrics
         metrics = dict()
         metrics['match_rate'] = z_matches[0, 2]

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -293,7 +293,7 @@ def match_vectors(peaks,
                 rhklss = np.rint(hklss)
                 ehklss = np.abs(hklss - rhklss)
                 valid_peak_mask = np.max(ehklss, axis=-1) < index_error_tol
-                valid_peak_mask_counts = np.count_nonzero(valid_peak_mask, axis=-1)
+                valid_peak_counts = np.count_nonzero(valid_peak_mask, axis=-1)
                 error_means = ehklss.mean(axis=(1, 2))
 
                 num_peaks = len(peaks)

--- a/pyxem/utils/sim_utils.py
+++ b/pyxem/utils/sim_utils.py
@@ -429,7 +429,7 @@ def peaks_from_best_vector_match(single_match_result, library):
     best_fit = single_match_result[np.argmax(single_match_result[:, 2])]
     best_index = best_fit[0]
 
-    rotation_matrix = best_fit[1].T
+    rotation_matrix = best_fit[1]
     # Don't change the original
     structure = library.structures[best_index]
     sim = simulate_rotated_structure(

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -146,8 +146,13 @@ def get_rotation_matrix_between_vectors(from_v1, from_v2, to_v1, to_v2):
     normalize_or_zero(plane_common_axes)
 
     # Create rotation from-plane -> to-plane
+    common_valid = ~np.isclose(np.sum(np.abs(plane_common_axes), axis=-1), 0.0)
     angles = get_angle_cartesian_vec(np.broadcast_to(plane_normal_from, plane_normal_to.shape), plane_normal_to)
-    R1 = np.array([axangle2mat(axis, angle, is_normalized=True) for axis, angle in zip(plane_common_axes, angles)])
+    R1 = np.empty((angles.shape[0], 3, 3))
+    if np.any(common_valid):
+        R1[common_valid] = np.array([axangle2mat(axis, angle, is_normalized=True)
+            for axis, angle in zip(plane_common_axes[common_valid], angles[common_valid])])
+    R1[~common_valid] = np.identity(3)
 
     # Rotate from-plane into to-plane
     rot_from_v1 = np.matmul(R1, from_v1)

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -196,7 +196,7 @@ def get_angle_cartesian(a, b):
     angle : float
         Angle between `a` and `b` in radians.
     """
-    determinant = np.linalg.norm(a) * np.linalg.norm(b)
-    if determinant == 0:
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    if denom == 0:
         return 0.0
-    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / determinant)))
+    return math.acos(max(-1.0, min(1.0, np.dot(a, b) / denom)))

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -183,6 +183,32 @@ def get_npeaks(found_peaks):
     return len(found_peaks[0])
 
 
+def get_angle_cartesian_vec(a, b):
+    """Compute the angles between two lists of vectors in a cartesian
+    coordinate system.
+
+    Parameters
+    ----------
+    a, b : np.array()
+        The two lists of directions to compute the angle between in Nx3 float
+        arrays.
+
+    Returns
+    -------
+    angles : np.array()
+        List of angles between `a` and `b` in radians.
+    """
+    if a.shape != b.shape:
+        raise ValueError('The shape of a {} and b {} must be the same.'.format(a.shape, b.shape))
+
+    denom = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1)
+    denom_nonzero = denom != 0.0
+    angles = np.zeros(a.shape[0])
+    angles[denom_nonzero] = np.arccos(np.clip(
+        np.sum(a[denom_nonzero] * b[denom_nonzero], axis=-1) / denom[denom_nonzero], -1.0, 1.0)).ravel()
+    return angles
+
+
 def get_angle_cartesian(a, b):
     """Compute the angle between two vectors in a cartesian coordinate system.
 


### PR DESCRIPTION
Fix vector library generator
---

Fix a bug in the vector library generator where the lengths were not sorted properly, causing lengths and indices to get out of sync in the library.

**What does this PR do? Please describe or link to an open issue.**
 - Closes #400
 - Both the vector library generator and `match_vector` has been rewritten to change an inner for loop with direct numpy operations for speed
 - Return the same rotation direction as the template matching implementation does (`R` such that `v_lab = R.dot(v_sample)`)
 - Better choice of peaks to do the initial pair matching with (even angular distribution instead of long and short)

The matching is much more reliable now, since we are actually matching against a reasonable library now. The new peak choice also helps.