### PR TITLE
Improving .apply_affine_transform()

### DIFF
--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -255,6 +255,7 @@ class ElectronDiffraction(Signal2D):
     def apply_affine_transformation(self,
                                     D,
                                     order=3,
+                                    casting=True,
                                     inplace=True,
                                     *args, **kwargs):
         """Correct geometric distortion by applying an affine transformation.
@@ -263,6 +264,11 @@ class ElectronDiffraction(Signal2D):
         ----------
         D : array
             3x3 np.array specifying the affine transform to be applied.
+        order : int
+            Interpolation order. See documentation of skimage.warp for details
+        casting : bool
+            If True (default) signal gets returned as cast by underlying scikit-image
+            code. If False dtype matches input dtype.
         inplace : bool
             If True (default), this signal is overwritten. Otherwise, returns a
             new signal.
@@ -295,6 +301,7 @@ class ElectronDiffraction(Signal2D):
         return self.map(affine_transformation,
                         transformation=transformation,
                         order=order,
+                        casting=casting,
                         inplace=inplace,
                         *args, **kwargs)
 

--- a/pyxem/signals/electron_diffraction.py
+++ b/pyxem/signals/electron_diffraction.py
@@ -26,7 +26,7 @@ from pyxem.signals.diffraction_profile import ElectronDiffractionProfile
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 
 from pyxem.utils.expt_utils import _index_coords, _cart2polar, _polar2cart, \
-    radial_average, gain_normalise, remove_dead, affine_transformation, \
+    radial_average, gain_normalise, remove_dead, affine_transformation, _affine_transformation, \
     regional_filter, subtract_background_dog, subtract_background_median, \
     subtract_reference, circular_mask, find_beam_offset_cross_correlation, \
     peaks_as_gvectors
@@ -283,27 +283,36 @@ class ElectronDiffraction(Signal2D):
             diffraction patterns.
 
         """
-        # Account for the transformation center not being (0,0)
-        shape = self.axes_manager.signal_shape
-        shift_x = (shape[1] - 1) / 2
-        shift_y = (shape[0] - 1) / 2
+        if type(D) == np.ndarray: #'normal' fast case
+            # Account for the transformation center not being (0,0)
+            shape = self.axes_manager.signal_shape
+            shift_x = (shape[1] - 1) / 2
+            shift_y = (shape[0] - 1) / 2
 
-        tf_shift = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
-        tf_shift_inv = tf.SimilarityTransform(translation=[shift_x, shift_y])
+            tf_shift = tf.SimilarityTransform(translation=[-shift_x, -shift_y])
+            tf_shift_inv = tf.SimilarityTransform(translation=[shift_x, shift_y])
 
-        # This defines the transform you want to perform
-        distortion = tf.AffineTransform(matrix=D)
+            # This defines the transform you want to perform
+            distortion = tf.AffineTransform(matrix=D)
 
-        # skimage transforms can be added like this, does matrix multiplication,
-        # hence the need for the brackets. (Note tf.warp takes the inverse)
-        transformation = (tf_shift + (distortion + tf_shift_inv)).inverse
+            # skimage transforms can be added like this, does matrix multiplication,
+            # hence the need for the brackets. (Note tf.warp takes the inverse)
+            transformation = (tf_shift + (distortion + tf_shift_inv)).inverse
 
-        return self.map(affine_transformation,
+            return self.map(_affine_transformation,
                         transformation=transformation,
                         order=order,
                         casting=casting,
                         inplace=inplace,
                         *args, **kwargs)
+        else: #hyperspy signal passed for D
+            return self.map(affine_transformation,
+                        transformation=D,
+                        order=order,
+                        casting=casting,
+                        inplace=inplace,
+                        *args, **kwargs)
+
 
     def apply_gain_normalisation(self,
                                  dark_reference,

--- a/pyxem/tests/test_signals/test_electron_diffraction.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction.py
@@ -58,6 +58,15 @@ class TestSimpleMaps:
                         [0., 0., 1.]]))
         assert isinstance(diffraction_pattern, ElectronDiffraction)
 
+    def test_apply_affine_transforms_paths(self,diffraction_pattern):
+        D=np.array([[1., 0.9, 0.],
+                    [1.1, 1., 0.],
+                    [0., 0., 1.]])
+        s = Signal2D(np.asarray([[D,D],[D,D]]))
+        static  = diffraction_pattern.apply_affine_transformation(D,inplace=False)
+        dynamic = diffraction_pattern.apply_affine_transformation(s,inplace=False)
+        assert np.allclose(static.data,dynamic.data,atol=1e-3)
+
     def test_apply_affine_transformation_with_casting(self, diffraction_pattern):
         transformed_dp = diffraction_pattern.apply_affine_transformation(
             D=np.array([[1., 0., 0.],

--- a/pyxem/tests/test_signals/test_electron_diffraction.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction.py
@@ -58,6 +58,13 @@ class TestSimpleMaps:
                         [0., 0., 1.]]))
         assert isinstance(diffraction_pattern, ElectronDiffraction)
 
+    def test_apply_affine_transformation_with_casting(self, diffraction_pattern):
+        transformed_dp = diffraction_pattern.apply_affine_transformation(
+            D=np.array([[1., 0., 0.],
+                        [0., 1., 0.],
+                        [0., 0., 1.2]]), order=2, casting=False, inplace=False)
+        assert isinstance(transformed_dp, ElectronDiffraction)
+
     methods = ['average', 'nan']
 
     @pytest.mark.parametrize('method', methods)

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -199,17 +199,20 @@ def remove_dead(z, deadpixels, deadvalue="average", d=1):
     return z_bar
 
 
-def affine_transformation(z, transformation, order, *args, **kwargs):
+def affine_transformation(z, transformation, order, casting, *args, **kwargs):
     """Apply an affine transformation to a 2-dimensional array.
 
     Parameters
     ----------
     z : np.array
         Array to be transformed
-    matrix : np.array
+    transformation : np.array
         3x3 numpy array specifying the affine transformation to be applied.
     order : int
-        Interpolation order.
+        Interpolation order. See documentation of skimage.warp for details
+    casting : bool
+        If False input and output data will have the same dtype (and
+        be forced to lie within the same range). If True data may be upcast.
     *args :
         To be passed to skimage.warp
     **kwargs :
@@ -220,8 +223,14 @@ def affine_transformation(z, transformation, order, *args, **kwargs):
     trans : array
         Affine transformed diffraction pattern.
     """
-    trans = tf.warp(z, transformation,
-                    order=order, *args, **kwargs)
+    if casting == True:
+        trans = tf.warp(z, transformation,
+                        order=order, *args, **kwargs)
+    elif casting == False:
+        trans = tf.warp(z, transformation,
+                        order=order, preserve_range=True, *args, **kwargs)
+        trans = trans.astype(z.dtype)
+
     return trans
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,13 @@ setup(
     packages=find_packages(),
 
     install_requires=[
-        'hyperspy >= 1.3',
+    	'scikit-image < 0.15', # See pyxem/pull/378
+        'matplotlib < 3.1.0' , # See pyxem/pull/403
+        'scikit-learn >= 0.19', # bug unknown
+        'hyperspy >= 1.3',      # 1.2 fails, (NTU Workshop - May 2019) 
         'transforms3d',
-	    'scikit-learn >= 0.19',
-        'scikit-image < 0.15'
-      ],
-
+        'diffpy.structure >= 3.0.0' # First Python 3 support
+      ], 
     package_data={
         "": ["LICENSE", "readme.rst", "requirements.txt"],
         "pyxem": ["*.py"],


### PR DESCRIPTION
---
name: Improving .apply_affine_transform()
about: Adds the option to prevent data casting, and opens two code paths for fixed (fast) vs variable (slower) matrix. Addresses #406 

---

**Release Notes**
> 0.8.1
> improvement + bugfix 

Summary: 
- apply_affine_transform now has a `"casting"`
- apply_affine_transform now accepts Signal2D as argument

**What does this PR do? Please describe and/or link to an open issue.**
1) Adds new option to cast data (usually back down from `float64`) internally, saving memory (quite a lot of memory for `uint8` data)
2) Allow Signal2D objects to be passed as for normal `map` without loss of speed granted by #361 (see attached profile for details, it saves about 30% of the time [1])  - solves https://github.com/pyxem/pyxem-demos/issues/21

**Describe alternatives you've considered**
Three options for (2) above. Could have scrapped the speed up (it's quite inconsistent with everything else) but 30% is 30%. Or could have scrapped the flexibility (but it's useful for a couple of things Phillip is currently doing, and is consistent with the general architecture). In the end we've got both at the cost of a slightly bulkier codebase

**Are there any known issues? Do you need help?**
is `keep_dtype` a clearer name for this variable?

**Work in progress?**
- [ ] Docstrings have a few errors in
- [ ] Settle on variable naming convention
- [ ] Pepstorm 

[1] [apply_affine_profile.txt](https://github.com/pyxem/pyxem/files/3207426/apply_affine_profile.txt)
