### PR TITLE
register as hyperspy extension

### DIFF
--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -17,18 +17,30 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 signals:
-  ElectronDiffraction:
-    signal_type: "ElectronDiffraction"
+  Diffraction1D:
+    signal_type: "Diffraction1D"
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    import: pyxem.signals.diffraction1d
+  Diffraction2D:
+    signal_type: "Diffraction2D"
     signal_dimension: 2
     dtype: real
     lazy: False
-    import: pyxem.signals.electron_diffraction
-  ElectronDiffractionProfile:
-    signal_type: "ElectronDiffractionProfile"
+    import: pyxem.signals.diffraction2d
+  ElectronDiffraction1D:
+    signal_type: "ElectronDiffraction1D"
     signal_dimension: 1
     dtype: real
-    lazy: True
-    import: pyxem.signals.diffraction_profile
+    lazy: False
+    import: pyxem.signals.electron_diffraction1d
+  ElectronDiffraction2D:
+    signal_type: "ElectronDiffraction2D"
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    import: pyxem.signals.electron_diffraction2d
   DiffractionVectors:
     signal_type: "DiffractionVectors"
     signal_dimension: None

--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -70,4 +70,4 @@ components:
     DiffractionComponent:
       import: pyxem.components.diffraction_component
     ScalableReferencePattern:
-      import pyxem.components.scalable_reference_component
+      import: pyxem.components.scalable_reference_component

--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+signals:
+  ElectronDiffraction:
+    signal_type: "ElectronDiffraction"
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    import: pyxem.signals.electron_diffraction
+  ElectronDiffractionProfile:
+    signal_type: "ElectronDiffractionProfile"
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    import: pyxem.signals.diffraction_profile
+  DiffractionVectors:
+    signal_type: "DiffractionVectors"
+    signal_dimension: None
+    dtype: real
+    lazy: False
+    import: pyxem.signals.diffraction_vectors
+  TemplateMatchingResults:
+    signal_type: "TemplateMatchingResults"
+    signal_dimension: None
+    dtype: real
+    lazy: False
+    import: pyxem.signals.indexation_results
+  VectorMatchingResults:
+    signal_type: "VectorMatchingResults"
+    signal_dimension: None
+    dtype: real
+    lazy: False
+    import: pyxem.signals.indexation_results
+  CrystallographicMap:
+    signal_type: "CrystallographicMap"
+    signal_dimension: None
+    dtype: real
+    lazy: False
+    import: pyxem.signals.crystallographic_map
+  DisplacementGradientMap:
+    signal_type: "DisplacementGradientMap"
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    import: pyxem.signals.tensor_field
+  VDFImage:
+    signal_type: "VDFImage"
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    import: pyxem.signals.vdf_image
+
+components:
+    DiffractionComponent:
+      import: pyxem.components.diffraction_component
+    ScalableReferencePattern:
+      import pyxem.components.ScalableReferencePattern

--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -70,4 +70,4 @@ components:
     DiffractionComponent:
       import: pyxem.components.diffraction_component
     ScalableReferencePattern:
-      import pyxem.components.ScalableReferencePattern
+      import pyxem.components.scalable_reference_component

--- a/setup.py
+++ b/setup.py
@@ -25,38 +25,38 @@ exec(open('pyxem/version.py').read())  # grab version info
 setup(
     name='pyxem',
     version=__version__,
-    description='Crystallographic Electron Microscopy in Python.',
+    description='Crystallographic Diffraction Microscopy in Python.',
     author=__author__,
     author_email=__email__,
     license="GPLv3",
     url="https://github.com/pyxem/pyxem",
     long_description=open('README.rst').read(),
     classifiers=[
-	   "Programming Language :: Python :: 3",
-       "Programming Language :: Python :: 3.6",
-	   "Programming Language :: Python :: 3.7",
-	   "Development Status :: 4 - Beta",
-	   "Intended Audience :: Science/Research",
-       "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-       "Natural Language :: English",
-       "Operating System :: OS Independent",
-       "Topic :: Scientific/Engineering",
-       "Topic :: Scientific/Engineering :: Physics",
+	"Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+	"Programming Language :: Python :: 3.7",
+	"Development Status :: 4 - Beta",
+	"Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Physics",
     ],
 
     packages=find_packages(),
     # adjust the tabbing
     install_requires=[
-    	'scikit-image < 0.15', # See pyxem/pull/378
-        'matplotlib < 3.1.0' , # See pyxem/pull/403
-        'scikit-learn >= 0.19', # bug unknown
-    	'hyperspy > 1.4',      # needs to have extension register
-        'transforms3d',
-        'diffpy.structure >= 3.0.0' # First Python 3 support
+      'scikit-image >= 0.15.0',   # exclude_border argument in peak_finder laplacian (PR #436)
+      'matplotlib >= 3.1.1' ,     # 3.1.0 failed
+      'scikit-learn >= 0.19',     # reason unknown
+      'hyperspy >= 1.5.2',        # earlier versions incompatible with numpy >= 1.17.0
+      'diffsims',
+      'lmfit >= 0.9.12'
       ],
     package_data={
-        "": ["LICENSE", "readme.rst", "hyperspy_extension.yaml"],
+        "": ["LICENSE", "readme.rst","hyperspy_extension.yaml"],
         "pyxem": ["*.py"],
-    },
     entry_points={'hyperspy.extensions': 'pyxem = pyxem'},
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -32,16 +32,16 @@ setup(
     url="https://github.com/pyxem/pyxem",
     long_description=open('README.rst').read(),
     classifiers=[
-	"Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-	"Programming Language :: Python :: 3.7",
-	"Development Status :: 4 - Beta",
-	"Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Natural Language :: English",
-        "Operating System :: OS Independent",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Physics",
+	   "Programming Language :: Python :: 3",
+       "Programming Language :: Python :: 3.6",
+	   "Programming Language :: Python :: 3.7",
+	   "Development Status :: 4 - Beta",
+	   "Intended Audience :: Science/Research",
+       "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+       "Natural Language :: English",
+       "Operating System :: OS Independent",
+       "Topic :: Scientific/Engineering",
+       "Topic :: Scientific/Engineering :: Physics",
     ],
 
     packages=find_packages(),
@@ -50,12 +50,13 @@ setup(
     	'scikit-image < 0.15', # See pyxem/pull/378
         'matplotlib < 3.1.0' , # See pyxem/pull/403
         'scikit-learn >= 0.19', # bug unknown
-    	'hyperspy >= 1.3',      # 1.2 fails, (NTU Workshop - May 2019) 
-        'transforms3d',        
+    	'hyperspy > 1.4',      # needs to have extension register
+        'transforms3d',
         'diffpy.structure >= 3.0.0' # First Python 3 support
-      ],                       
+      ],
     package_data={
-        "": ["LICENSE", "readme.rst",],
+        "": ["LICENSE", "readme.rst", "hyperspy_extension.yaml"],
         "pyxem": ["*.py"],
     },
+    entry_points={'hyperspy.extensions': 'pyxem = pyxem'},
 )


### PR DESCRIPTION
The next_minor_release (after 23/05/2019) of hyperspy will include a mechanism to register extension packages such as pyxem. See https://github.com/hyperspy/hyperspy/pull/2180

This PR makes changes necessary for pyxem to be a fully registered hyperspy_extension.