### PR TITLE
Updating install requires for 0.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,12 @@ setup(
     packages=find_packages(),
 
     install_requires=[
-        'hyperspy >= 1.3',
-        'transforms3d',
-	    'scikit-learn >= 0.19',
-        'scikit-image < 0.15'
+        'scikit-image < 0.15', # See pyxem/pull/378
+        'matplotlib < 3.1.0' , # See pyxem/pull/403
+        'scikit-learn >= 0.19', # bug unknown
+    	'hyperspy >= 1.3',      # 1.2 fails, (NTU Workshop - May 2019) 
+        'transforms3d',        
+	'diffpy.structure >= 3.0.0' # First Python 3 support
       ],
 
     package_data={


### PR DESCRIPTION
---
name: Updating install requires for 0.8.1
about: This is the same set of changes to `setup.py` as we have in master, in preparation for fixing affine transform.

---

**Release Notes**
> 0.8.1
> developer change
Summary: Slightly more constraints on dependencies 

**What does this PR do? Please describe and/or link to an open issue.**
Our CI will now build on this branch, more details at #403  ~ note that this now means we have to manually merge other PR's to both `0.8.x` and `master` to save us the conflict.

