### PR TITLE
Subpixelrefinement local gaussian shift

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -254,7 +254,7 @@ class SubpixelrefinementGenerator():
             UY, DY = z_ref[0, 1], z_ref[2, 1]
             x_ans = 0.5 * (LX - RX) / (LX + RX - 2 * M)
             y_ans = 0.5 * (UY - DY) / (UY + DY - 2 * M)
-            return x_ans, y_ans
+            return (si[1] - z.shape[1] // 2 + x_ans, si[0] - z.shape[0] // 2 + y_ans)
 
         def _lg_map(dp, vectors, square_size, center, calibration):
             shifts = np.zeros_like(vectors, dtype=np.float64)

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -245,16 +245,16 @@ class SubpixelrefinementGenerator():
             (x,y) : tuple
                 Containing subpixel resolved values for the center
             """
-            si = np.unravel_index(np.argmax(z),z.shape)
-            z_ref = z[si[0]-1:si[0]+2,si[1]-1:si[1]+2]
-            if z_ref.shape != (3,3):
+            si = np.unravel_index(np.argmax(z), z.shape)
+            z_ref = z[si[0] - 1:si[0] + 2, si[1] - 1:si[1] + 2]
+            if z_ref.shape != (3, 3):
                 raise ValueError("The local maxima needs to have 4 adjacent pixels")
-            M = z_ref[1,1]
-            LX,RX = z_ref[1,0],z_ref[1,2]
-            UY,DY = z_ref[0,1],z_ref[2,1]
-            x_ans = 0.5 * (LX-RX) / (LX + RX - 2*M)
-            y_ans = 0.5 * (UY-DY) / (UY + DY - 2*M)
-            return (si[1]+x_ans,si[0]+y_ans)
+            M = z_ref[1, 1]
+            LX, RX = z_ref[1, 0], z_ref[1, 2]
+            UY, DY = z_ref[0, 1], z_ref[2, 1]
+            x_ans = 0.5 * (LX - RX) / (LX + RX - 2 * M)
+            y_ans = 0.5 * (UY - DY) / (UY + DY - 2 * M)
+            return x_ans, y_ans
 
         def _lg_map(dp, vectors, square_size, center, calibration):
             shifts = np.zeros_like(vectors, dtype=np.float64)

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -122,7 +122,10 @@ def test_assertioned_com(dp, diffraction_vectors):
 
 
 @pytest.mark.parametrize('dp, diffraction_vectors, refined_vectors', [
-    (create_spot_gaussian(), np.array([[55 - 64, 25 - 64]]), np.array([[55.1 - 64, 25.3 - 64]]))
+    # Refinement within 1 px
+    (create_spot_gaussian(), np.array([[55 - 64, 25 - 64]]), np.array([[55.1 - 64, 25.3 - 64]])),
+    # Refinement to recover from 2 px error in peak finding
+    (create_spot_gaussian(), np.array([[53 - 64, 23 - 64]]), np.array([[55.1 - 64, 25.3 - 64]]))
 ])
 def test_local_gaussian_method(dp, diffraction_vectors, refined_vectors):
     spr = SubpixelrefinementGenerator(dp, diffraction_vectors)

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -38,7 +38,16 @@ def create_spot():
         z2[rr2, cc2] = c
 
     dp = ElectronDiffraction(np.asarray([[z1, z1], [z2, z2]]))  # this needs to be in 2x2
-    print(dp.axes_manager)
+    return dp
+
+
+def create_spot_gaussian():
+    z1 = np.zeros((128, 128))
+
+    x = np.arange(0.0, 10, 1.0)
+    y = x[:, np.newaxis]
+    z1[20:30, 50:60] = np.exp(-((x - 5.1)**2 + (y - 5.3)**2) / 4)
+    dp = ElectronDiffraction(np.asarray([[z1, z1], [z1, z1]]))  # this needs to be in 2x2
     return dp
 
 
@@ -112,25 +121,20 @@ def test_assertioned_com(dp, diffraction_vectors):
     assert rms_error < 1e-5  # perfect detection for this trivial case
 
 
-@pytest.mark.parametrize('dp, diffraction_vectors', [
-    (create_spot(), np.array([[90 - 64, 30 - 64]])),
+@pytest.mark.parametrize('dp, diffraction_vectors, refined_vectors', [
+    (create_spot_gaussian(), np.array([[55 - 64, 25 - 64]]), np.array([[55.1 - 64, 25.3 - 64]]))
 ])
-def test_local_gaussian_method_dull(dp, diffraction_vectors):
-    """
-    This aims to test that our x/y convention is correct. The peak shape for
-    these tests is unsuitable for this method.
-    """
+def test_local_gaussian_method(dp, diffraction_vectors, refined_vectors):
     spr = SubpixelrefinementGenerator(dp, diffraction_vectors)
-    s = spr.local_gaussian_method(8)
-    error = s.data[0, 0] - np.asarray([[90 - 64, 30 - 64]])
-    assert np.all(error < 5)
+    s = spr.local_gaussian_method(10)
+    np.testing.assert_allclose(s.data[0, 0], refined_vectors, atol=0.1)
+
 
 @pytest.mark.parametrize('dp, diffraction_vectors', [
     (create_spot(), create_vectors())
 ])
-
 @pytest.mark.xfail(raises=ValueError)
-def test_local_gaussian_method_exciting(dp,diffraction_vectors):
+def test_local_gaussian_method_exciting(dp, diffraction_vectors):
     """
     This aims to test that our x/y convention is correct. The peak shape for
     these tests is unsuitable for this method.


### PR DESCRIPTION
---
name: Local gaussian shift
about: Fix subpixel refinement using local gaussian shift

- [x] ready for review and merge?
---

**Release Notes**
> major
> bugfix
Summary: Fix subpixel refinement using local gaussian shift

**What does this PR do? Please describe and/or link to an open issue.**
The subpixel refinement with `local_gaussian_method` included the offset to experimental square centre (local search area) in the shift applied to the vectors. This PR adds a test that catches this error and then fixes it by changing the returned shift from `_new_lg_idea`.

**Work in progress?**
- [x] Wait for #419, then rebase (this changeset is built on top of the cleanup in that PR)


