### PR TITLE
add default values to plot_diffraction_vectors

### DIFF
--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -67,23 +67,24 @@ class DiffractionVectors(BaseSignal):
         self.cartesian = None
         self.hkls = None
 
-    def plot_diffraction_vectors(self, xlim, ylim, distance_threshold):
+    def plot_diffraction_vectors(self, xlim=1.0, ylim=1.0,
+                                 distance_threshold=0.01):
         """Plot the unique diffraction vectors.
 
         Parameters
         ----------
         xlim : float
-            The maximum x coordinate to be plotted.
+            The maximum x coordinate in reciprocal Angstroms to be plotted.
         ylim : float
-            The maximum y coordinate to be plotted.
+            The maximum y coordinate in reciprocal Angstroms to be plotted.
         distance_threshold : float
-            The minimum distance between diffraction vectors to be passed to
-            get_unique_vectors.
+            The minimum distance in reciprocal Angstroms between diffraction
+            vectors to be passed to get_unique_vectors.
 
         Returns
         -------
         fig : matplotlib figure
-            The plot as a matplot lib figure.
+            The plot as a matplotlib figure.
 
         """
         # Find the unique gvectors to plot.


### PR DESCRIPTION
Default values for the plot_diffraction_vectors method to make it a little easier to use. Also some small docstring updates to the same method.

Addresses #405 based on feedback at NTNU diffraction workshop.