### PR TITLE
Decomposition wrapper

### DIFF
--- a/pyxem/signals/diffraction1d.py
+++ b/pyxem/signals/diffraction1d.py
@@ -138,6 +138,10 @@ class Diffraction1D(Signal1D):
         res.__init__(**res._to_dictionary())
         return res
 
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = Diffraction1D
+
 
 class LazyDiffraction1D(LazySignal, Diffraction1D):
 
@@ -150,3 +154,7 @@ class LazyDiffraction1D(LazySignal, Diffraction1D):
         super().compute(*args, **kwargs)
         self.__class__ = Diffraction1D
         self.__init__(**self._to_dictionary())
+
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = LazyDiffraction1D

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -499,6 +499,7 @@ class Diffraction2D(Signal2D):
         super(Signal2D, self).decomposition(*args, **kwargs)
         self.learning_results.loadings = np.nan_to_num(
             self.learning_results.loadings)
+        self.__class__ = Diffraction2D
 
     def find_peaks(self, method, *args, **kwargs):
         """Find the position of diffraction peaks.
@@ -633,3 +634,7 @@ class LazyDiffraction2D(LazySignal, Diffraction2D):
         super().compute(*args, **kwargs)
         self.__class__ = Diffraction2D
         self.__init__(**self._to_dictionary())
+
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = LazyDiffraction2D

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -480,27 +480,6 @@ class Diffraction2D(Signal2D):
 
         return bg_subtracted
 
-    def decomposition(self, *args, **kwargs):
-        """Decomposition with a choice of algorithms.
-
-        Parameters
-        ----------
-        *args :
-            Arguments to be passed to decomposition().
-        **kwargs :
-            Keyword arguments to be passed to decomposition().
-
-        Returns
-        -------
-        The results are stored in self.learning_results. For a full description
-        of parameters see :meth:`hyperspy.learn.mva.MVA.decomposition`
-
-        """
-        super(Signal2D, self).decomposition(*args, **kwargs)
-        self.learning_results.loadings = np.nan_to_num(
-            self.learning_results.loadings)
-        self.__class__ = Diffraction2D
-
     def find_peaks(self, method, *args, **kwargs):
         """Find the position of diffraction peaks.
 
@@ -621,6 +600,10 @@ class Diffraction2D(Signal2D):
         res.__class__ = LazyDiffraction2D
         res.__init__(**res._to_dictionary())
         return res
+
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = Diffraction2D
 
 
 class LazyDiffraction2D(LazySignal, Diffraction2D):

--- a/pyxem/signals/electron_diffraction1d.py
+++ b/pyxem/signals/electron_diffraction1d.py
@@ -137,6 +137,10 @@ class ElectronDiffraction1D(Diffraction1D):
         res.__init__(**res._to_dictionary())
         return res
 
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = ElectronDiffraction1D
+
 
 class LazyElectronDiffraction1D(LazySignal, ElectronDiffraction1D):
 
@@ -149,3 +153,7 @@ class LazyElectronDiffraction1D(LazySignal, ElectronDiffraction1D):
         super().compute(*args, **kwargs)
         self.__class__ = ElectronDiffraction1D
         self.__init__(**self._to_dictionary())
+
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = LazyElectronDiffraction1D

--- a/pyxem/signals/electron_diffraction2d.py
+++ b/pyxem/signals/electron_diffraction2d.py
@@ -173,6 +173,10 @@ class ElectronDiffraction2D(Diffraction2D):
         res.__init__(**res._to_dictionary())
         return res
 
+    def decomposition(self, *args, **kwargs):
+        super(ElectronDiffraction2D, self).decomposition(*args, **kwargs)
+        self.__class__ = ElectronDiffraction2D
+
 
 class LazyElectronDiffraction2D(LazySignal, ElectronDiffraction2D):
 

--- a/pyxem/signals/electron_diffraction2d.py
+++ b/pyxem/signals/electron_diffraction2d.py
@@ -174,7 +174,7 @@ class ElectronDiffraction2D(Diffraction2D):
         return res
 
     def decomposition(self, *args, **kwargs):
-        super(ElectronDiffraction2D, self).decomposition(*args, **kwargs)
+        super().decomposition(*args, **kwargs)
         self.__class__ = ElectronDiffraction2D
 
 
@@ -189,3 +189,7 @@ class LazyElectronDiffraction2D(LazySignal, ElectronDiffraction2D):
         super().compute(*args, **kwargs)
         self.__class__ = ElectronDiffraction2D
         self.__init__(**self._to_dictionary())
+
+    def decomposition(self, *args, **kwargs):
+        super().decomposition(*args, **kwargs)
+        self.__class__ = LazyElectronDiffraction2D

--- a/pyxem/tests/test_signals/test_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_diffraction1d.py
@@ -69,3 +69,15 @@ class TestComputeAndAsLazy1D:
         s_lazy = s.as_lazy()
         assert s_lazy.__class__ == LazyDiffraction1D
         assert data.shape == s_lazy.data.shape
+
+
+class TestDecomposition:
+    def test_decomposition_is_performed(self, electron_diffraction1d):
+        s = Diffraction1D(electron_diffraction1d)
+        s.decomposition()
+        assert s.learning_results is not None
+
+    def test_decomposition_class_assignment(self, electron_diffraction1d):
+        s = Diffraction1D(electron_diffraction1d)
+        s.decomposition()
+        assert isinstance(s, Diffraction1D)

--- a/pyxem/tests/test_signals/test_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_diffraction2d.py
@@ -69,3 +69,15 @@ class TestComputeAndAsLazy2D:
         s_lazy = s.as_lazy()
         assert s_lazy.__class__ == LazyDiffraction2D
         assert data.shape == s_lazy.data.shape
+
+
+class TestDecomposition:
+    def test_decomposition_is_performed(self, diffraction_pattern):
+        s = Diffraction2D(diffraction_pattern)
+        s.decomposition()
+        assert s.learning_results is not None
+
+    def test_decomposition_class_assignment(self, diffraction_pattern):
+        s = Diffraction2D(diffraction_pattern)
+        s.decomposition()
+        assert isinstance(s, Diffraction2D)

--- a/pyxem/tests/test_signals/test_electron_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction1d.py
@@ -109,10 +109,6 @@ class TestComputeAndAsLazyElectron1D:
 
 
 class TestDecomposition:
-    def test_decomposition_is_performed(self, electron_diffraction1d):
-        electron_diffraction1d.decomposition()
-        assert electron_diffraction1d.learning_results is not None
-
     def test_decomposition_class_assignment(self, electron_diffraction1d):
         electron_diffraction1d.decomposition()
         assert isinstance(electron_diffraction1d, ElectronDiffraction1D)

--- a/pyxem/tests/test_signals/test_electron_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction1d.py
@@ -106,3 +106,13 @@ class TestComputeAndAsLazyElectron1D:
         s_lazy = s.as_lazy()
         assert s_lazy.__class__ == LazyElectronDiffraction1D
         assert data.shape == s_lazy.data.shape
+
+
+class TestDecomposition:
+    def test_decomposition_is_performed(self, electron_diffraction1d):
+        electron_diffraction1d.decomposition()
+        assert electron_diffraction1d.learning_results is not None
+
+    def test_decomposition_class_assignment(self, electron_diffraction1d):
+        electron_diffraction1d.decomposition()
+        assert isinstance(electron_diffraction1d, ElectronDiffraction1D)

--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -325,16 +325,6 @@ class TestPeakFinding:
 
 
 class TestsAssertionless:
-    def test_decomposition(self, diffraction_pattern):
-        storage = diffraction_pattern.decomposition()
-
-    def test_decomposition_class_assignment(self, diffraction_pattern):
-        diffraction_pattern.decomposition()
-        assert isinstance(diffraction_pattern, ElectronDiffraction2D)
-
-    def test_decomposition_is_performed(self, diffraction_pattern):
-        diffraction_pattern.decomposition()
-        assert diffraction_pattern.learning_results is not None
 
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     # we don't want to use xc in this bit
@@ -409,3 +399,12 @@ class TestComputeAndAsLazyElectron2D:
         s_lazy = s.as_lazy()
         assert s_lazy.__class__ == LazyElectronDiffraction2D
         assert data.shape == s_lazy.data.shape
+
+
+class TestDecomposition:
+    def test_decomposition(self, diffraction_pattern):
+        storage = diffraction_pattern.decomposition()
+
+    def test_decomposition_class_assignment(self, diffraction_pattern):
+        diffraction_pattern.decomposition()
+        assert isinstance(diffraction_pattern, ElectronDiffraction2D)

--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -328,6 +328,14 @@ class TestsAssertionless:
     def test_decomposition(self, diffraction_pattern):
         storage = diffraction_pattern.decomposition()
 
+    def test_decomposition_class_assignment(self, diffraction_pattern):
+        diffraction_pattern.decomposition()
+        assert isinstance(diffraction_pattern, ElectronDiffraction2D)
+
+    def test_decomposition_is_performed(self, diffraction_pattern):
+        diffraction_pattern.decomposition()
+        assert diffraction_pattern.learning_results is not None
+
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     # we don't want to use xc in this bit
     @pytest.mark.filterwarnings('ignore::UserWarning')

--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -402,9 +402,6 @@ class TestComputeAndAsLazyElectron2D:
 
 
 class TestDecomposition:
-    def test_decomposition(self, diffraction_pattern):
-        storage = diffraction_pattern.decomposition()
-
     def test_decomposition_class_assignment(self, diffraction_pattern):
         diffraction_pattern.decomposition()
         assert isinstance(diffraction_pattern, ElectronDiffraction2D)

--- a/pyxem/tests/test_signals/test_lazy_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_lazy_diffraction1d.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyxem.signals.diffraction1d import Diffraction1D, LazyDiffraction1D
+
+
+class TestDecomposition:
+    def test_decomposition_class_assignment(self, electron_diffraction1d):
+        s = Diffraction1D(electron_diffraction1d)
+        s = s.as_lazy()
+        s.decomposition()
+        assert isinstance(s, LazyDiffraction1D)

--- a/pyxem/tests/test_signals/test_lazy_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_lazy_diffraction2d.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
+
+
+class TestDecomposition:
+    def test_decomposition_class_assignment(self, diffraction_pattern):
+        s = Diffraction2D(diffraction_pattern)
+        s = s.as_lazy()
+        s.decomposition()
+        assert isinstance(s, LazyDiffraction2D)

--- a/pyxem/tests/test_signals/test_lazy_electron_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_lazy_electron_diffraction1d.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyxem.signals.electron_diffraction1d import LazyElectronDiffraction1D
+
+
+class TestDecomposition:
+    def test_decomposition_class_assignment(self, electron_diffraction1d):
+        s = electron_diffraction1d.as_lazy()
+        s.decomposition()
+        assert isinstance(s, LazyElectronDiffraction1D)

--- a/pyxem/tests/test_signals/test_lazy_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_lazy_electron_diffraction2d.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyxem.signals.electron_diffraction2d import LazyElectronDiffraction2D
+
+
+class TestDecomposition:
+    def test_decomposition_class_assignment(self, diffraction_pattern):
+        diffraction_pattern = diffraction_pattern.as_lazy()
+        diffraction_pattern.decomposition()
+        assert isinstance(diffraction_pattern, LazyElectronDiffraction2D)


### PR DESCRIPTION
---
name: Basic decomposition wrapper for `ElectronDiffraction2D` and `LazyElectronDiffraction2D`
about: Keep pyXem's signal classes after using HyperSpy's `decomposition()`

- [x] testing
- [x] ready for review and merge?
---

**Release Notes**
> minor
> improvement
Summary: Keep signal classes ElectronDiffraction2D and LazyElectronDiffraction2D after using HyperSpy's decomposition function.

**What does this PR do? Please describe and/or link to an open issue.**
Addresses #404.

**Are there any known issues? Do you need help?**
The solution is as simple as it gets. I am not sure how much of the docstring from HyperSpy's `decomposition()` is passed over using Jupyter Notebook, I have only tested the functionality in the PyCharm editor. So the user might have to look up HyperSpy's docstring for info about the input parameters...