### PR TITLE
Added lazy processing to transform

### DIFF
--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -260,12 +260,18 @@ def apply_transformation(z, transformation,keep_dtype,order=1,*args, **kwargs):
     Generally used in combination with pyxem.expt_utils.convert_affine_to_transform
     """
     if keep_dtype == False:
-        trans = tf.warp(z, transformation,
-                    order=order, *args, **kwargs)
+        if z._lazy == True:
+            trans = z.data.map_blocks(tf.warp, transformation,order = order, *args, **kwargs)
+        else:
+            trans = tf.warp(z, transformation,
+                        order=order, *args, **kwargs)
     if keep_dtype == True:
+        if z._lazy == True:
+            trans = z.data.map_blocks(tf.warp, transformation,order = order ,preserve_range=True, *args, **kwargs)
+        else:
             trans = tf.warp(z, transformation,
                         order=order,preserve_range=True, *args, **kwargs)
-            trans = trans.astype(z.dtype)
+        trans = trans.astype(z.dtype)
 
     return trans
 


### PR DESCRIPTION
**Not tested at all,**  will do so later this week.

---
name:  Pull request  -  Added lazy processing to expt_utils.apply_transformation
about: This should allow lazy transformation of abitrarily large dask arrays usiing the scikit image warp function.

---

**Release Notes**
>  minor 
> improvement 
Summary:  Implemented lazy transformation of abitrarily large dask arrays 

**What does this PR do? Please describe and/or link to an open issue.**
Implemented lazy transformation of abitrarily large dask arrays 

**Are there any known issues? Do you need help?**
If the code isn't quite working as you want it to, tell us here so we can help you polish the code.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [ ] Test with data
- [ ] add order, preserve range keyword args to kwargs


