### PR TITLE
Strain mapping improvements - Least Squares only

### DIFF
--- a/pyxem/generators/displacement_gradient_tensor_generator.py
+++ b/pyxem/generators/displacement_gradient_tensor_generator.py
@@ -112,7 +112,7 @@ def get_single_DisplacementGradientTensor(Vs, Vu=None, weights=None):
         else:
             Vs, Vu = Vs.T, Vu.T
 
-        L = np.linalg.lstsq(Vu, Vs)[0]  # only need the return array, see np,linalg.lstsq docs
+        L = np.linalg.lstsq(Vu, Vs, rcond=-1)[0]  # only need the return array, see np,linalg.lstsq docs
     # Put caculated matrix values into 3 x 3 matrix to be returned.
     D = np.eye(3)
     D[0:2, 0:2] = L

--- a/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
@@ -146,7 +146,7 @@ def test_weight_function_behaviour():
 
 
 @pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_rotation(xy_vectors, right_handed, left_handed, multi_vector):
+def test_rotation(xy_vectors, right_handed, left_handed, multi_vector): # pragma: no cover
     """
     We should always measure the same rotations, regardless of basis (as long as it's right handed)
     """
@@ -161,7 +161,7 @@ def test_rotation(xy_vectors, right_handed, left_handed, multi_vector):
 
 
 @pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_trace(xy_vectors, right_handed, multi_vector):
+def test_trace(xy_vectors, right_handed, multi_vector): # pragma: no cover
     """
     Basis does effect strain measurement, but we can simply calculate suitable invarients.
     See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.

--- a/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
@@ -105,6 +105,7 @@ def left_handed():
     s_da = generate_strain_map(danger)
     return s_da
 
+
 @pytest.fixture()
 def multi_vector():
     four_vectors = np.asarray([[1, 0, 1, 1], [0, 1, -1, 1]])
@@ -114,7 +115,8 @@ def multi_vector():
 
 """ Each of these basis should return the same results, in an xy basis"""
 
-def test_results_returned_correctly_in_same_basis(xy_vectors,right_handed,left_handed,multi_vector):
+
+def test_results_returned_correctly_in_same_basis(xy_vectors, right_handed, left_handed, multi_vector):
     """ Basic test of the summary statement for this section """
     np.testing.assert_almost_equal(xy_vectors.data, right_handed.data, decimal=2)
     np.testing.assert_almost_equal(xy_vectors.data, left_handed.data, decimal=2)
@@ -146,7 +148,7 @@ def test_weight_function_behaviour():
 
 
 @pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_rotation(xy_vectors, right_handed, left_handed, multi_vector): # pragma: no cover
+def test_rotation(xy_vectors, right_handed, left_handed, multi_vector):  # pragma: no cover
     """
     We should always measure the same rotations, regardless of basis (as long as it's right handed)
     """
@@ -161,7 +163,7 @@ def test_rotation(xy_vectors, right_handed, left_handed, multi_vector): # pragma
 
 
 @pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_trace(xy_vectors, right_handed, multi_vector): # pragma: no cover
+def test_trace(xy_vectors, right_handed, multi_vector):  # pragma: no cover
     """
     Basis does effect strain measurement, but we can simply calculate suitable invarients.
     See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.

--- a/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
@@ -127,10 +127,10 @@ def test_rotation(xy_vectors, right_handed, multi_vector):
 
 def test_left_vs_right_rotation(xy_vectors, left_handed):
     """
-    We should pick up a minus sign if we compare left vs right handed basis
+    We no longer pick up a minus sign if we compare left vs right handed basis
     """
     xy_rot = xy_vectors.inav[3].data
-    lh_rot = np.multiply(left_handed.inav[3].data, -1)
+    lh_rot = np.multiply(left_handed.inav[3].data, +1)
 
     np.testing.assert_almost_equal(xy_rot, lh_rot, decimal=2)  # rotations
 


### PR DESCRIPTION
---
name: Strain mapping improvements - Least Squares only 
about: In `0.8` and `0.9` pyxem was able to solve a matrix equation to generate a displacement gradient tensor. This has some scientific appeal, but means results are returned in a weird basis. Going forward the least squares method (introduced in `0.9`) will apply even in the 2 vector case (it gives basically the same answer, fitting a line to 2 points only really has one answer) - and all answer will be returned in the `x,y` basis.

---

**Release Notes**
> improvement 
> Summary: All strain maps will return in `e_xx` and `e_yy`

**Describe alternatives you've considered**
In the end, the benefit of no `left-vs-right` outweighed everything else.

**Are there any known issues? Do you need help?**
A basis change functionality will need to be introduced to help users adapt to this change, but this will be left to a different pull request.
