### PR TITLE
Strain Mapping Enhancement: StrainMap class, with basis changing method

### DIFF
--- a/pyxem/signals/__init__.py
+++ b/pyxem/signals/__init__.py
@@ -48,6 +48,32 @@ def push_metadata_through(dummy, *args, **kwargs):
 
     return dummy, args, kwargs
 
+def transfer_signal_axes(new_signal, old_signal):
+    """ Transfers signal axis calibrations from an old signal to a new
+    signal produced from it by a method or a generator.
+
+    Parameters
+    ----------
+    new_signal : Signal
+        The product signal with undefined signal axes.
+    old_signal : Signal
+        The parent signal with calibrated signal axes.
+
+    Returns
+    -------
+    new_signal : Signal
+        The new signal with calibrated signal axes.
+    """
+
+    for i in range(old_signal.axes_manager.signal_dimension):
+        ax_new = new_signal.axes_manager.signal_axes[i]
+        ax_old = old_signal.axes_manager.signal_axes[i]
+        ax_new.name = ax_old.name
+        ax_new.scale = ax_old.scale
+        ax_new.units = ax_old.units
+
+    return new_signal
+
 
 def transfer_navigation_axes(new_signal, old_signal):
     """ Transfers navigation axis calibrations from an old signal to a new

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -18,6 +18,7 @@
 
 from hyperspy.signals import Signal2D
 import numpy as np
+from pyxem.signals import push_metadata_through
 
 
 
@@ -25,18 +26,43 @@ class StrainMap(Signal2D):
     _signal_type = "strain_map"
 
     def __init__(self, *args, **kwargs):
-        Signal2D.__init__(self, *args, **kwargs)
+        self, args, kwargs = push_metadata_through(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
+        # check init dimension are correct
         self.current_basis_x = [1,0]
         self.current_basis_y = [0,1]
 
-    def change_strain_basis(x_new):
+
+    def rotate_strain_basis(self,x_new):
         # following
         #https://www.continuummechanics.org/stressxforms.html
         # retrived August 2019
+        from hyperspy.api import transpose
 
         def _get_rotation_matrix(x_new):
-            # just do an inverse job
-            x_old = self.current_basis_x
-            pass
-        
-        pass
+            # ONLY WORKS FOR self.current_basis_x = [1,0] etc
+            try:
+                rotation_angle = np.arctan(x_new[1]/x_new[0])
+            except ZeroDivisionError:
+               rotation_angle = np.deg2rad(90) #check sign on this
+
+            R    = np.array([[np.cos(rotation_angle),-np.sin(rotation_angle)],
+                             [np.sin(rotation_angle), np.cos(rotation_angle)]])
+            return R
+
+        R = _get_rotation_matrix(x_new)
+
+        def apply_rotation(transposed_strain_map,R=R):
+                sigmaxx_old = transposed_strain_map[0]
+                sigmaxy_old = transposed_strain_map[1]
+                sigmaxy_old = transposed_strain_map[1]
+                sigmayy_old = transposed_strain_map[2]
+                z = np.asarray([[sigmaxx_old,sigmaxy_old],
+                                [sigmaxy_old,sigmayy_old]])
+                new = np.matmul(R,np.matmul(z,R.T))
+                return [new[0,0],new[0,1],new[1,1],transposed_strain_map[3]]
+
+        transposed = transpose(self)[0]
+        transposed_to_new_basis = transposed.map(apply_rotation,R=R,inplace=False)
+
+        return StrainMap(transposed_to_new_basis.T)

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -16,6 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+from hyperspy.signals import Signal2D
+import numpy as np
+
+
+
 class StrainMap(Signal2D):
     _signal_type = "strain_map"
 
@@ -25,4 +30,13 @@ class StrainMap(Signal2D):
         self.current_basis_y = [0,1]
 
     def change_strain_basis(x_new):
+        # following
+        #https://www.continuummechanics.org/stressxforms.html
+        # retrived August 2019
+
+        def _get_rotation_matrix(x_new):
+            # just do an inverse job
+            x_old = self.current_basis_x
+            pass
+        
         pass

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -102,7 +102,7 @@ class StrainMap(Signal2D):
 
         if self.current_basis_x != [1, 0]:
             # this takes us back to [1,0] if our current map is in a diferent basis
-            R = _get_rotation_matrix(self.curent_basis_x).T
+            R = _get_rotation_matrix(self.current_basis_x).T
             strain_map_core = apply_rotation_complete(self, R)
         else:
             strain_map_core = self

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -45,6 +45,12 @@ def _get_rotation_matrix(x_new):
 
 
 class StrainMap(Signal2D):
+    """
+    Class for storing strain maps, if created within pyxem conventions are such that:
+    The 'y-axis' will always lie 90 degrees from the 'x-axis'
+    Rotations are defined such that positive corresponds to anticlockwise.
+    """
+
     _signal_type = "strain_map"
 
     def __init__(self, *args, **kwargs):

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -115,5 +115,6 @@ class StrainMap(Signal2D):
 
         R = _get_rotation_matrix(x_new)
         transposed_to_new_basis = apply_rotation_complete(strain_map_core, R)
+        meta_dict = self.metadata.as_dictionary()
 
-        return StrainMap(transposed_to_new_basis, current_basis_x=x_new)
+        return StrainMap(transposed_to_new_basis, current_basis_x=x_new, metadata=meta_dict)

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -18,7 +18,7 @@
 
 from hyperspy.signals import Signal2D
 import numpy as np
-from pyxem.signals import push_metadata_through
+from pyxem.signals import push_metadata_through, transfer_navigation_axes
 
 
 def _get_rotation_matrix(x_new):
@@ -117,4 +117,5 @@ class StrainMap(Signal2D):
         transposed_to_new_basis = apply_rotation_complete(strain_map_core, R)
         meta_dict = self.metadata.as_dictionary()
 
-        return StrainMap(transposed_to_new_basis, current_basis_x=x_new, metadata=meta_dict)
+        strainmap = StrainMap(transposed_to_new_basis, current_basis_x=x_new, metadata=meta_dict)
+        return transfer_navigation_axes(strainmap,self)

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -18,7 +18,7 @@
 
 from hyperspy.signals import Signal2D
 import numpy as np
-from pyxem.signals import push_metadata_through, transfer_navigation_axes
+from pyxem.signals import push_metadata_through, transfer_signal_axes
 
 
 def _get_rotation_matrix(x_new):
@@ -118,4 +118,4 @@ class StrainMap(Signal2D):
         meta_dict = self.metadata.as_dictionary()
 
         strainmap = StrainMap(transposed_to_new_basis, current_basis_x=x_new, metadata=meta_dict)
-        return transfer_navigation_axes(strainmap,self)
+        return transfer_signal_axes(strainmap,self)

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+class StrainMap(Signal2D):
+    _signal_type = "strain_map"
+
+    def __init__(self, *args, **kwargs):
+        Signal2D.__init__(self, *args, **kwargs)
+        self.current_basis_x = [1,0]
+        self.current_basis_y = [0,1]
+
+    def change_strain_basis(x_new):
+        pass

--- a/pyxem/signals/tensor_field.py
+++ b/pyxem/signals/tensor_field.py
@@ -21,6 +21,7 @@ import numpy as np
 from scipy.linalg import polar
 from hyperspy.utils import stack
 import math
+from pyxem.signals.strain_map import StrainMap
 
 """
 Signal class for Tensor Fields
@@ -111,4 +112,4 @@ class DisplacementGradientMap(Signal2D):
 
         strain_results = stack([e11, e22, e12, theta])
 
-        return strain_results
+        return StrainMap(strain_results)

--- a/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
@@ -142,37 +142,3 @@ def test_weight_function_behaviour():
     deformed = hs.signals.Signal2D(np.asarray([[vectors, vectors], [vectors, vectors]]))
     strain_map = get_DisplacementGradientMap(deformed, multi_vector_array, weights=weights).get_strain_maps()
     np.testing.assert_almost_equal(strain_map.inav[0].isig[0, 0].data[0], -1.0166666 + 1, decimal=2)
-
-
-""" These test will be operational once a basis change functionality is introduced """
-
-
-@pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_rotation(xy_vectors, right_handed, left_handed, multi_vector):  # pragma: no cover
-    """
-    We should always measure the same rotations, regardless of basis (as long as it's right handed)
-    """
-    xy_rot = xy_vectors.inav[3].data
-    rh_rot = right_handed.inav[3].data
-    lh_rot = left_handed.inav[3].data
-    mv_rot = multi_vector.inav[3].data
-
-    np.testing.assert_almost_equal(xy_rot, rh_rot, decimal=2)  # rotations
-    np.testing.assert_almost_equal(xy_rot, lh_rot, decimal=2)  # rotations
-    np.testing.assert_almost_equal(xy_rot, mv_rot, decimal=2)  # rotations
-
-
-@pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_trace(xy_vectors, right_handed, multi_vector):  # pragma: no cover
-    """
-    Basis does effect strain measurement, but we can simply calculate suitable invarients.
-    See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.
-    """
-    np.testing.assert_almost_equal(
-        np.add(
-            xy_vectors.inav[0].data, xy_vectors.inav[1].data), np.add(
-            right_handed.inav[0].data, right_handed.inav[1].data), decimal=2)
-    np.testing.assert_almost_equal(
-        np.add(
-            xy_vectors.inav[0].data, xy_vectors.inav[1].data), np.add(
-            multi_vector.inav[0].data, multi_vector.inav[1].data), decimal=2)

--- a/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
@@ -1,9 +1,4 @@
-from pyxem.generators.displacement_gradient_tensor_generator import \
-    get_DisplacementGradientMap, get_single_DisplacementGradientTensor
-import hyperspy.api as hs
-import pytest
-import numpy as np
-decimal = 2  # -*- coding: utf-8 -*-
+ # -*- coding: utf-8 -*-
 # Copyright 2017-2019 The pyXem developers
 #
 # This file is part of pyXem.
@@ -21,6 +16,11 @@ decimal = 2  # -*- coding: utf-8 -*-
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+from pyxem.generators.displacement_gradient_tensor_generator import \
+    get_DisplacementGradientMap, get_single_DisplacementGradientTensor
+import hyperspy.api as hs
+import pytest
+import numpy as np
 
 def vector_operation(z, M):
     """

--- a/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/test_generators/test_displacement_gradient_tensor_generator.py
@@ -1,4 +1,4 @@
- # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # Copyright 2017-2019 The pyXem developers
 #
 # This file is part of pyXem.
@@ -21,6 +21,7 @@ from pyxem.generators.displacement_gradient_tensor_generator import \
 import hyperspy.api as hs
 import pytest
 import numpy as np
+
 
 def vector_operation(z, M):
     """

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -43,8 +43,14 @@ def test__init__(Displacement_Grad_Map):
     strain_map = Displacement_Grad_Map.get_strain_maps()
     assert strain_map.axes_manager.navigation_size == 4
 
-# TODO consider if there is something important going on with +- for shear
-# TODO confirm (and document) the handedness of our rotation matrix
+def test_signal_axes_carry_through(Displacement_Grad_Map):
+    """ A strain map that is calibrated, should stay calibrated when we change basis """
+    strain_map = Displacement_Grad_Map.get_strain_maps()
+    strain_map.axes_manager.signal_axes[1].units = 'nm'
+    strain_map.axes_manager.signal_axes[0].scale = 19
+    strain_alpha = strain_map.rotate_strain_basis([np.random.rand(), np.random.rand()])
+    assert strain_alpha.axes_manager.signal_axes[1].units == 'nm'
+    assert strain_alpha.axes_manager.signal_axes[0].scale == 19
 
 
 """ These are change of basis tests """

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -20,8 +20,8 @@ import hyperspy.api as hs
 import pytest
 import numpy as np
 from pyxem.tests.test_generators.test_displacement_gradient_tensor_generator import generate_test_vectors
-import hyperspy.api as hs
 from pyxem.generators.displacement_gradient_tensor_generator import get_DisplacementGradientMap
+from pyxem.signals.strain_map import StrainMap, _get_rotation_matrix
 
 @pytest.fixture()
 def Displacement_Grad_Map():
@@ -29,6 +29,12 @@ def Displacement_Grad_Map():
     deformed = hs.signals.Signal2D(generate_test_vectors(xy))
     D = get_DisplacementGradientMap(deformed,xy)
     return D
+
+def test_rotation_matrix_former():
+    x_new = [np.random.rand(),np.random.rand()]
+    R = _get_rotation_matrix(x_new)
+    ratio_array = np.divide(x_new,np.matmul(R,[1,0]))
+    assert np.allclose(ratio_array[0],ratio_array[1])
 
 def test__init__(Displacement_Grad_Map):
     strain_map = Displacement_Grad_Map.get_strain_maps()
@@ -64,7 +70,7 @@ def test_trace(Displacement_Grad_Map):
     Basis does effect strain measurement, but we can simply calculate suitable invarients.
     See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.
     """
-    
+
     local_D  = Displacement_Grad_Map
     original = local_D.get_strain_maps()
     rotation_alpha = original.rotate_strain_basis([1.3,+1.9])

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -1,0 +1,80 @@
+ # -*- coding: utf-8 -*-
+# Copyright 2017-2019 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+import hyperspy.api as hs
+import pytest
+import numpy as np
+from pyxem.tests.test_generators.test_displacement_gradient_tensor_generator import generate_test_vectors
+import hyperspy.api as hs
+from pyxem.generators.displacement_gradient_tensor_generator import get_DisplacementGradientMap
+
+@pytest.fixture()
+def Displacement_Grad_Map():
+    xy = np.asarray([[1, 0], [0, 1]])
+    deformed = hs.signals.Signal2D(generate_test_vectors(xy))
+    D = get_DisplacementGradientMap(deformed,xy)
+    return D
+
+def test__init__(Displacement_Grad_Map):
+    strain_map = Displacement_Grad_Map.get_strain_maps()
+    assert strain_map.axes_manager.navigation_size == 4
+
+
+""" These are change of basis tests """
+
+#@pytest.mark.skip(reason="Failing test above")
+def test_something_changes(Displacement_Grad_Map):
+    oneone_strain_original = Displacement_Grad_Map.get_strain_maps()
+    local_D  = Displacement_Grad_Map
+    strain_alpha = local_D.get_strain_maps()
+    oneone_strain_alpha = strain_alpha.rotate_strain_basis([1.3,+1.9])
+    assert not np.allclose(oneone_strain_original.data,oneone_strain_alpha.data, atol=0.01)
+
+
+@pytest.mark.skip(reason="Failing test above")
+def test_rotation(Displacement_Grad_Map):  # pragma: no cover
+    """
+    We should always measure the same rotations, regardless of basis
+    """
+    local_D  = Displacement_Grad_Map
+    original = local_D.get_strain_maps().inav[3].data
+    local_D.rotate_strain_basis([1.3,+1.9]) #works in place
+    rotation_alpha =  local_D.get_strain_maps().inav[3].data
+    local_D = Displacement_Grad_Map
+    local_D.rotate_strain_basis([1.7,-0.3])
+    rotation_beta = local_D.get_strain_maps().inav[3].data
+
+    # check the functionality has left invarient quantities invarient
+    np.testing.assert_almost_equal(original, rotation_alpha, decimal=2)  # rotations
+    np.testing.assert_almost_equal(original, rotation_beta, decimal=2)  # rotations
+
+
+@pytest.mark.skip(reason="basis change functionality not yet implemented")
+def test_trace(xy_vectors, right_handed, multi_vector):  # pragma: no cover
+    """
+    Basis does effect strain measurement, but we can simply calculate suitable invarients.
+    See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.
+    """
+    np.testing.assert_almost_equal(
+        np.add(
+            xy_vectors.inav[0].data, xy_vectors.inav[1].data), np.add(
+            right_handed.inav[0].data, right_handed.inav[1].data), decimal=2)
+    np.testing.assert_almost_equal(
+        np.add(
+            xy_vectors.inav[0].data, xy_vectors.inav[1].data), np.add(
+            multi_vector.inav[0].data, multi_vector.inav[1].data), decimal=2)

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -1,4 +1,4 @@
- # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # Copyright 2017-2019 The pyXem developers
 #
 # This file is part of pyXem.
@@ -23,46 +23,60 @@ from pyxem.tests.test_generators.test_displacement_gradient_tensor_generator imp
 from pyxem.generators.displacement_gradient_tensor_generator import get_DisplacementGradientMap
 from pyxem.signals.strain_map import StrainMap, _get_rotation_matrix
 
+
 @pytest.fixture()
 def Displacement_Grad_Map():
     xy = np.asarray([[1, 0], [0, 1]])
     deformed = hs.signals.Signal2D(generate_test_vectors(xy))
-    D = get_DisplacementGradientMap(deformed,xy)
+    D = get_DisplacementGradientMap(deformed, xy)
     return D
 
+
 def test_rotation_matrix_formation():
-    x_new = [np.random.rand(),np.random.rand()]
+    x_new = [np.random.rand(), np.random.rand()]
     R = _get_rotation_matrix(x_new)
-    ratio_array = np.divide(x_new,np.matmul(R,[1,0]))
-    assert np.allclose(ratio_array[0],ratio_array[1])
+    ratio_array = np.divide(x_new, np.matmul(R, [1, 0]))
+    assert np.allclose(ratio_array[0], ratio_array[1])
+
 
 def test__init__(Displacement_Grad_Map):
     strain_map = Displacement_Grad_Map.get_strain_maps()
     assert strain_map.axes_manager.navigation_size == 4
 
-#TODO test that a 90 degree rotation of basis does a sensible thing
-#TODO consider if there is something important going on with +- for shear
-#TODO confirm (and document) the handedness of our rotation matrix
-#TODO consider randomising all the extra bases
+# TODO test that a 90 degree rotation of basis does a sensible thing
+# TODO consider if there is something important going on with +- for shear
+# TODO confirm (and document) the handedness of our rotation matrix
+
 
 """ These are change of basis tests """
 
+
 def test_something_changes(Displacement_Grad_Map):
     oneone_strain_original = Displacement_Grad_Map.get_strain_maps()
-    local_D  = Displacement_Grad_Map
+    local_D = Displacement_Grad_Map
     strain_alpha = local_D.get_strain_maps()
-    oneone_strain_alpha = strain_alpha.rotate_strain_basis([1.3,+1.9])
-    assert not np.allclose(oneone_strain_original.data,oneone_strain_alpha.data, atol=0.01)
+    oneone_strain_alpha = strain_alpha.rotate_strain_basis([np.random.rand(), np.random.rand()])
+    assert not np.allclose(oneone_strain_original.data, oneone_strain_alpha.data, atol=0.01)
+
+
+def test_90_degree_rotation(Displacement_Grad_Map):
+    oneone_strain_original = Displacement_Grad_Map.get_strain_maps()
+    local_D = Displacement_Grad_Map
+    strain_alpha = local_D.get_strain_maps()
+    oneone_strain_alpha = strain_alpha.rotate_strain_basis([0, 1])
+    assert np.allclose(oneone_strain_original.inav[2:].data, oneone_strain_alpha.inav[2:].data, atol=0.01)
+    assert np.allclose(oneone_strain_original.inav[0].data, oneone_strain_alpha.inav[1].data, atol=0.01)
+    assert np.allclose(oneone_strain_original.inav[1].data, oneone_strain_alpha.inav[0].data, atol=0.01)
 
 
 def test_rotation(Displacement_Grad_Map):
     """
     We should always measure the same rotations, regardless of basis
     """
-    local_D  = Displacement_Grad_Map
+    local_D = Displacement_Grad_Map
     original = local_D.get_strain_maps()
-    rotation_alpha = original.rotate_strain_basis([1.3,+1.9])
-    rotation_beta  = original.rotate_strain_basis([1.7,-0.3])
+    rotation_alpha = original.rotate_strain_basis([np.random.rand(), np.random.rand()])
+    rotation_beta = original.rotate_strain_basis([np.random.rand(), -np.random.rand()])
 
     # check the functionality has left invarient quantities invarient
     np.testing.assert_almost_equal(original.inav[3].data, rotation_alpha.inav[3].data, decimal=2)  # rotations
@@ -75,11 +89,10 @@ def test_trace(Displacement_Grad_Map):
     See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.
     """
 
-    local_D  = Displacement_Grad_Map
+    local_D = Displacement_Grad_Map
     original = local_D.get_strain_maps()
-    rotation_alpha = original.rotate_strain_basis([1.3,+1.9])
-    rotation_beta  = original.rotate_strain_basis([1.7,-0.3])
-
+    rotation_alpha = original.rotate_strain_basis([1.3, +1.9])
+    rotation_beta = original.rotate_strain_basis([1.7, -0.3])
 
     np.testing.assert_almost_equal(np.add(original.inav[0].data, original.inav[1].data),
                                    np.add(rotation_alpha.inav[0].data, rotation_alpha.inav[1].data),

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -37,7 +37,6 @@ def test__init__(Displacement_Grad_Map):
 
 """ These are change of basis tests """
 
-#@pytest.mark.skip(reason="Failing test above")
 def test_something_changes(Displacement_Grad_Map):
     oneone_strain_original = Displacement_Grad_Map.get_strain_maps()
     local_D  = Displacement_Grad_Map

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -43,7 +43,6 @@ def test__init__(Displacement_Grad_Map):
     strain_map = Displacement_Grad_Map.get_strain_maps()
     assert strain_map.axes_manager.navigation_size == 4
 
-# TODO test that a 90 degree rotation of basis does a sensible thing
 # TODO consider if there is something important going on with +- for shear
 # TODO confirm (and document) the handedness of our rotation matrix
 
@@ -67,6 +66,18 @@ def test_90_degree_rotation(Displacement_Grad_Map):
     assert np.allclose(oneone_strain_original.inav[2:].data, oneone_strain_alpha.inav[2:].data, atol=0.01)
     assert np.allclose(oneone_strain_original.inav[0].data, oneone_strain_alpha.inav[1].data, atol=0.01)
     assert np.allclose(oneone_strain_original.inav[1].data, oneone_strain_alpha.inav[0].data, atol=0.01)
+
+
+def test_going_back_and_forward_between_bases(Displacement_Grad_Map):
+    """ Checks that going via an intermediate strain map doesn't give incorrect answers"""
+    strain_original = Displacement_Grad_Map.get_strain_maps()
+    local_D = Displacement_Grad_Map
+    temp_strain = local_D.get_strain_maps()
+    temp_strain = temp_strain.rotate_strain_basis([np.random.rand(), np.random.rand()])
+    fixed_xnew = [3.1, 4.1]
+    alpha = strain_original.rotate_strain_basis(fixed_xnew)
+    beta = temp_strain.rotate_strain_basis(fixed_xnew)
+    assert np.allclose(alpha, beta, atol=0.01)
 
 
 def test_rotation(Displacement_Grad_Map):

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -30,7 +30,7 @@ def Displacement_Grad_Map():
     D = get_DisplacementGradientMap(deformed,xy)
     return D
 
-def test_rotation_matrix_former():
+def test_rotation_matrix_formation():
     x_new = [np.random.rand(),np.random.rand()]
     R = _get_rotation_matrix(x_new)
     ratio_array = np.divide(x_new,np.matmul(R,[1,0]))
@@ -40,6 +40,10 @@ def test__init__(Displacement_Grad_Map):
     strain_map = Displacement_Grad_Map.get_strain_maps()
     assert strain_map.axes_manager.navigation_size == 4
 
+#TODO test that a 90 degree rotation of basis does a sensible thing
+#TODO consider if there is something important going on with +- for shear
+#TODO confirm (and document) the handedness of our rotation matrix
+#TODO consider randomising all the extra bases
 
 """ These are change of basis tests """
 

--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -45,35 +45,35 @@ def test_something_changes(Displacement_Grad_Map):
     assert not np.allclose(oneone_strain_original.data,oneone_strain_alpha.data, atol=0.01)
 
 
-@pytest.mark.skip(reason="Failing test above")
-def test_rotation(Displacement_Grad_Map):  # pragma: no cover
+def test_rotation(Displacement_Grad_Map):
     """
     We should always measure the same rotations, regardless of basis
     """
     local_D  = Displacement_Grad_Map
-    original = local_D.get_strain_maps().inav[3].data
-    local_D.rotate_strain_basis([1.3,+1.9]) #works in place
-    rotation_alpha =  local_D.get_strain_maps().inav[3].data
-    local_D = Displacement_Grad_Map
-    local_D.rotate_strain_basis([1.7,-0.3])
-    rotation_beta = local_D.get_strain_maps().inav[3].data
+    original = local_D.get_strain_maps()
+    rotation_alpha = original.rotate_strain_basis([1.3,+1.9])
+    rotation_beta  = original.rotate_strain_basis([1.7,-0.3])
 
     # check the functionality has left invarient quantities invarient
-    np.testing.assert_almost_equal(original, rotation_alpha, decimal=2)  # rotations
-    np.testing.assert_almost_equal(original, rotation_beta, decimal=2)  # rotations
+    np.testing.assert_almost_equal(original.inav[3].data, rotation_alpha.inav[3].data, decimal=2)  # rotations
+    np.testing.assert_almost_equal(original.inav[3].data, rotation_beta.inav[3].data, decimal=2)  # rotations
 
 
-@pytest.mark.skip(reason="basis change functionality not yet implemented")
-def test_trace(xy_vectors, right_handed, multi_vector):  # pragma: no cover
+def test_trace(Displacement_Grad_Map):
     """
     Basis does effect strain measurement, but we can simply calculate suitable invarients.
     See https://en.wikipedia.org/wiki/Infinitesimal_strain_theory for details.
     """
-    np.testing.assert_almost_equal(
-        np.add(
-            xy_vectors.inav[0].data, xy_vectors.inav[1].data), np.add(
-            right_handed.inav[0].data, right_handed.inav[1].data), decimal=2)
-    np.testing.assert_almost_equal(
-        np.add(
-            xy_vectors.inav[0].data, xy_vectors.inav[1].data), np.add(
-            multi_vector.inav[0].data, multi_vector.inav[1].data), decimal=2)
+    
+    local_D  = Displacement_Grad_Map
+    original = local_D.get_strain_maps()
+    rotation_alpha = original.rotate_strain_basis([1.3,+1.9])
+    rotation_beta  = original.rotate_strain_basis([1.7,-0.3])
+
+
+    np.testing.assert_almost_equal(np.add(original.inav[0].data, original.inav[1].data),
+                                   np.add(rotation_alpha.inav[0].data, rotation_alpha.inav[1].data),
+                                   decimal=2)
+    np.testing.assert_almost_equal(np.add(original.inav[0].data, original.inav[1].data),
+                                   np.add(rotation_beta.inav[0].data, rotation_beta.inav[1].data),
+                                   decimal=2)


### PR DESCRIPTION
---
name: Strain Mapping Enhancement: StrainMap class, with basis changing method
about: Strain maps automatically (since #452) returns in one basis, this functionality allows this basis to be changed after the formation of StrainMap by introducing a new class (currently with a single method)

---

**Release Notes**
> new feature 
> Summary: Introduction of StrainMap class

**_NB: Marked as stalled as I wait for an answer to question {and do something else!}_** 

**Describe alternatives you've considered**
I made a dent in performing this rotation on `DisplacementGradientTensor`, but this proved more complicated at best, and completely wrong at worst - see https://github.com/pc494/pyxem/pull/60

**Are there any known issues? Do you need help?**
**Question**: Should a strain mapping basis change return inplace? (@dnjohnstone) - 

Assuming I can code up either version it would be good to get it right first time. If the opinions aren't that strong it will be not inplace as this is simpler to code

**Work in progress?**
Yes, this still needs, docstrings, some cleaned up tests, and several look overs, it's being pulled to the main repo so I can the correct _inplace_ decision can be made. I'll request a review when it is done. 
