### PR TITLE
Bug Fix: io_utils

### DIFF
--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -24,6 +24,7 @@ import os
 import warnings
 
 from hyperspy.io import load as hyperspyload
+from hyperspy.io import load_with_reader
 
 import numpy as np
 


### PR DESCRIPTION
Added import of hs load_with_reader to io_utils which had been removed, since it's needed by load_mib.

---