### PR TITLE
Moving away from RNG bases in testing

### DIFF
--- a/pyxem/tests/test_signals/test_strain_map.py
+++ b/pyxem/tests/test_signals/test_strain_map.py
@@ -60,7 +60,7 @@ def test_something_changes(Displacement_Grad_Map):
     oneone_strain_original = Displacement_Grad_Map.get_strain_maps()
     local_D = Displacement_Grad_Map
     strain_alpha = local_D.get_strain_maps()
-    oneone_strain_alpha = strain_alpha.rotate_strain_basis([np.random.rand(), np.random.rand()])
+    oneone_strain_alpha = strain_alpha.rotate_strain_basis([1,1])
     assert not np.allclose(oneone_strain_original.data, oneone_strain_alpha.data, atol=0.01)
 
 


### PR DESCRIPTION
---
name: Moving away from RNG bases in testing
about: We used to test that any random basis gives a change, now we use a specific one.

---

**Release Notes**
> developer change
> Summary: n/a

**What does this PR do? Please describe and/or link to an open issue.**
#458 is currently failing on a Random Number Generator test, in this case
a) the RNG doesn't actually aid us in testing the functionality
b) Debugging it isn't really possible

So I've removed the random element in the failing test.


