### PR TITLE
Lock numpy version to 1.16.5 due to hyperspy bug with 1.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
       'scikit-learn >= 0.19',     # reason unknown
       'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
       'diffsims',
-      'numpy == 1.16.*'           # See PR#464 and Issue#466
+      'numpy == 1.16.5'           # See PR#464 and Issue#466
       ],
     package_data={
         "": ["LICENSE", "readme.rst",],

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
       'scikit-image >= 0.15.0',   # exclude_border argument in peak_finder laplacian (PR #436)
       'matplotlib >= 3.1.1' ,     # 3.1.0 failed
       'scikit-learn >= 0.19',     # reason unknown
-      'hyperspy >= 1.5',          # 1.2 fails, (NTU Workshop - May 2019)
+      'hyperspy <= 1.4',          # 1.2 fails, (NTU Workshop - May 2019)
       'diffsims',
       'numpy < 1.17.0'            # 3.7 appveyor test failed on 1.17.1
       ],

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ setup(
       'scikit-image >= 0.15.0',   # exclude_border argument in peak_finder laplacian (PR #436)
       'matplotlib >= 3.1.1' ,     # 3.1.0 failed
       'scikit-learn >= 0.19',     # reason unknown
-      'hyperspy <= 1.4',          # 1.2 fails, (NTU Workshop - May 2019)
+      'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
       'diffsims',
-      'numpy < 1.17.0'            # 3.7 appveyor test failed on 1.17.1
+      'numpy == 1.16.*'           # See PR#464 and Issue#466
       ],
     package_data={
         "": ["LICENSE", "readme.rst",],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
       'matplotlib >= 3.1.1' ,     # 3.1.0 failed
       'scikit-learn >= 0.19',     # reason unknown
       'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
-      'diffsims'                 
+      'diffsims',
+      'numpy < 1.17.0'            # 3.7 appveyor test failed on 1.17.1
       ],
     package_data={
         "": ["LICENSE", "readme.rst",],

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ setup(
       'scikit-image >= 0.15.0',   # exclude_border argument in peak_finder laplacian (PR #436)
       'matplotlib >= 3.1.1' ,     # 3.1.0 failed
       'scikit-learn >= 0.19',     # reason unknown
-      'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
+      'hyperspy >= 1.5',          # 1.2 fails, (NTU Workshop - May 2019)
       'diffsims',
-      'numpy >= 1.17.0'            # 3.7 appveyor test failed on 1.17.1
+      'numpy < 1.17.0'            # 3.7 appveyor test failed on 1.17.1
       ],
     package_data={
         "": ["LICENSE", "readme.rst",],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
       'scikit-learn >= 0.19',     # reason unknown
       'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
       'diffsims',
-      'numpy < 1.17.0'            # 3.7 appveyor test failed on 1.17.1
+      'numpy >= 1.17.0'            # 3.7 appveyor test failed on 1.17.1
       ],
     package_data={
         "": ["LICENSE", "readme.rst",],


### PR DESCRIPTION
---
name: Lock numpy version to potentially fix appveyor
about: Appveyor (`3.7`) has started failing recently, it appears to be the only CI that is using numpy `1.17`. This PR tests if this the cause of failure. If so more investigation will be needed.

---

**Release Notes**
> n/a
> Summary: n/a

**What does this PR do? Please describe and/or link to an open issue.**
Runs the CI with a low numpy version for diagnostic purposes. Not to be merged as is.
