### PR TITLE
Implement orientation refinement routine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 env:
   global:
-    - DEPS="hyperspy-base diffsims"
+    - DEPS="hyperspy-base diffsims lmfit"
     - TEST_DEPS="pytest pytest-cov coveralls"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 environment:
 
   global:
-    DEPS: "hyperspy-base diffsims"
+    DEPS: "hyperspy-base diffsims lmfit"
     TEST_DEPS: "pytest"
     MPLBACKEND: "agg"
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -205,6 +205,9 @@ def _refine_best_orientations(single_match_result,
                               rank=0,
                               index_error_tol=0.2,
                               method="leastsq",
+                              vary_angles=True,
+                              vary_center=False,
+                              vary_scale=False,
                               verbose=False
                               ):
     """
@@ -234,6 +237,12 @@ def _refine_best_orientations(single_match_result,
         'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
         See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
         for more information.
+    vary_angles : bool,
+        Free the euler angles (rotation matrix) during the refinement.
+    vary_center : bool
+        Free the center of the diffraction pattern (beam center) during the refinement.
+    vary_scale : bool
+        Free the scale (i.e. pixel size) of the diffraction vectors during refinement.
 
     Returns
     -------
@@ -265,6 +274,9 @@ def _refine_best_orientations(single_match_result,
                                      camera_length=camera_length,
                                      index_error_tol=index_error_tol,
                                      method=method,
+                                     vary_angles=vary_angles,
+                                     vary_center=vary_center,
+                                     vary_scale=vary_scale,
                                      verbose=verbose)
         
         top_matches[i] = result[0]
@@ -283,6 +295,9 @@ def _refine_orientation(solution,
                         camera_length,
                         index_error_tol=0.2,
                         method="leastsq",
+                        vary_angles=True,
+                        vary_center=False,
+                        vary_scale=False,
                         verbose=False,
                         ):
     """
@@ -305,6 +320,12 @@ def _refine_orientation(solution,
         'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
         See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
         for more information.
+    vary_angles : bool,
+        Free the euler angles (rotation matrix) during the refinement.
+    vary_center : bool
+        Free the center of the diffraction pattern (beam center) during the refinement.
+    vary_scale : bool
+        Free the scale (i.e. pixel size) of the diffraction vectors during refinement.
     verbose : bool
         Be more verbose
 
@@ -342,12 +363,12 @@ def _refine_orientation(solution,
     ai, aj, ak = mat2euler(solution.rotation_matrix)
     
     params = lmfit.Parameters()
-    params.add("center_x", value=solution.center_x, vary=False)
-    params.add("center_y", value=solution.center_y, vary=False)
-    params.add("ai", value=ai, vary=True)
-    params.add("aj", value=aj, vary=True)
-    params.add("ak", value=ak, vary=True)
-    params.add("scale", value=solution.scale, vary=True, min=0.8, max=1.2)
+    params.add("center_x", value=solution.center_x, vary=vary_center)
+    params.add("center_y", value=solution.center_y, vary=vary_center)
+    params.add("ai", value=ai, vary=vary_angles)
+    params.add("aj", value=aj, vary=vary_angles)
+    params.add("ak", value=ak, vary=vary_angles)
+    params.add("scale", value=solution.scale, vary=vary_scale, min=0.8, max=1.2)
     
     wavelength = get_electron_wavelength(accelarating_voltage)
     camera_length = camera_length * 1e10
@@ -500,6 +521,9 @@ class VectorIndexationGenerator():
                                 camera_length,
                                 rank=0,
                                 index_error_tol=0.2,
+                                vary_angles=True,
+                                vary_center=False,
+                                vary_scale=False,
                                 method="leastsq"):
         """Refines the best orientation and assigns hkl indices to diffraction vectors.
 
@@ -515,6 +539,12 @@ class VectorIndexationGenerator():
             'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
             See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
             for more information.
+        vary_angles : bool,
+            Free the euler angles (rotation matrix) during the refinement.
+        vary_center : bool
+            Free the center of the diffraction pattern (beam center) during the refinement.
+        vary_scale : bool
+            Free the scale (i.e. pixel size) of the diffraction vectors during refinement.
 
         Returns
         -------
@@ -531,7 +561,10 @@ class VectorIndexationGenerator():
                                                n_best=1,
                                                rank=rank,
                                                index_error_tol=index_error_tol,
-                                               method=method)
+                                               method=method,
+                                               vary_angles=vary_angles,
+                                               vary_center=vary_center,
+                                               vary_scale=vary_scale)
 
     def refine_n_best_orientations(self,
                                    orientations,
@@ -540,6 +573,9 @@ class VectorIndexationGenerator():
                                    n_best=0,
                                    rank=0,
                                    index_error_tol=0.2,
+                                   vary_angles=True,
+                                   vary_center=False,
+                                   vary_scale=False,
                                    method="leastsq"):
         """Refines the best orientation and assigns hkl indices to diffraction vectors.
 
@@ -564,6 +600,12 @@ class VectorIndexationGenerator():
             'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
             See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
             for more information.
+        vary_angles : bool,
+            Free the euler angles (rotation matrix) during the refinement.
+        vary_center : bool
+            Free the center of the diffraction pattern (beam center) during the refinement.
+        vary_scale : bool
+            Free the scale (i.e. pixel size) of the diffraction vectors during refinement.
 
         Returns
         -------
@@ -583,6 +625,9 @@ class VectorIndexationGenerator():
                                    rank=rank,
                                    method="leastsq",
                                    verbose=False,
+                                   vary_angles=vary_angles,
+                                   vary_center=vary_center,
+                                   vary_scale=vary_scale,
                                    inplace=False, parallel=False)
         
         indexation = matched.isig[0]

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -32,6 +32,13 @@ from pyxem.utils.indexation_utils import correlate_library
 from pyxem.utils.indexation_utils import index_magnitudes
 from pyxem.utils.indexation_utils import match_vectors
 
+from collections import namedtuple
+
+from transforms3d.euler import mat2euler, euler2mat
+from pyxem.utils.vector_utils import detector_to_fourier
+from diffsims.utils.sim_utils import get_electron_wavelength
+
+import lmfit
 
 class IndexationGenerator():
     """Generates an indexer for data using a number of methods.
@@ -186,6 +193,217 @@ class ProfileIndexationGenerator():
         return index_magnitudes(np.array(self.magnitudes), self.simulation, tolerance)
 
 
+def get_nth_best_solution(single_match_result, rank=0):
+    """Get the nth best solution by match_rate from a pool of solutions
+
+    Parameters
+    ----------
+    single_match_result : VectorMatchingResults, TemplateMatchingResults
+        Pool of solutions from the vector matching algorithm
+    rank : int
+        The rank of the solution, i.e. rank=2 returns the third best solution
+
+    Returns
+    -------
+    best_fit : np.array
+        Parameters for the best fitting orientation
+        VectorMatching: 
+            Library Number, rotation_matrix, match_rate, error_hkls, total_error
+        TemplateMatching:
+            Library Number , [z, x, z], Correlation Score
+
+    """
+    srt_idx = np.argsort(single_match_result[:, 2])[rank]
+    best_fit = single_match_result[rank]
+    return best_fit
+
+
+# container for OrientationRefinementResults
+OrientationRefinementResults = namedtuple("OrientationRefinementResult", 
+                                          "phase_index rotation_matrix match_rate error_hkls total_error scale center_x center_y".split())
+
+
+def _refine_best_orientation(single_match_result, 
+                             vectors,
+                             library,
+                             accelarating_voltage,
+                             camera_length,
+                             rank=0,
+                             index_error_tol=0.2,
+                             method="leastsq"
+                             ):
+    """
+    Refine a single orientation agains the given cartesian vector coordinates.
+
+    Parameters
+    ----------
+    single_match_result : VectorMatchingResults
+        Pool of solutions from the vector matching algorithm
+    rank : int
+        The rank of the solution, i.e. rank=2 returns the third best solution    solution : list
+        np.array containing the initial orientation
+    vectors : DiffractionVectors
+        DiffractionVectors to be indexed.
+    structure_library : :obj:`diffsims:StructureLibrary` Object
+        Dictionary of structures and associated orientations for which
+        electron diffraction is to be simulated.
+    index_error_tol : float
+        Max allowed error in peak indexation for classifying it as indexed,
+        calculated as :math:`|hkl_calculated - round(hkl_calculated)|`.
+    method : str
+        Minimization algorithm to use, choose from: 
+        'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
+        See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
+        for more information.
+
+    Returns
+    -------
+    result : OrientationRefinementResult
+        Container for the orientation refinement results
+    """
+    solution = get_nth_best_solution(single_match_result, rank=rank)
+    
+    result = _refine_orientation(solution, 
+                                 vectors, 
+                                 library,
+                                 accelarating_voltage=accelarating_voltage,
+                                 camera_length=camera_length,
+                                 index_error_tol=index_error_tol,
+                                 method=method,)
+
+    return result
+
+
+def _refine_orientation(solution, 
+                        k_xy,
+                        structure_library, 
+                        accelarating_voltage,
+                        camera_length,
+                        index_error_tol=0.2,
+                        method="leastsq",
+                        verbose=False,
+                        ):
+    """
+    Refine a single orientation agains the given cartesian vector coordinates.
+
+    Parameters
+    ----------
+    solution : list
+        np.array containing the initial orientation
+    k_xy : DiffractionVectors
+        DiffractionVectors (x,y pixel format) to be indexed.
+    structure_library : :obj:`diffsims:StructureLibrary` Object
+        Dictionary of structures and associated orientations for which
+        electron diffraction is to be simulated.
+    index_error_tol : float
+        Max allowed error in peak indexation for classifying it as indexed,
+        calculated as :math:`|hkl_calculated - round(hkl_calculated)|`.
+    method : str
+        Minimization algorithm to use, choose from: 
+        'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
+        See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
+        for more information.
+    verbose : bool
+        Be more verbose
+
+    Returns
+    -------
+    result : OrientationRefinementResult
+        Container for the orientation refinement results
+    """
+    phase_index, rotation_matrix, match_rate, error_hkls, total_error = solution
+
+    angles = mat2euler(rotation_matrix)
+
+    # prepare reciprocal_lattice
+    structure = structure_library.structures[phase_index]
+    lattice_recip = structure.lattice.reciprocal()
+    
+    def objfunc(params, k_xy, lattice_recip, wavelength, camera_length):
+        cx = params["center_x"].value
+        cy = params["center_y"].value
+        ai = params["ai"].value
+        aj = params["aj"].value
+        ak = params["ak"].value
+        scale = params["scale"].value
+        
+        rotmat = euler2mat(ai, aj, ak)
+
+        k_xy = (k_xy + np.array((cx, cy)) * scale)
+        cart = detector_to_fourier(k_xy, wavelength, camera_length)
+        
+        intermediate = cart.dot(rotmat.T) # Must use the transpose here
+        hklss = lattice_recip.fractional(intermediate) * scale
+        
+        rhklss = np.rint(hklss)
+        ehklss = np.abs(hklss - rhklss)
+        
+        return ehklss
+    
+    ai, aj, ak = mat2euler(rotation_matrix)
+    
+    params = lmfit.Parameters()
+    params.add("center_x", value=0.0, vary=False)
+    params.add("center_y", value=0.0, vary=False)
+    params.add("ai", value=ai, vary=True)
+    params.add("aj", value=aj, vary=True)
+    params.add("ak", value=ak, vary=True)
+    params.add("scale", value=1.0, vary=True, min=0.8, max=1.2)
+    
+    wavelength = get_electron_wavelength(accelarating_voltage)
+    camera_length = camera_length * 1e10
+    args = k_xy, lattice_recip, wavelength, camera_length 
+    
+    res = lmfit.minimize(objfunc, params, args=args, method=method)
+    
+    if verbose:
+        lmfit.report_fit(res)
+            
+    p = res.params
+
+    ai, aj, ak = p["ai"].value, p["aj"].value, p["ak"].value
+    scale = p["scale"].value
+    cx = params["center_x"].value
+    cy = params["center_y"].value
+    
+    rotation_matrix = euler2mat(ai, aj, ak)
+    
+    k_xy = (k_xy + np.array((cx, cy)) * scale)
+    cart = detector_to_fourier(k_xy, wavelength=wavelength, camera_length=camera_length)
+    
+    intermediate = cart.dot(rotation_matrix.T) # Must use the transpose here
+    hklss = lattice_recip.fractional(intermediate)
+
+    rhklss = np.rint(hklss)
+    
+    error_hkls = res.residual.reshape(-1, 3)
+    error_mean = np.mean(error_hkls)
+    
+    print("Final", error_mean)
+    
+    valid_peak_mask = np.max(error_hkls, axis=-1) < index_error_tol
+    valid_peak_count = np.count_nonzero(valid_peak_mask, axis=-1)
+    
+    num_peaks = len(k_xy)
+    
+    match_rate = (valid_peak_count * (1 / num_peaks)) if num_peaks else 0
+    
+    orientation = OrientationRefinementResults(phase_index=phase_index,
+                                               rotation_matrix=rotation_matrix,
+                                               match_rate=match_rate,
+                                               error_hkls=error_hkls,
+                                               total_error=error_mean,
+                                               scale=scale,
+                                               center_x=cx,
+                                               center_y=cy)
+
+    res = np.empty(2, dtype=np.object)
+    res[0] = orientation
+    res[1] = rhklss
+
+    return res
+
+
 class VectorIndexationGenerator():
     """Generates an indexer for DiffractionVectors using a number of methods.
 
@@ -278,3 +496,60 @@ class VectorIndexationGenerator():
         vectors.hkls = rhkls
 
         return indexation_results
+
+    def refine_best_orientation(self, 
+                                indexation_results,
+                                accelarating_voltage,
+                                camera_length,
+                                rank=0,
+                                index_error_tol=0.2,
+                                method="leastsq"):
+        """Refines the best orientation and assigns hkl indices to diffraction vectors.
+
+        Parameters
+        ----------
+        rank : int
+            The rank of the solution, i.e. rank=2 returns the third best solution
+        index_error_tol : float
+            Max allowed error in peak indexation for classifying it as indexed,
+            calculated as :math:`|hkl_calculated - round(hkl_calculated)|`.
+        method : str
+            Minimization algorithm to use, choose from: 
+            'leastsq', 'nelder', 'powell', 'cobyla', 'least-squares'.
+            See `lmfit` documentation (https://lmfit.github.io/lmfit-py/fitting.html)
+            for more information.
+
+        Returns
+        -------
+        indexation_results : VectorMatchingResults
+            Navigation axes of the diffraction vectors signal containing vector
+            indexation results for each probe position.
+        """
+        vectors = self.vectors
+        library = self.library
+
+        result = indexation_results.map(_refine_best_orientation,
+                                        vectors=vectors,
+                                        library=library,
+                                        accelarating_voltage=accelarating_voltage,
+                                        camera_length=camera_length,
+                                        index_error_tol=index_error_tol,
+                                        method=method,
+                                        parallel=False, inplace=False)
+
+        indexation = result.isig[0]
+        rhkls = result.isig[1].data
+
+        indexation_results = VectorMatchingResults(indexation)
+        indexation_results.vectors = vectors
+        indexation_results.hkls = rhkls
+        indexation_results = transfer_navigation_axes(indexation_results,
+                                                      vectors.cartesian)
+
+        vectors.hkls = rhkls
+
+        return indexation_results
+
+    def refine_all_orientations(self):
+        pass
+

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -131,7 +131,7 @@ class VectorMatchingResults(BaseSignal):
 
     def __init__(self, *args, **kwargs):
         BaseSignal.__init__(self, *args, **kwargs)
-        self.axes_manager.set_signal_dimension(2)
+        # self.axes_manager.set_signal_dimension(2)
         self.vectors = None
         self.hkls = None
 

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -199,6 +199,7 @@ class VectorMatchingResults(BaseSignal):
 
     def plot_best_matching_results_on_signal(self, signal,
                                              library,
+                                             rank=0,
                                              permanent_markers=True,
                                              *args, **kwargs):
         """Plot the best matching diffraction vectors on a signal.
@@ -210,6 +211,8 @@ class VectorMatchingResults(BaseSignal):
             This signal must have the same navigation dimensions as the peaks.
         library : DiffractionLibrary
             Diffraction library containing the phases and rotations
+        rank : int
+            Plot results from nth best matching result (default: 0, best match)
         permanent_markers : bool
             Permanently save the peaks as markers on the signal. Default True.
         *args :

--- a/pyxem/tests/conftest.py
+++ b/pyxem/tests/conftest.py
@@ -24,6 +24,7 @@ from transforms3d.euler import euler2mat
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from diffsims.libraries.vector_library import DiffractionVectorLibrary
 
+from pyxem.utils.indexation_utils import OrientationResult
 
 @pytest.fixture
 def default_structure():
@@ -135,19 +136,17 @@ def dp_template_match_result():
 @pytest.fixture
 def sp_vector_match_result():
     # We require (total_error of row_1 > correlation row_2)
-    return np.array([
-        # [phase, R, match_rate, ehkls, total_error]
-        np.array([0, euler2mat(*np.deg2rad([0, 0, 90]), 'rzxz'), 0.5, np.array([0.1, 0.05, 0.2]), 0.1], dtype='object'),
-        np.array([0, euler2mat(*np.deg2rad([0, 0, 90]), 'rzxz'), 0.6, np.array([0.1, 0.1, 0.2]), 0.2], dtype='object')
-    ], dtype='object')
-
+    res = np.empty(2, dtype="object")
+    res[0] = OrientationResult(0, euler2mat(*np.deg2rad([0, 0, 90]), 'rzxz'), 0.5, np.array([0.1, 0.05, 0.2]), 0.1, 1.0, 0, 0)
+    res[1] = OrientationResult(0, euler2mat(*np.deg2rad([0, 0, 90]), 'rzxz'), 0.6, np.array([0.1, 0.10, 0.2]), 0.2, 1.0, 0, 0)
+    return res
+    
 
 @pytest.fixture
 def dp_vector_match_result():
-    return np.array([
-        # [phase, R, match_rate, ehkls, total_error]
-        np.array([0, euler2mat(*np.deg2rad([90, 0, 0]), 'rzxz'), 0.6, np.array([0.1, 0.1, 0.2]), 0.3], dtype='object'),
-        np.array([0, euler2mat(*np.deg2rad([0, 10, 20]), 'rzxz'), 0.5, np.array([0.1, 0.05, 0.2]), 0.4], dtype='object'),
-        np.array([1, euler2mat(*np.deg2rad([0, 45, 45]), 'rzxz'), 0.8, np.array([0.1, 0.3, 0.2]), 0.1], dtype='object'),
-        np.array([1, euler2mat(*np.deg2rad([0, 0, 90]), 'rzxz'), 0.7, np.array([0.1, 0.05, 0.1]), 0.2], dtype='object')
-    ], dtype='object')
+    res = np.empty(4, dtype="object")
+    res[0] = OrientationResult(0, euler2mat(*np.deg2rad([90, 0,  0]), 'rzxz'), 0.6, np.array([0.1, 0.10, 0.2]), 0.3, 1.0, 0, 0)
+    res[1] = OrientationResult(0, euler2mat(*np.deg2rad([0, 10, 20]), 'rzxz'), 0.5, np.array([0.1, 0.05, 0.2]), 0.4, 1.0, 0, 0)
+    res[2] = OrientationResult(1, euler2mat(*np.deg2rad([0, 45, 45]), 'rzxz'), 0.8, np.array([0.1, 0.30, 0.2]), 0.1, 1.0, 0, 0)
+    res[3] = OrientationResult(1, euler2mat(*np.deg2rad([0,  0, 90]), 'rzxz'), 0.7, np.array([0.1, 0.05, 0.1]), 0.2, 1.0, 0, 0)
+    return res

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -134,12 +134,17 @@ def test_vector_indexation_generator_index_vectors(vector_match_peaks,
         n_peaks_to_index=2,
         n_best=5)
 
+    # Values are tested directly on the match_vector in the util tests
+    assert isinstance(indexation.vectors, DiffractionVectors)
+    
+    # (n_best=1, 5 result values from each)
     np.testing.assert_equal(indexation.data.shape, (5,))
+    
     # n_best=1, 3 peaks with hkl)
     np.testing.assert_equal(indexation.hkls.shape, (1, 3, 3))
     
     refined1 = gen.refine_n_best_orientations(indexation, 1.0, 1.0, n_best=0)
-
+    
     assert isinstance(refined1.vectors, DiffractionVectors)
     np.testing.assert_equal(refined1.data.shape, (5,))
     
@@ -148,3 +153,12 @@ def test_vector_indexation_generator_index_vectors(vector_match_peaks,
     assert isinstance(refined2.vectors, DiffractionVectors)
     np.testing.assert_equal(refined2.data.shape, (1,))
     assert isinstance(refined2.data[0], OrientationResult)
+    
+    assert refined2.data[0].phase_index == indexation.data[0].phase_index
+    assert refined2.data[0].match_rate == indexation.data[0].match_rate
+
+    # Must use a large tolerance here, because there are only 3 vectors
+    np.testing.assert_almost_equal(np.diag(  refined1.data[0].rotation_matrix), 
+                                   np.diag(indexation.data[0].rotation_matrix), 1)
+    np.testing.assert_almost_equal(np.diag(  refined2.data[0].rotation_matrix), 
+                                   np.diag(indexation.data[0].rotation_matrix), 1)

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -26,6 +26,8 @@ from diffsims.libraries.vector_library import DiffractionVectorLibrary
 from diffsims.sims.diffraction_simulation import ProfileSimulation
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 
+from pyxem.utils.indexation_utils import OrientationResult
+
 
 @pytest.fixture
 def profile_simulation():
@@ -130,11 +132,19 @@ def test_vector_indexation_generator_index_vectors(vector_match_peaks,
         angle_tol=6,
         index_error_tol=0.3,
         n_peaks_to_index=2,
-        n_best=1)
+        n_best=5)
 
-    # Values are tested directly on the match_vector in the util tests
-    assert isinstance(indexation.vectors, DiffractionVectors)
-    # (n_best=1, 5 result values from each)
-    np.testing.assert_equal(indexation.data.shape, (1, 5))
+    np.testing.assert_equal(indexation.data.shape, (5,))
     # n_best=1, 3 peaks with hkl)
     np.testing.assert_equal(indexation.hkls.shape, (1, 3, 3))
+    
+    refined1 = gen.refine_n_best_orientations(indexation, 1.0, 1.0, n_best=0)
+
+    assert isinstance(refined1.vectors, DiffractionVectors)
+    np.testing.assert_equal(refined1.data.shape, (5,))
+    
+    refined2 = gen.refine_best_orientation(indexation, 1.0, 1.0)
+    
+    assert isinstance(refined2.vectors, DiffractionVectors)
+    np.testing.assert_equal(refined2.data.shape, (1,))
+    assert isinstance(refined2.data[0], OrientationResult)

--- a/pyxem/tests/test_physical/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_physical/test_orientation_mapping_phys.py
@@ -34,6 +34,7 @@ from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 from pyxem.utils.indexation_utils import peaks_from_best_template
 from pyxem.utils.indexation_utils import peaks_from_best_vector_match
+from pyxem.utils.indexation_utils import OrientationResult
 from pyxem.utils.sim_utils import sim_as_signal
 
 """
@@ -198,9 +199,10 @@ def test_generate_peaks_from_best_template(default_structure, rot_list, pattern_
 @pytest.mark.parametrize('structure, rot_list', [(create_Hex(), [(0, 0, 10), (0, 0, 0)])])
 def test_vector_matching_physical(structure, rot_list, edc):
     _, match_results = get_vector_match_results(structure, rot_list, edc)
-    assert match_results.data.shape == (2, 2, 2, 5)  # 2x2 rotations, 2 best peaks, 5 values
-    np.testing.assert_allclose(match_results.data[0, 0, 0, 2], 1.0)  # match rate for best orientation
-    np.testing.assert_allclose(match_results.data[0, 1, 0, 2], 1.0)  # match rate for best orientation
+    assert match_results.data.shape == (2, 2)  # 2x2 rotations, 2 best peaks, 5 values
+    isinstance(match_results.data[0, 0][0], OrientationResult)
+    np.testing.assert_allclose(match_results.data[0, 0][0].match_rate, 1.0)  # match rate for best orientation
+    np.testing.assert_allclose(match_results.data[0, 1][0].match_rate, 1.0)  # match rate for best orientation
 
 
 @pytest.mark.parametrize('structure, rot_list', [(create_Hex(), [(0, 0, 10), (0, 0, 0)])])

--- a/pyxem/tests/test_signals/test_indexation_results.py
+++ b/pyxem/tests/test_signals/test_indexation_results.py
@@ -38,9 +38,9 @@ def test_vector_get_crystallographic_map(dp_vector_match_result,
                                          sp_vector_match_result):
     # Assertion free test, as the tests in test_indexation_utils do the heavy
     # lifting
-    match_results = np.array([np.vstack((dp_vector_match_result, sp_vector_match_result))])
+    match_results = np.hstack([dp_vector_match_result, sp_vector_match_result])
     match_results = VectorMatchingResults(match_results)
-    match_results.axes_manager.set_signal_dimension(2)
+    match_results.axes_manager.set_signal_dimension(1)
     cryst_map = match_results.get_crystallographic_map()
     assert cryst_map.method == 'vector_matching'
 

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -82,13 +82,15 @@ def test_match_vectors(vector_match_peaks, vector_library):
         n_peaks_to_index=2,
         n_best=1)
     assert len(matches) == 1
-    np.testing.assert_allclose(matches[0][2], 1.0)  # match rate
-    np.testing.assert_allclose(matches[0][1], np.identity(3), atol=0.1)
-    np.testing.assert_allclose(matches[0][4], 0.03, atol=0.01)  # error mean
+    np.testing.assert_allclose(matches[0].match_rate, 1.0)
+    np.testing.assert_allclose(matches[0].rotation_matrix, np.identity(3), atol=0.1)
+    np.testing.assert_allclose(matches[0].total_error, 0.03, atol=0.01)
 
     np.testing.assert_allclose(rhkls[0][0], [1, 0, 0])
     np.testing.assert_allclose(rhkls[0][1], [0, 2, 0])
     np.testing.assert_allclose(rhkls[0][2], [1, 2, 3])
+
+
 
 
 def test_match_vector_total_error_default(vector_match_peaks, vector_library):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -449,7 +449,7 @@ def crystal_from_vector_matching(z_matches):
         Crystallographic mapping results in an array of shape (3) with entries
         [phase, np.array((z, x, z)), dict(metrics)]
     """
-    if z_matches.shape == (1,):
+    if z_matches.shape == (1,):  # pragma: no cover
         z_matches = z_matches[0]
 
     # Create empty array for results.

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -219,7 +219,7 @@ def match_vectors(peaks,
     n_peaks_to_index : int
         The maximum number of peak to index.
     n_best : int
-        The maximum number of good solutions to be retained.
+        The maximum number of good solutions to be retained for each phase.
 
     Returns
     -------
@@ -244,76 +244,78 @@ def match_vectors(peaks,
         phase_indices = phase['indices']
         phase_measurements = phase['measurements']
 
-        if peaks.shape[0] >= 2:
-            # Choose up to n_peaks_to_index unindexed peaks to be paired in all
-            # combinations.
-            # TODO: Matching can be done iteratively where successfully indexed
-            #       peaks are removed after each iteration. This can possibly
-            #       handle overlapping patterns.
-            # unindexed_peak_ids = range(min(peaks.shape[0], n_peaks_to_index))
-            # TODO: Better choice of peaks (longest, highest SNR?)
-            # TODO: Inline after choosing the best, and possibly require external sorting (if using sorted)?
-            unindexed_peak_ids = _choose_peak_ids(peaks, n_peaks_to_index)
+        if peaks.shape[0] < 2:
+            continue
 
-            # Find possible solutions for each pair of peaks.
-            for vector_pair_index, peak_pair_indices in enumerate(list(combinations(unindexed_peak_ids, 2))):
-                # Consider a pair of experimental scattering vectors.
-                q1, q2 = peaks[peak_pair_indices, :]
-                q1_len, q2_len = np.linalg.norm(q1), np.linalg.norm(q2)
+        # Choose up to n_peaks_to_index unindexed peaks to be paired in all
+        # combinations.
+        # TODO: Matching can be done iteratively where successfully indexed
+        #       peaks are removed after each iteration. This can possibly
+        #       handle overlapping patterns.
+        # unindexed_peak_ids = range(min(peaks.shape[0], n_peaks_to_index))
+        # TODO: Better choice of peaks (longest, highest SNR?)
+        # TODO: Inline after choosing the best, and possibly require external sorting (if using sorted)?
+        unindexed_peak_ids = _choose_peak_ids(peaks, n_peaks_to_index)
 
-                # Ensure q1 is longer than q2 for consistent order.
-                if q1_len < q2_len:
-                    q1, q2 = q2, q1
-                    q1_len, q2_len = q2_len, q1_len
+        # Find possible solutions for each pair of peaks.
+        for vector_pair_index, peak_pair_indices in enumerate(list(combinations(unindexed_peak_ids, 2))):
+            # Consider a pair of experimental scattering vectors.
+            q1, q2 = peaks[peak_pair_indices, :]
+            q1_len, q2_len = np.linalg.norm(q1), np.linalg.norm(q2)
 
-                # Calculate the angle between experimental scattering vectors.
-                angle = get_angle_cartesian(q1, q2)
+            # Ensure q1 is longer than q2 for consistent order.
+            if q1_len < q2_len:
+                q1, q2 = q2, q1
+                q1_len, q2_len = q2_len, q1_len
 
-                # Get library indices for hkls matching peaks within tolerances.
-                # TODO: phase are object arrays. Test performance of direct float arrays
-                tolerance_mask = np.abs(phase_measurements[:, 0] - q1_len) < mag_tol
-                tolerance_mask[tolerance_mask] &= np.abs(phase_measurements[tolerance_mask, 1] - q2_len) < mag_tol
-                tolerance_mask[tolerance_mask] &= np.abs(phase_measurements[tolerance_mask, 2] - angle) < angle_tol
+            # Calculate the angle between experimental scattering vectors.
+            angle = get_angle_cartesian(q1, q2)
 
-                # Iterate over matched library vectors determining the error in the
-                # associated indexation.
-                if np.count_nonzero(tolerance_mask) == 0:
-                    continue
+            # Get library indices for hkls matching peaks within tolerances.
+            # TODO: phase are object arrays. Test performance of direct float arrays
+            tolerance_mask = np.abs(phase_measurements[:, 0] - q1_len) < mag_tol
+            tolerance_mask[tolerance_mask] &= np.abs(phase_measurements[tolerance_mask, 1] - q2_len) < mag_tol
+            tolerance_mask[tolerance_mask] &= np.abs(phase_measurements[tolerance_mask, 2] - angle) < angle_tol
 
-                # Reference vectors are cartesian coordinates of hkls
-                reference_vectors = lattice_recip.cartesian(phase_indices[tolerance_mask])
+            # Iterate over matched library vectors determining the error in the
+            # associated indexation.
+            if np.count_nonzero(tolerance_mask) == 0:
+                continue
 
-                # Rotation from experimental to reference frame
-                rotations = get_rotation_matrix_between_vectors(q1, q2, reference_vectors[:, 0], reference_vectors[:, 1])
+            # Reference vectors are cartesian coordinates of hkls
+            reference_vectors = lattice_recip.cartesian(phase_indices[tolerance_mask])
 
-                # Index the peaks by rotating them to the reference coordinate
-                # system. Use rotation directly since it is multiplied from the
-                # right. Einsum gives list of peaks.dot(rotation).
-                hklss = lattice_recip.fractional(np.einsum('ijk,lk->ilj', rotations, peaks))
+            # Rotation from experimental to reference frame
+            rotations = get_rotation_matrix_between_vectors(q1, q2, reference_vectors[:, 0], reference_vectors[:, 1])
 
-                # Evaluate error of peak hkl indexation
-                rhklss = np.rint(hklss)
-                ehklss = np.abs(hklss - rhklss)
-                valid_peak_mask = np.max(ehklss, axis=-1) < index_error_tol
-                valid_peak_counts = np.count_nonzero(valid_peak_mask, axis=-1)
-                error_means = ehklss.mean(axis=(1, 2))
+            # Index the peaks by rotating them to the reference coordinate
+            # system. Use rotation directly since it is multiplied from the
+            # right. Einsum gives list of peaks.dot(rotation).
+            hklss = lattice_recip.fractional(np.einsum('ijk,lk->ilj', rotations, peaks))
 
-                num_peaks = len(peaks)
-                match_rates = (valid_peak_counts * (1 / num_peaks)) if num_peaks else 0
+            # Evaluate error of peak hkl indexation
+            rhklss = np.rint(hklss)
+            ehklss = np.abs(hklss - rhklss)
+            valid_peak_mask = np.max(ehklss, axis=-1) < index_error_tol
+            valid_peak_counts = np.count_nonzero(valid_peak_mask, axis=-1)
+            error_means = ehklss.mean(axis=(1, 2))
 
-                possible_solution_mask = match_rates > 0
-                solutions += [[
-                    R,
-                    match_rate,
-                    ehkls,  # TODO: Needed?
-                    error_mean,
-                    vector_pair_index
-                ] for R, match_rate, ehkls, error_mean in zip(
-                    rotations[possible_solution_mask],
-                    match_rates[possible_solution_mask],
-                    ehklss[possible_solution_mask],
-                    error_means[possible_solution_mask])]
-                res_rhkls += rhklss[possible_solution_mask].tolist()
+            num_peaks = len(peaks)
+            match_rates = (valid_peak_counts * (1 / num_peaks)) if num_peaks else 0
+
+            possible_solution_mask = match_rates > 0
+            solutions += [[
+                R,
+                match_rate,
+                ehkls,  # TODO: Needed?
+                error_mean,
+                vector_pair_index
+            ] for R, match_rate, ehkls, error_mean in zip(
+                rotations[possible_solution_mask],
+                match_rates[possible_solution_mask],
+                ehklss[possible_solution_mask],
+                error_means[possible_solution_mask])]
+            res_rhkls += rhklss[possible_solution_mask].tolist()
 
         n_solutions = min(n_best, len(solutions))
         if n_solutions > 0:
@@ -461,7 +463,7 @@ def crystal_from_vector_matching(z_matches):
     return results_array
 
 
-def peaks_from_best_template(single_match_result, library):
+def peaks_from_best_template(single_match_result, library, rank=0):
     """ Takes a TemplateMatchingResults object and return the associated peaks,
     to be used in combination with map().
 
@@ -471,13 +473,16 @@ def peaks_from_best_template(single_match_result, library):
         An entry in a TemplateMatchingResults.
     library : DiffractionLibrary
         Diffraction library containing the phases and rotations.
+    rank : int
+        Get peaks from nth best orientation (default: 0, best vector match)
 
     Returns
     -------
     peaks : array
         Coordinates of peaks in the matching results object in calibrated units.
     """
-    best_fit = single_match_result[np.argmax(single_match_result[:, 2])]
+    srt_idx = np.argsort(single_match_result[:, 2])[rank]
+    best_fit = single_match_result[rank]
     phase_names = list(library.keys())
     best_index = int(best_fit[0])
     phase = phase_names[best_index]
@@ -499,8 +504,8 @@ def peaks_from_best_template(single_match_result, library):
     return peaks
 
 
-def peaks_from_best_vector_match(single_match_result, library):
-    """ Takes a VectorMatchingResults object and return the associated peaks,
+def peaks_from_best_vector_match(single_match_result, library, rank=0):
+    """Takes a VectorMatchingResults object and return the associated peaks,
     to be used in combination with map().
 
     Parameters
@@ -509,13 +514,16 @@ def peaks_from_best_vector_match(single_match_result, library):
         An entry in a VectorMatchingResults
     library : DiffractionLibrary
         Diffraction library containing the phases and rotations
+    rank : int
+        Get peaks from nth best orientation (default: 0, best vector match)
 
     Returns
     -------
     peaks : ndarray
         Coordinates of peaks in the matching results object in calibrated units.
     """
-    best_fit = single_match_result[np.argmax(single_match_result[:, 2])]
+    srt_idx = np.argsort(single_match_result[:, 2])[rank]
+    best_fit = single_match_result[rank]
     best_index = best_fit[0]
 
     rotation_matrix = best_fit[1]

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ setup(
       'scikit-image >= 0.15.0',   # exclude_border argument in peak_finder laplacian (PR #436)
       'matplotlib >= 3.1.1' ,     # 3.1.0 failed
       'scikit-learn >= 0.19',     # reason unknown
-      'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
+      'hyperspy >= 1.5.2',        # earlier versions incompatible with numpy >= 1.17.0
+      'numpy >= 1.17.0',
       'diffsims',
-      'numpy == 1.16.5',          # See PR#464 and Issue#466
       'lmfit >= 0.9.12'
       ],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ setup(
       'scikit-learn >= 0.19',     # reason unknown
       'hyperspy >= 1.3',          # 1.2 fails, (NTU Workshop - May 2019)
       'diffsims',
-      'numpy == 1.16.5'           # See PR#464 and Issue#466
+      'numpy == 1.16.5',          # See PR#464 and Issue#466
+      'lmfit >= 0.9.12'
       ],
     package_data={
         "": ["LICENSE", "readme.rst",],


### PR DESCRIPTION
Implements code to do refinement of the orientations found using the vector matching routine. Continuation from #459 which became a bit messy with the commit history.

I added a basic refinement refinement routine onto the VectorIndexationGenerator, it seems like a more logical place than to have it in its own generator class. I'm using the error_mean as the minimization target, which is similar to what I used before, and works well in most cases. The downside is that it is somewhat binary, as in, the number of reflections compared depends on the value of index_error_tol, which can give unexpected results if the orientation is not stable.

I added support for refining a scaling factor and the center of the reciprocal space, which can be useful in some cases where the scale/center is ambiguous. I have implemented this using namedtuples, which are more easily extended than normal tuples. It still needs some work to make the output compatible with some of the methods on VectorMatchingResults, so they can be used with all the mapping functions in pyxem. I will also match the output of the vector matching to use the namedtuple.

Also, we need a way, imo, to store/load crystal orientations. Simply pickling the IndexationResults does not work, and results in errors.

Adds `lmfit` as a dependency.