### PR TITLE
Unrestricting our numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
       'matplotlib >= 3.1.1' ,     # 3.1.0 failed
       'scikit-learn >= 0.19',     # reason unknown
       'hyperspy >= 1.5.2',        # earlier versions incompatible with numpy >= 1.17.0
-      'numpy >= 1.17.0',
       'diffsims',
       'lmfit >= 0.9.12'
       ],


### PR DESCRIPTION
---
name: Unrestricting our numpy version
about: as `hyperspy 1.5.2` is compatible with almost all versions, also see #470 (which does something similar for `0.9.x`)

---

**Release Notes**
> developer change
> Summary: n/a
