### PR TITLE
Make hyperspy_extension.yaml part of source distribution in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
       'lmfit >= 0.9.12'
       ],
     package_data={
-        "": ["LICENSE", "readme.rst","hyperspy_extension.yaml"],
-        "pyxem": ["*.py"],
+        "": ["LICENSE", "readme.rst"],
+        "pyxem": ["*.py", "hyperspy_extension.yaml"],
     },
     entry_points={'hyperspy.extensions': ['pyxem = pyxem']},
 )


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

---
name: Make hyperspy_extension.yaml part of source distribution in setup.py
about: Ensures pyXem signals are listed when calling `hs.print_known_signal_types()`

---

**Release Notes**
> bugfix
> Summary: Make hyperspy_extension.yaml part of source distribution in setup.py

**What does this PR do? Please describe and/or link to an open issue.**
I think the `hyperspy_extension.yaml` file in the `package_data` variable in `setup.py` should be entered like this:

```python
setup(
[...]
    package_data={
        "": ["LICENSE", "readme.rst"],
        "pyxem": ["*.py", "hyperspy_extension.yaml"],
[...]
)
```

Otherwise, pip/conda will exclude it (along with other files like `LICENSE` and `readme.rst`) when installing pyXem.

When installing pyXem in a new environment, either using pip or conda, pyxem's signals are not listed when calling `hs.print_known_signal_types()`. The following, **_done outside the repo directory_**

```bash
conda create -n pxm python=3
conda activate pxm
conda install pyxem
```

followed by this, prints

```python
>>> import hyperspy.api as hs
>>> hs.print_known_signal_types()
+--------------------+---------------------+--------------------+----------+
|    signal_type     |       aliases       |     class name     | package  |
+--------------------+---------------------+--------------------+----------+
| DielectricFunction | dielectric function | DielectricFunction | hyperspy |
|      EDS_SEM       |                     |   EDSSEMSpectrum   | hyperspy |
|      EDS_TEM       |                     |   EDSTEMSpectrum   | hyperspy |
|        EELS        |       TEM EELS      |    EELSSpectrum    | hyperspy |
|      hologram      |                     |   HologramImage    | hyperspy |
+--------------------+---------------------+--------------------+----------+
```

Note that all pyXem signals _are_ listed in the above table if the Python commands are run in the repo directory with the `pyxem/hyperspy_extension.yaml` available.

**Additional context**
I don't know how to test if the yaml file is included in the source distribution when doing this change, although the Python documentation (https://docs.python.org/3/distutils/setupscript.html#installing-package-data) and this answer (https://stackoverflow.com/questions/29036937/how-can-i-include-package-data-without-a-manifest-in-file) indicates this.