### PR TITLE
Subpixelrefinement.conventional_xc bugfix for x,y error (see #490)

### DIFF
--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -23,8 +23,6 @@ from pyxem.generators.subpixelrefinement_generator import SubpixelrefinementGene
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from skimage import draw
-from numpy import array, pad
-import pyxem as pxm
 
 
 def create_spot():
@@ -148,8 +146,8 @@ def test_xy_errors_in_conventional_xc_method_as_per_issue_490():
     dp = get_simulated_disc(100,20)
     # translate y by +4
     shifted = np.pad(dp, ((0,4),(0,0)), 'constant')[4:].reshape(1,1,*dp.shape)
-    signal = pxm.ElectronDiffraction2D(shifted)
-    spg = SubpixelrefinementGenerator(signal, array([[0,0]]))
+    signal = ElectronDiffraction2D(shifted)
+    spg = SubpixelrefinementGenerator(signal, np.array([[0,0]]))
     peaks = spg.conventional_xc(100,20,1).data[0,0,0] #as quoted in the issue
     np.testing.assert_allclose([0,-4],peaks)
     """ we also test com method for clarity """

--- a/pyxem/tests/test_utils/test_subpixel_utils.py
+++ b/pyxem/tests/test_utils/test_subpixel_utils.py
@@ -22,7 +22,6 @@ import numpy as np
 from pyxem.utils.subpixel_refinements_utils import get_experimental_square
 from pyxem.utils.subpixel_refinements_utils import get_simulated_disc
 
-from skimage.transform import rescale
 from skimage import draw
 
 
@@ -36,15 +35,15 @@ def exp_disc():
     return arr
 
 @pytest.mark.filterwarnings('ignore::UserWarning')  # various skimage warnings
-def test_get_experimental_square(exp_disc):
+def test_experimental_square_size(exp_disc):
     square = get_experimental_square(exp_disc, [17, 19], 6)
     assert square.shape[0] == int(6)
     assert square.shape[1] == int(6)
 
 @pytest.mark.xfail(strict=True)
-def test_non_even_errors_get_simulated_disc():
+def test_failure_for_non_even_entry_to_get_simulated_disc():
     disc = get_simulated_disc(61, 5)
 
 @pytest.mark.xfail(strict=True)
-def test_non_even_errors_get_experimental_errors(exp_disc):
+def test_failure_for_non_even_errors_get_experimental_square(exp_disc):
     square = get_experimental_square(exp_disc, [17, 19], 7)

--- a/pyxem/tests/test_utils/test_subpixel_utils.py
+++ b/pyxem/tests/test_utils/test_subpixel_utils.py
@@ -19,7 +19,6 @@
 import pytest
 import numpy as np
 
-from pyxem.utils.subpixel_refinements_utils import _conventional_xc
 from pyxem.utils.subpixel_refinements_utils import get_experimental_square
 from pyxem.utils.subpixel_refinements_utils import get_simulated_disc
 
@@ -36,37 +35,15 @@ def exp_disc():
     arr[rr, cc] = 1
     return arr
 
-
-@pytest.fixture()
-def sim_disc():
-    return get_simulated_disc(60, 5)
-
-
-@pytest.fixture()
-def upsample_factor():
-    return int(10)
-
-
-@pytest.mark.filterwarnings('ignore::UserWarning')  # various skimage warnings
-def test___conventional_xc(exp_disc, sim_disc, upsample_factor):
-    # this work (and measures) on the upsampled versions of the images
-    s = _conventional_xc(exp_disc, sim_disc, upsample_factor)
-    error = np.subtract(s, np.asarray([20, -10]))
-    rms = np.sqrt(error[0]**2 + error[1]**2)
-    assert rms < 1  # which corresponds to a 10th of a pixel
-
-
 @pytest.mark.filterwarnings('ignore::UserWarning')  # various skimage warnings
 def test_get_experimental_square(exp_disc):
     square = get_experimental_square(exp_disc, [17, 19], 6)
     assert square.shape[0] == int(6)
     assert square.shape[1] == int(6)
 
-
 @pytest.mark.xfail(strict=True)
 def test_non_even_errors_get_simulated_disc():
     disc = get_simulated_disc(61, 5)
-
 
 @pytest.mark.xfail(strict=True)
 def test_non_even_errors_get_experimental_errors(exp_disc):

--- a/pyxem/utils/subpixel_refinements_utils.py
+++ b/pyxem/utils/subpixel_refinements_utils.py
@@ -104,4 +104,5 @@ def _conventional_xc(exp_disc, sim_disc, upsample_factor):
     """
 
     shifts, error, _ = register_translation(exp_disc, sim_disc, upsample_factor)
+    shifts = np.flip(shifts) #to comply with hyperspy conventions - see issue#490
     return shifts


### PR DESCRIPTION
---
name: Subpixelrefinement.conventional_xc bugfix for x,y error (see #490)
about: Details in the issue.

---

**Release Notes**
>  bugfix
> Summary: .conventional_xc method of subpixelrefinement now has the correct (x,y) return.