### PR TITLE
Removing inplane rotations and style improvements to template matching

### DIFF
--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -71,9 +71,6 @@ class IndexationGenerator():
 
         Parameters
         ----------
-        method : 'pNCC'
-            The method for comparing template and pattern, currently on partially
-            normalised cross correlation ('pNCC') is avaliable.
         n_largest : int
             The n orientations with the highest correlation values are returned.
         mask : Array

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -62,7 +62,6 @@ class IndexationGenerator():
         self.library = diffraction_library
 
     def correlate(self,
-                  method='pNCC',
                   n_largest=5,
                   mask=None,
                   *args,
@@ -99,7 +98,9 @@ class IndexationGenerator():
             # Index at all real space pixels
             mask = 1
 
-        if method == 'pNCC':
+        #TODO: Add extra methods
+        no_extra_methods_yet = True
+        if no_extra_methods_yet:
             #adds a normalisation to library
             for phase in library.keys():
                 norm_array = np.ones(library[phase]['intensities'].shape[0]) #will store the norms

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -34,13 +34,6 @@ from pyxem import CrystallographicMap
 class TemplateMatchingResults(BaseSignal):
     """Template matching results containing the top n best matching crystal
     phase and orientation at each navigation position with associated metrics.
-
-    Attributes
-    ----------
-    vectors : DiffractionVectors
-        Diffraction vectors indexed.
-    hkls : BaseSignal
-        Miller indices associated with each diffraction vector.
     """
 
     _signal_type = "template_matching"

--- a/pyxem/tests/test_physical/test_orientation_mapping_nonphys.py
+++ b/pyxem/tests/test_physical/test_orientation_mapping_nonphys.py
@@ -71,7 +71,7 @@ def create_library():
 dp, library = create_library()
 
 indexer = IndexationGenerator(dp, library)
-match_results = indexer.correlate(inplane_rotations=[0])
+match_results = indexer.correlate()
 
 
 def test_match_results():

--- a/pyxem/tests/test_physical/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_physical/test_orientation_mapping_phys.py
@@ -171,15 +171,6 @@ def test_masked_OM(default_structure, rot_list, pattern_list, edc):
 def expected_best_peaks_pattern_list(library, _):
     return library.get_library_entry("A", (0, 0, 0))['Sim'].coordinates[:, :2]
 
-
-def expected_best_peaks_rotated(library, rotation_euler):
-    angle = np.deg2rad(rotation_euler[0][2])
-    rotation = np.array([
-        [np.cos(angle), np.sin(angle)],
-        [-np.sin(angle), np.cos(angle)]])
-    coords = library.get_library_entry("A", (0, 0, 0))['Sim'].coordinates[:, :2]
-    return (rotation @ coords.T).T
-
 @pytest.mark.parametrize('structure, rot_list', [(create_Hex(), [(0, 0, 10), (0, 0, 0)])])
 def test_vector_matching_physical(structure, rot_list, edc):
     _, match_results = get_vector_match_results(structure, rot_list, edc)

--- a/pyxem/tests/test_physical/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_physical/test_orientation_mapping_phys.py
@@ -167,10 +167,6 @@ def test_masked_OM(default_structure, rot_list, pattern_list, edc):
     M = get_template_match_results(default_structure, pattern_list, edc, rot_list, mask)
     assert np.all(np.equal(M.inav[0, 1].data, None))
 
-
-def expected_best_peaks_pattern_list(library, _):
-    return library.get_library_entry("A", (0, 0, 0))['Sim'].coordinates[:, :2]
-
 @pytest.mark.parametrize('structure, rot_list', [(create_Hex(), [(0, 0, 10), (0, 0, 0)])])
 def test_vector_matching_physical(structure, rot_list, edc):
     _, match_results = get_vector_match_results(structure, rot_list, edc)

--- a/pyxem/tests/test_physical/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_physical/test_orientation_mapping_phys.py
@@ -121,14 +121,14 @@ def get_template_library(structure, rot_list, edc):
     return library
 
 
-def get_template_match_results(structure, pattern_list, edc, rot_list, mask=None, inplane_rotations=[0]):
+def get_template_match_results(structure, pattern_list, edc, rot_list, mask=None):
     dp_library = get_template_library(structure, pattern_list, edc)
     for sim in dp_library['A']['simulations']:
         pattern = (sim_as_signal(sim, 2 * half_side_length, 0.025, 1).data)
     dp = pxm.ElectronDiffraction2D([[pattern, pattern], [pattern, pattern]])
     library = get_template_library(structure, rot_list, edc)
     indexer = IndexationGenerator(dp, library)
-    return indexer.correlate(mask=mask, inplane_rotations=inplane_rotations)
+    return indexer.correlate(mask=mask)
 
 
 def get_vector_match_results(structure, rot_list, edc):

--- a/pyxem/tests/test_physical/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_physical/test_orientation_mapping_phys.py
@@ -180,22 +180,6 @@ def expected_best_peaks_rotated(library, rotation_euler):
     coords = library.get_library_entry("A", (0, 0, 0))['Sim'].coordinates[:, :2]
     return (rotation @ coords.T).T
 
-
-@pytest.mark.parametrize('pattern_list, inplane_rotations, get_expected_peaks', [
-    ([(0, 0, 2)], [0], expected_best_peaks_pattern_list),
-    ([(0, 0, 45)], np.arange(0, 360, 1), expected_best_peaks_rotated),
-])
-def test_generate_peaks_from_best_template(default_structure, rot_list, pattern_list, edc, get_expected_peaks, inplane_rotations):
-    library = get_template_library(default_structure, rot_list, edc)
-    M = get_template_match_results(default_structure, pattern_list, edc, rot_list, inplane_rotations=inplane_rotations)
-    peaks = M.map(peaks_from_best_template,
-                  library=library,
-                  inplace=False)
-    expected_peaks = get_expected_peaks(library, pattern_list)
-    for expected_peak in expected_peaks:
-        assert np.any(np.isclose(np.linalg.norm(peaks.inav[0, 0] - expected_peak, axis=1), 0, atol=0.03))
-
-
 @pytest.mark.parametrize('structure, rot_list', [(create_Hex(), [(0, 0, 10), (0, 0, 0)])])
 def test_vector_matching_physical(structure, rot_list, edc):
     _, match_results = get_vector_match_results(structure, rot_list, edc)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -106,16 +106,17 @@ def correlate_library(image, library, n_largest, mask):
 
             or_saved,corr_saved = np.empty((n_largest,3)),np.zeros((n_largest,1))
             for (or_local,px_local,int_local,pn_local) in zip_for_locals:
-                # Extract experimental intensities from the diffraction image
-                image_intensities = image[px_local[:, 1], px_local[:, 0]]
-                # Correlation is the normalized dot product
-                corr_local = np.sum(np.multiply(image_intensities,int_local)) / pn_local
+                #TODO: Factorise out the generation of corr_local to a method='mthd' section
+                image_intensities = image[px_local[:, 1], px_local[:, 0]]     # Extract experimental intensities from the diffraction image
+                corr_local = np.sum(np.multiply(image_intensities,int_local)) / pn_local # Correlation is the partially normalized dot product
+
                 if corr_local > np.min(corr_saved):
                     or_saved[np.argmin(corr_saved)] = or_local
                     corr_saved[np.argmin(corr_saved)] = corr_local
 
+                #TODO: Tidy this up so that it returns in the same style as the vector matching.
                 top_matches[phase_index] = np.concatenate((np.ones_like(corr_saved)*phase_index,np.asarray(or_saved),corr_saved),axis=1)
-                #sort them now
+                #TODO: This includes sorting the results within any given phase
     return top_matches
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -513,19 +513,9 @@ def peaks_from_best_template(single_match_result, library, rank=0):
     phase_names = list(library.keys())
     phase_index = int(best_fit[0])
     phase = phase_names[phase_index]
-    try:
-        simulation = library.get_library_entry(
-            phase=phase,
-            angle=tuple(best_fit[1]))['Sim']
-    except ValueError:
-        structure = library.structures[phase_index]
-        rotation_matrix = euler2mat(*np.deg2rad(best_fit[1]), 'rzxz')
-        simulation = simulate_rotated_structure(
-            library.diffraction_generator,
-            structure,
-            rotation_matrix,
-            library.reciprocal_radius,
-            library.with_direct_beam)
+    simulation = library.get_library_entry(
+                            phase=phase,
+                            angle=tuple(best_fit[1]))['Sim']
 
     peaks = simulation.coordinates[:, :2]  # cut z
     return peaks

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -117,6 +117,8 @@ def correlate_library(image, library, n_largest, mask):
                 #TODO: Tidy this up so that it returns in the same style as the vector matching.
                 combined_array = np.hstack((or_saved,corr_saved))
                 combined_array = combined_array[np.flip(combined_array[:,3].argsort())] #see stackoverflow/2828059 for details
+                top_matches[phase_index,:,0] = phase_index
+                top_matches[phase_index,:,2] = combined_array[:,3]  #correlation
     return top_matches
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -115,7 +115,6 @@ def correlate_library(image, library, n_largest, mask):
                     corr_saved[np.argmin(corr_saved)] = corr_local
 
                 #TODO: Tidy this up so that it returns in the same style as the vector matching.
-                top_matches[phase_index] = np.concatenate((np.ones_like(corr_saved)*phase_index,np.asarray(or_saved),corr_saved),axis=1)
                 #TODO: This includes sorting the results within any given phase
     return top_matches
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -115,7 +115,8 @@ def correlate_library(image, library, n_largest, mask):
                     corr_saved[np.argmin(corr_saved)] = corr_local
 
                 #TODO: Tidy this up so that it returns in the same style as the vector matching.
-                #TODO: This includes sorting the results within any given phase
+                combined_array = np.hstack((or_saved,corr_saved))
+                combined_array = combined_array[np.flip(combined_array[:,3].argsort())] #see stackoverflow/2828059 for details
     return top_matches
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -114,11 +114,13 @@ def correlate_library(image, library, n_largest, mask):
                     or_saved[np.argmin(corr_saved)] = or_local
                     corr_saved[np.argmin(corr_saved)] = corr_local
 
-                #TODO: Tidy this up so that it returns in the same style as the vector matching.
                 combined_array = np.hstack((or_saved,corr_saved))
                 combined_array = combined_array[np.flip(combined_array[:,3].argsort())] #see stackoverflow/2828059 for details
                 top_matches[phase_index,:,0] = phase_index
                 top_matches[phase_index,:,2] = combined_array[:,3]  #correlation
+                for i in np.arange(n_largest):
+                    top_matches[phase_index,i,1] = combined_array[i,:3] #orientation
+
     return top_matches
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -100,7 +100,7 @@ def correlate_library(image, library, n_largest, mask):
             orientations = library_entry['orientations']
             pixel_coords = library_entry['pixel_coords']
             intensities = library_entry['intensities']
-            pattern_norms = library_entry['pattern_norms']
+            pattern_norms = library_entry['pattern_norms'] #TODO: This is only applicable some of the time, probably use an if + special_local in the for
 
             zip_for_locals = zip(orientations,pixel_coords,intensities,pattern_norms)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -121,7 +121,7 @@ def correlate_library(image, library, n_largest, mask):
                 for i in np.arange(n_largest):
                     top_matches[phase_index,i,1] = combined_array[i,:3] #orientation
 
-    return top_matches
+    return top_matches.reshape(-1, 3)
 
 
 def index_magnitudes(z, simulation, tolerance):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -93,7 +93,7 @@ def correlate_library(image, library, n_largest, mask):
     E. F. Rauch and L. Dupuy, “Rapid Diffraction Patterns identification through
        template matching,” vol. 50, no. 1, pp. 87–99, 2005.
     """
-    top_matches = np.empty((len(library), n_largest, 5), dtype='object')
+    top_matches = np.empty((len(library), n_largest, 3), dtype='object')
 
     if mask == 1:
         for phase_index, library_entry in enumerate(library.values()):


### PR DESCRIPTION
---
name: Removing inplane rotations and style improvements to template matching
about: See also #489 

---

**Release Notes**
> improvement
> Summary: inplane_rotations argument for indexation generation is now deprecated

**What does this PR do? Please describe and/or link to an open issue.**
Refactors our template matching towards a more modular approach, in part motivated by `orix `as a far better way of generating specific types of rotations lists, and partly by the bug described in #489 

**Describe alternatives you've considered**
I've left a couple of TODO's in, I think I'm going to run with this single change for `0.10.0` and then have a fairly large (internal) overhaul for `0.11.0`

**Are there any known issues? Do you need help?**
It's missing some coverage right now, but I'll let coveralls pick up where that is and get to it.
