### PR TITLE
reference_xc sub-pixel refinement method

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -130,17 +130,17 @@ class SubpixelrefinementGenerator():
         self.last_method = "conventional_xc"
         return self.vectors_out
 
-    def reference_xc(self, reference_dp, square_size, upsample_factor):
+    def reference_xc(self, square_size, reference_dp, upsample_factor):
         """Refines the peaks using (phase) cross correlation with a reference
         diffraction image.
 
         Parameters
         ----------
-        reference_dp: ndarray
-            Same shape as a single diffraction image
         square_size : int
             Length (in pixels) of one side of a square the contains the peak to
             be refined.
+        reference_dp: ndarray
+            Same shape as a single diffraction image
         upsample_factor: int
             Factor by which to upsample the patterns
 

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -130,6 +130,46 @@ class SubpixelrefinementGenerator():
         self.last_method = "conventional_xc"
         return self.vectors_out
 
+    def reference_xc(self, reference_dp, square_size, upsample_factor):
+        """Refines the peaks using (phase) cross correlation with a reference
+        diffraction image.
+
+        Parameters
+        ----------
+        reference_dp: ndarray
+            Same shape as a single diffraction image
+        square_size : int
+            Length (in pixels) of one side of a square the contains the peak to
+            be refined.
+        upsample_factor: int
+            Factor by which to upsample the patterns
+
+        Returns
+        -------
+        vector_out: DiffractionVectors
+            DiffractionVectors containing the refined vectors in calibrated
+            units with the same navigation shape as the diffraction patterns.
+
+        """
+        def _reference_xc_map(dp, vectors, upsample_factor, center, calibration):
+            shifts = np.zeros_like(vectors, dtype=np.float64)
+            for i, vector in enumerate(vectors):
+                ref_disc = get_experimental_square(reference_dp, vector, square_size)
+                expt_disc = get_experimental_square(dp, vector, square_size)
+                shifts[i] = _conventional_xc(expt_disc, ref_disc, upsample_factor)
+            return (((vectors + shifts) - center) * calibration)
+
+        self.vectors_out = DiffractionVectors(
+            self.dp.map(_reference_xc_map,
+                        vectors=self.vector_pixels,
+                        upsample_factor=upsample_factor,
+                        center=self.center,
+                        calibration=self.calibration,
+                        inplace=False))
+        self.vectors_out.axes_manager.set_signal_dimension(0)
+        self.last_method = "reference_xc"
+        return self.vectors_out
+
     def center_of_mass_method(self, square_size):
         """Find the subpixel refinement of a peak by assuming it lies at the
         center of intensity.

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -152,3 +152,6 @@ def test_xy_errors_in_conventional_xc_method_as_per_issue_490():
     """ we also test com method for clarity """
     peaks = spg.center_of_mass_method(60).data[0,0,0]
     np.testing.assert_allclose([0,-4],peaks,atol=1.5)
+    """ we also test reference_xc """
+    peaks = spg.reference_xc(100,dp,1).data[0,0,0] #as quoted in the issue
+    np.testing.assert_allclose([0,-4],peaks)


### PR DESCRIPTION
This PR covers the implementation and testing of a new sub-pixel refinement generator called 'reference_xc'.

The current conventional_xc method computes the centre of a spot on the diffraction pattern by registering each spot with a flat disc of given radius. reference_xc instead registers each spot with a copy on a template diffraction pattern.

The implementation appears to work as expected in my own project so hopefully this is relatively complete however I feel there are a couple of things left to address.
- [  ] Start simple, is there a commonly excepted name for this method rather than my own?
- [  ] At the moment you can only use a single template to register every diffraction vector. I believe the default behaviour of SubpixelrefinementGenerator is that an array input applies the same vectors to each diffraction pattern but a DiffractionVectors input provides one set of diffraction vectors per navigation index. Should something similar happen here? If so, then should it be one template per tilt angle or similarly one template per navigation index?
- [  ] Once the above is decided we should update the tests to implement this in the first set of tests