### PR TITLE
Changed wording for parameter square_width to half_square_width.

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -477,7 +477,7 @@ class Diffraction2D(Signal2D):
 
     def center_direct_beam(self,
                            method,
-                           square_width=None,
+                           half_square_width=None,
                            return_shifts=False,
                            *args, **kwargs):
         """Estimate the direct beam position in each experimentally acquired
@@ -488,7 +488,7 @@ class Diffraction2D(Signal2D):
         ----------
         method : str,
             Must be one of 'cross_correlate', 'blur', 'interpolate'
-        square_width  : int
+        half_square_width  : int
             Half the side length of square that captures the direct beam in all
             scans. Means that the centering algorithm is stable against
             diffracted spots brighter than the direct beam.
@@ -507,10 +507,10 @@ class Diffraction2D(Signal2D):
         signal_shape = self.axes_manager.signal_shape
         origin_coordinates = np.array(signal_shape) / 2
 
-        if square_width is not None:
-            min_index = np.int(origin_coordinates[0] - square_width)
+        if half_square_width is not None:
+            min_index = np.int(origin_coordinates[0] - half_square_width)
             # fails if non-square dp
-            max_index = np.int(origin_coordinates[0] + square_width)
+            max_index = np.int(origin_coordinates[0] + half_square_width)
             cropped = self.isig[min_index:max_index, min_index:max_index]
             shifts = cropped.get_direct_beam_position(method=method, **kwargs)
         else:

--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -54,7 +54,7 @@ class TestSimpleMaps:
     def test_center_direct_beam_blur_return_shifts(self, diffraction_pattern):
         shifts = diffraction_pattern.center_direct_beam(method='blur',
                                                         sigma=5,
-                                                        square_width=3,
+                                                        half_square_width=3,
                                                         return_shifts=True)
         ans = np.array([[-1., -1.],
                         [-0., -0.],
@@ -66,7 +66,7 @@ class TestSimpleMaps:
         assert isinstance(diffraction_pattern, ElectronDiffraction2D)
         diffraction_pattern.center_direct_beam(method='blur',
                                                sigma=5,
-                                               square_width=3)
+                                               half_square_width=3)
         assert isinstance(diffraction_pattern, ElectronDiffraction2D)
 
     def test_apply_affine_transformation(self, diffraction_pattern):


### PR DESCRIPTION
Changed wording for parameter square_width to half_square_width.

The parameter square_width in center_direct_beam referred to half the square width and may lead to the user doubling the argument, hence leading to bad centering.

The attached picture shows an example of the problem. 
The square width is 12 px as can be seen in the picture, however what the program in fact asks for is half the square width, namely 6 px.

[Center_direct_beam.pdf](https://github.com/pyxem/pyxem/files/4098123/Center_direct_beam.pdf)
