### PR TITLE
Making calls to peakfinders using an integer for num_sigma ~ (fixing the travis)

### DIFF
--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -65,7 +65,7 @@ class TestSimpleMaps:
     def test_center_direct_beam_in_small_region(self, diffraction_pattern):
         assert isinstance(diffraction_pattern, ElectronDiffraction2D)
         diffraction_pattern.center_direct_beam(method='blur',
-                                               sigma=5,
+                                               sigma=int(5),
                                                square_width=3)
         assert isinstance(diffraction_pattern, ElectronDiffraction2D)
 

--- a/pyxem/utils/peakfinders2D.py
+++ b/pyxem/utils/peakfinders2D.py
@@ -299,7 +299,7 @@ def find_peaks_dog(z, min_sigma=1., max_sigma=50., sigma_ratio=1.6,
     return centers
 
 
-def find_peaks_log(z, min_sigma=1., max_sigma=50., num_sigma=10.,
+def find_peaks_log(z, min_sigma=1., max_sigma=50., num_sigma=int(10),
                    threshold=0.2, overlap=0.5, log_scale=False, exclude_border=False):
     """
     Finds peaks via the Laplacian of Gaussian Matrices method from


### PR DESCRIPTION
---
name: Making calls to peakfinders using an integer for num_sigma ~ (fixing the travis)
about: Addresses #533, in future we will limit ourselves to patch release skimages that correct this (I'll write it in if needs be)

---

**Release Notes**
> developer change
> Summary: Code keeping compliance with new versions of dependencies.
