### PR TITLE
- peaks from best vector match - To deal with removed diffsims function

### DIFF
--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -546,7 +546,7 @@ def peaks_from_best_vector_match(single_match_result, library, rank=0):
     rotation_orientation = mat2euler(best_fit.rotation_matrix)
     # Don't change the original
     structure = library.structures[phase_index]
-    sim = calculate_ed_data(structure,
+    sim = library.diffraction_generator.calculate_ed_data(structure,
                             reciprocal_radius = library.reciprocal_radius,
                             rotation=rotation_orientation,
                             with_direct_beam=False)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -24,8 +24,6 @@ from operator import itemgetter, attrgetter
 
 import numpy as np
 
-from diffsims.utils.sim_utils import simulate_rotated_structure
-
 from pyxem.utils.expt_utils import _cart2polar
 from pyxem.utils.vector_utils import get_rotation_matrix_between_vectors
 from pyxem.utils.vector_utils import get_angle_cartesian
@@ -545,15 +543,13 @@ def peaks_from_best_vector_match(single_match_result, library, rank=0):
     best_fit = get_nth_best_solution(single_match_result, rank=rank)
     phase_index = best_fit.phase_index
 
-    rotation_matrix = best_fit.rotation_matrix
+    rotation_orientation = mat2euler(best_fit.rotation_matrix)
     # Don't change the original
     structure = library.structures[phase_index]
-    sim = simulate_rotated_structure(
-        library.diffraction_generator,
-        structure,
-        rotation_matrix,
-        library.reciprocal_radius,
-        with_direct_beam=False)
+    sim = calculate_ed_data(structure,
+                            reciprocal_radius = library.reciprocal_radius,
+                            rotation=rotation_orientation,
+                            with_direct_beam=False)
 
     # Cut z
     return sim.coordinates[:, :2]

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'matplotlib >= 3.1.1',     # 3.1.0 failed
         'scikit-learn >= 0.19',     # reason unknown
         'hyperspy >= 1.5.2',        # earlier versions incompatible with numpy >= 1.17.0
-        'diffsims' >= 0.2.0,        # Makes use of functionality introduced in this release
+        'diffsims > 0.1.5',        # Makes use of functionality introduced in this release
         'lmfit >= 0.9.12',
         'pyfai'
     ],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'matplotlib >= 3.1.1',     # 3.1.0 failed
         'scikit-learn >= 0.19',     # reason unknown
         'hyperspy >= 1.5.2',        # earlier versions incompatible with numpy >= 1.17.0
-        'diffsims',
+        'diffsims' >= 0.2.0,        # Makes use of functionality introduced in this release
         'lmfit >= 0.9.12',
         'pyfai'
     ],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'matplotlib >= 3.1.1',     # 3.1.0 failed
         'scikit-learn >= 0.19',     # reason unknown
         'hyperspy >= 1.5.2',        # earlier versions incompatible with numpy >= 1.17.0
-        'diffsims > 0.1.5',        # Makes use of functionality introduced in this release
+        'diffsims > 0.2.1',        # Makes use of functionality introduced in this release
         'lmfit >= 0.9.12',
         'pyfai'
     ],


### PR DESCRIPTION
Function simulate_rotated_structure was removed and integrated to calculate_ed_data. The aim of this bugfix is to make changes for the function peaks_from_best_vector_match to deal with the diffsims changes. The changes are described in Diffsims Bugfix #60 (Note: The hyperlink is not the correct bugfix, see diffsims "#" 60) 

---
name: - peaks from best vector match - To deal with removed diffsims function
about: A pull request that fixes a bug

---

**Release Notes**
> bugfix / developer change
> Summary: Replaced simulate_rotated_structure with calculate_ed_data

**What does this PR do? Please describe and/or link to an open issue.**
This bugfix intends to keep peaks from best vector match working without the dependency of the removed function simulate_rotated_structure. 

This is done as a response to a Diffsims bugfix "Fix simulations of rotated structure #60".  

The use of the function is still the same, but the output will have changed as the bug in simulate_rotated_structure is removed. 

