### PR TITLE
Remove import statement  / functions commented out

### DIFF
--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -23,7 +23,8 @@ from warnings import warn
 
 from pyxem.signals import push_metadata_through, transfer_navigation_axes
 from pyxem.utils.indexation_utils import peaks_from_best_template
-from pyxem.utils.indexation_utils import peaks_from_best_vector_match
+# TODO Fix peaks_from_best_vector_match
+# from pyxem.utils.indexation_utils import peaks_from_best_vector_match
 from pyxem.utils.indexation_utils import crystal_from_template_matching
 from pyxem.utils.indexation_utils import crystal_from_vector_matching
 from pyxem.utils.plot import generate_marker_inputs_from_peaks
@@ -190,34 +191,37 @@ class VectorMatchingResults(BaseSignal):
 
         return vectors
 
-    def plot_best_matching_results_on_signal(self, signal,
-                                             library,
-                                             rank=0,
-                                             permanent_markers=True,
-                                             *args, **kwargs):
-        """Plot the best matching diffraction vectors on a signal.
-
-        Parameters
-        ----------
-        signal : ElectronDiffraction2D
-            The ElectronDiffraction2D signal object on which to plot the peaks.
-            This signal must have the same navigation dimensions as the peaks.
-        library : DiffractionLibrary
-            Diffraction library containing the phases and rotations
-        rank : int
-            Plot results from nth best matching result (default: 0, best match)
-        permanent_markers : bool
-            Permanently save the peaks as markers on the signal. Default True.
-        *args :
-            Arguments passed to signal.plot()
-        **kwargs :
-            Keyword arguments passed to signal.plot()
-        """
-        match_peaks = self.map(peaks_from_best_vector_match,
-                               library=library,
-                               inplace=False)
-        mmx, mmy = generate_marker_inputs_from_peaks(match_peaks)
-        signal.plot(*args, **kwargs)
-        for mx, my in zip(mmx, mmy):
-            m = hs.markers.point(x=mx, y=my, color='red', marker='x')
-            signal.add_marker(m, plot_marker=True, permanent=permanent_markers)
+# TODO peaks_from_best_vector_match is  dependant on
+# simulate_rotated_structure which was removed in PR #60
+#
+#    def plot_best_matching_results_on_signal(self, signal,
+#                                             library,
+#                                             rank=0,
+#                                             permanent_markers=True,
+#                                             *args, **kwargs):
+#        """Plot the best matching diffraction vectors on a signal.
+#
+#        Parameters
+#        ----------
+#        signal : ElectronDiffraction2D
+#            The ElectronDiffraction2D signal object on which to plot the peaks.
+#            This signal must have the same navigation dimensions as the peaks.
+#        library : DiffractionLibrary
+#            Diffraction library containing the phases and rotations
+#        rank : int
+#            Plot results from nth best matching result (default: 0, best match)
+#        permanent_markers : bool
+#            Permanently save the peaks as markers on the signal. Default True.
+#        *args :
+#            Arguments passed to signal.plot()
+#        **kwargs :
+#            Keyword arguments passed to signal.plot()
+#        """
+#        match_peaks = self.map(peaks_from_best_vector_match,
+#                               library=library,
+#                               inplace=False)
+#        mmx, mmy = generate_marker_inputs_from_peaks(match_peaks)
+#        signal.plot(*args, **kwargs)
+#        for mx, my in zip(mmx, mmy):
+#            m = hs.markers.point(x=mx, y=my, color='red', marker='x')
+#            signal.add_marker(m, plot_marker=True, permanent=permanent_markers)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -24,8 +24,6 @@ from operator import itemgetter, attrgetter
 
 import numpy as np
 
-from diffsims.utils.sim_utils import simulate_rotated_structure
-
 from pyxem.utils.expt_utils import _cart2polar
 from pyxem.utils.vector_utils import get_rotation_matrix_between_vectors
 from pyxem.utils.vector_utils import get_angle_cartesian
@@ -523,37 +521,37 @@ def peaks_from_best_template(single_match_result, library, rank=0):
     peaks = simulation.coordinates[:, :2]  # cut z
     return peaks
 
-
-def peaks_from_best_vector_match(single_match_result, library, rank=0):
-    """Takes a VectorMatchingResults object and return the associated peaks,
-    to be used in combination with map().
-
-    Parameters
-    ----------
-    single_match_result : ndarray
-        An entry in a VectorMatchingResults
-    library : DiffractionLibrary
-        Diffraction library containing the phases and rotations
-    rank : int
-        Get peaks from nth best orientation (default: 0, best vector match)
-
-    Returns
-    -------
-    peaks : ndarray
-        Coordinates of peaks in the matching results object in calibrated units.
-    """
-    best_fit = get_nth_best_solution(single_match_result, rank=rank)
-    phase_index = best_fit.phase_index
-
-    rotation_matrix = best_fit.rotation_matrix
-    # Don't change the original
-    structure = library.structures[phase_index]
-    sim = simulate_rotated_structure(
-        library.diffraction_generator,
-        structure,
-        rotation_matrix,
-        library.reciprocal_radius,
-        with_direct_beam=False)
-
-    # Cut z
-    return sim.coordinates[:, :2]
+# TODO simulate_rotated_structure was removed in PR #60. This function does thus not work.
+#def peaks_from_best_vector_match(single_match_result, library, rank=0):
+#    """Takes a VectorMatchingResults object and return the associated peaks,
+#    to be used in combination with map().
+#
+#    Parameters
+#    ----------
+#    single_match_result : ndarray
+#        An entry in a VectorMatchingResults
+#    library : DiffractionLibrary
+#        Diffraction library containing the phases and rotations
+#    rank : int
+#        Get peaks from nth best orientation (default: 0, best vector match)
+#
+#    Returns
+#    -------
+#    peaks : ndarray
+#        Coordinates of peaks in the matching results object in calibrated units.
+#    """
+#    best_fit = get_nth_best_solution(single_match_result, rank=rank)
+#    phase_index = best_fit.phase_index
+#
+#    rotation_matrix = best_fit.rotation_matrix
+#    # Don't change the original
+#    structure = library.structures[phase_index]
+#    sim = simulate_rotated_structure(
+#        library.diffraction_generator,
+#        structure,
+#        rotation_matrix,
+#        library.reciprocal_radius,
+#        with_direct_beam=False)
+#
+#    # Cut z
+#    return sim.coordinates[:, :2]


### PR DESCRIPTION
---
Remove import statement  / functions commented out
---
Bugfix: Broken import statement


**Release Notes**


**What does this PR do? Please describe and/or link to an open issue.**
Removes a import statement as discussed in https://github.com/pyxem/diffsims/pull/60
I also commented out the functions which depended on simulate_rotated_structure. 

**Work in progress**
- [ ] Fix function` peaks_from_best_vector_match() `