### PR TITLE
Add flip to load_mib

### DIFF
--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -781,6 +781,10 @@ def mib_to_h5stack(fp, save_path, mmap_mode='r'):
     -------
     None
     """
+    # check to see if the h5 path already exists and if so raise warning
+    if os.path.exists(save_path):
+        print('The h5 path provided already exists. Change file name to avoid overwrite.')
+        return
     hdr_info = _parse_hdr(fp)
     width = hdr_info['width']
     height = hdr_info['height']

--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -167,6 +167,7 @@ def load_mib(mib_path, reshape=True, flip=True, h5_stack_path=None):
                 └── Signal
                     ├── binned = False
                     ├── exposure_time = 0.001
+                    ├── flip = True
                     ├── flyback_times = [0.066, 0.071, 0.065, 0.017825]
                     ├── frames_number_skipped = 90
                     ├── scan_X = 256
@@ -848,9 +849,7 @@ def _stack_h5dump(data, hdr_info, saving_path, raw_binary=False):
     for i in range(iters_num):
         if (i + 1) * stack_num < data.shape[0]:
             if i == 0:
-                print(i)
                 data_dump0 = data[:(i + 1) * stack_num, :]
-                print(data_dump0.shape)
                 if raw_binary is True:
                     data_dump1 = np.unpackbits(data_dump0)
                     data_dump1.reshape(data_dump0.shape[0], data_dump0.shape[1] * 8)
@@ -863,9 +862,7 @@ def _stack_h5dump(data, hdr_info, saving_path, raw_binary=False):
                 del data_dump0
                 del data_dump1
             else:
-                print(i)
                 data_dump0 = data[i * stack_num:(i + 1) * stack_num, :]
-                print(data_dump0.shape)
                 if raw_binary is True:
                     data_dump1 = np.unpackbits(data_dump0)
                     data_dump1.reshape(data_dump0.shape[0], data_dump0.shape[1] * 8)
@@ -873,13 +870,10 @@ def _stack_h5dump(data, hdr_info, saving_path, raw_binary=False):
                 else:
                     data_dump1 = _untangle_raw(data_dump0, hdr_info, data_dump0.shape[0])
                 _h5_chunk_write(data_dump1, saving_path)
-                print(data_dump1.shape)
                 del data_dump0
                 del data_dump1
         else:
-            print(i)
             data_dump0 = data[i * stack_num:, :]
-            print(data_dump0.shape)
             if raw_binary is True:
                 data_dump1 = np.unpackbits(data_dump0)
                 data_dump1.reshape(data_dump0.shape[0], data_dump0.shape[1] * 8)
@@ -887,7 +881,6 @@ def _stack_h5dump(data, hdr_info, saving_path, raw_binary=False):
             else:
                 data_dump1 = _untangle_raw(data_dump0, hdr_info, data_dump0.shape[0])
             _h5_chunk_write(data_dump1, saving_path)
-            print(data_dump1.shape)
             del data_dump0
             del data_dump1
             return

--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -144,15 +144,14 @@ def load_mib(mib_path, reshape=True, flip=True, h5_stack_path=None):
     mib_path : str
         The full path of the .mib file to be read.
     reshape: boolean
-        keywork argument to control reshaping of the stack (default is True).
+        Keyword argument to control reshaping of the stack (default is True).
         It attepmts to reshape using the flyback pixel.
     flip: boolean
-        keyword argument to vertically flip the diffraction signal (default)
+        Keyword argument to vertically flip the diffraction signal (default)
         or return unchanged. The metadata is updated accordingly.
     h5_stack_path: str
-    default None. this is the h5 file path that we can read the data from in the case of large scan arrays.
-    flip: boolean
-        keyword argument to vertically flip the diffraction signal (default)
+        Default None. this is the h5 file path that we can read the data from in the case of large scan arrays
+        using the pxm.utils.io_utils.mib_to_h5stack function.
 
     Returns
     -------

--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -136,7 +136,7 @@ def load_hspy(filename, lazy=False, assign_to=None):
 
     return s
 
-def load_mib(mib_path, reshape=True, flip, True, h5_stack_path=None):
+def load_mib(mib_path, reshape=True, flip=True, h5_stack_path=None):
     """Read a .mib file or an h5 stack file using dask and return as a lazy pyXem / hyperspy signal.
 
     Parameters

--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -160,7 +160,7 @@ def load_mib(mib_path, reshape=True, flip=True, h5_stack_path=None):
     exposure times appearing on the header and if no exposure times available using the
     sum frames and detecting the flyback frames. If TEM data, a single frame or if
     reshaping the STEM fails, the stack is returned.
-                The metadata adds the following domains:
+                The metadata adds the following domains for STEM mib file:
                 General
                 │   └── title =
                 └── Signal
@@ -171,7 +171,16 @@ def load_mib(mib_path, reshape=True, flip=True, h5_stack_path=None):
                     ├── frames_number_skipped = 90
                     ├── scan_X = 256
                     └── signal_type = STEM
-
+                The returned metadata for TEM mib file:
+                General
+                │   └── title =
+                └── Signal
+                    ├── binned = False
+                    ├── exposure_time = [0.0001]
+                    ├── flyback_times = None
+                    ├── frames_number_skipped = None
+                    ├── scan_X = None
+                    └── signal_type = TEM
     """
     hdr_stuff = _parse_hdr(mib_path)
     width = hdr_stuff['width']


### PR DESCRIPTION
---
name: Add flip to `load_mib`
about: the missing flip option is now back. 
---

**Release Notes**
> vertical flip option for the `load_mib` function is added in (default set to `True`)
> an older version of the `load_mib` function now removed - thanks to @ericpre for spotting it!
> Removed some unnecessary `print` commands 

**Are there any known issues? Do you need help?**
The docstrings in `load_mib` only briefly mentions the possibility of importing large mib datasets (see below). Would this be more appropriate in the pyxem website loading instructions?

Example for importing a large dataset:
`import pyxem as pxm
`
```
fn = '/dls/e02/data/2020/mg23814-20/Merlin/20200304 122155/03_CeO2_8C.mib'
h5_path = '/dls/e02/data/2020/mg23814-20/processing/test.h5'

pxm.utils.io_utils.mib_to_h5stack(fn, h5_path)
```
This would create an h5 file in the path above and saves the stack in the 'data_stack' key.

`dp = pxm.load_mib(fn, h5_path)
`This would read the stack and attempt to reshape it as pass to dp as LazyElectronDiffraction2D

With the smaller mib files just passing the mib file path is sufficient:
`dp = pxm.load_mib(fn)
`
**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] The stack number written in each iteration into h5 file (currently 100) has not been optimised. Also the chunk size when read from it (currently chunks = (100, hdr_info['width'], hdr_info['height']).
- [x] The h5 stack writer does not work with non-RAW data 
- [ ] Adding testing functions


