### PR TITLE
Peak finder performance

### DIFF
--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -22,6 +22,7 @@ credits = [
     "Rob Tovey",
     "Matt von Lany",
     "Endre Jacobsen",
+    "Tom Furnival",
 ]
 license = "GPLv3"
 maintainer = "Duncan Johnstone, Phillip Crout"

--- a/pyxem/tests/test_utils/test_peakfinders2D.py
+++ b/pyxem/tests/test_utils/test_peakfinders2D.py
@@ -24,7 +24,18 @@ from pyxem.utils.peakfinders2D import (
     find_peaks_dog,
     find_peaks_log,
     find_peaks_xc,
+    _fast_mean,
+    _fast_std,
 )
+
+
+def test_mean_std():
+    x = np.array([1, 2, 3, 4, 5, 6])
+    np.testing.assert_allclose(_fast_mean(x), np.mean(x))
+    np.testing.assert_allclose(_fast_mean(x), 3.5)
+    np.testing.assert_allclose(_fast_std(x), np.std(x))
+    np.testing.assert_allclose(_fast_std(x), 1.707825)
+
 
 # see https://stackoverflow.com/questions/9205081/
 dispatcher = {

--- a/pyxem/tests/test_utils/test_peakfinders2D.py
+++ b/pyxem/tests/test_utils/test_peakfinders2D.py
@@ -31,8 +31,10 @@ from pyxem.utils.peakfinders2D import (
 
 def test_mean_std():
     x = np.array([1, 2, 3, 4, 5, 6])
+    np.testing.assert_allclose(_fast_mean(x), _fast_mean.py_func(x))
     np.testing.assert_allclose(_fast_mean(x), np.mean(x))
     np.testing.assert_allclose(_fast_mean(x), 3.5)
+    np.testing.assert_allclose(_fast_std(x), _fast_std.py_func(x))
     np.testing.assert_allclose(_fast_std(x), np.std(x))
     np.testing.assert_allclose(_fast_std(x), 1.707825)
 

--- a/pyxem/utils/peakfinders2D.py
+++ b/pyxem/utils/peakfinders2D.py
@@ -27,13 +27,13 @@ NO_PEAKS = np.array([[np.nan, np.nan]])
 
 
 @njit(cache=True)
-def mean_thresholding(window):
-    return np.mean(window)
+def _fast_mean(X):
+    return np.mean(X)
 
 
 @njit(cache=True)
-def std_thresholding(window):
-    return np.std(window)
+def _fast_std(X):
+    return np.std(X)
 
 
 def clean_peaks(peaks):
@@ -199,16 +199,16 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
 
     def local_mean(image, radius):
         """Calculates rolling mean over a circular kernel."""
-        return _local_stat(image, radius, np.mean)
+        return _local_stat(image, radius, _fast_mean)
 
     def local_std(image, radius):
         """Calculates rolling standard deviation over a circular kernel."""
-        return _local_stat(image, radius, np.std)
+        return _local_stat(image, radius, _fast_std)
 
     def single_pixel_desensitize(image):
         """Reduces single-pixel anomalies by nearest-neighbor smoothing."""
         kernel = np.array([[0.5, 1, 0.5], [1, 1, 1], [0.5, 1, 0.5]])
-        smoothed_image = ndi.filters.generic_filter(image, np.mean, footprint=kernel)
+        smoothed_image = ndi.filters.generic_filter(image, _fast_mean, footprint=kernel)
         return smoothed_image
 
     def stat_binarise(image):

--- a/pyxem/utils/peakfinders2D.py
+++ b/pyxem/utils/peakfinders2D.py
@@ -28,11 +28,47 @@ NO_PEAKS = np.array([[np.nan, np.nan]])
 
 @njit(cache=True)
 def _fast_mean(X):
+    """JIT-compiled mean of array.
+
+    Parameters
+    ----------
+    X : numpy.ndarray
+        Input array.
+
+    Returns
+    -------
+    float
+        Mean of X.
+
+    Notes
+    -----
+    Used by scipy.ndimage.generic_filter in the find_peaks_stat
+    method to reduce overhead of repeated Python function calls.
+    See https://github.com/scipy/scipy/issues/8916 for more details.
+    """
     return np.mean(X)
 
 
 @njit(cache=True)
 def _fast_std(X):
+    """JIT-compiled standard deviation of array.
+
+    Parameters
+    ----------
+    X : numpy.ndarray
+        Input array.
+
+    Returns
+    -------
+    float
+        Standard deviation of X.
+
+    Notes
+    -----
+    Used by scipy.ndimage.generic_filter in the find_peaks_stat
+    method to reduce overhead of repeated Python function calls.
+    See https://github.com/scipy/scipy/issues/8916 for more details.
+    """
     return np.std(X)
 
 

--- a/pyxem/utils/peakfinders2D.py
+++ b/pyxem/utils/peakfinders2D.py
@@ -293,13 +293,13 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
         n_peaks = np.infty  # Initial number of peaks
         image, peaks = _peak_find_once(image)  # 4-6
         m_peaks = len(peaks)  # Actual number of peaks
-        """
-        #XXX
-        while (n_peaks - m_peaks) / n_peaks > convergence_ratio:  # 8
-            n_peaks = m_peaks
-            image, peaks = _peak_find_once(image)
-            m_peaks = len(peaks)
-        """
+
+        # Algorithm branch not currently used
+        # while (n_peaks - m_peaks) / n_peaks > convergence_ratio:  # 8
+        #     n_peaks = m_peaks
+        #     image, peaks = _peak_find_once(image)
+        #     m_peaks = len(peaks)
+
         peak_centers = np.array([np.mean(peak, axis=0) for peak in peaks])  # 7
         return peak_centers
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "diffsims >= 0.2.3",  # Makes use of functionality introduced in this release
         "lmfit >= 0.9.12",
         "pyfai",
+        "numba",
     ],
     package_data={
         "": ["LICENSE", "readme.rst"],


### PR DESCRIPTION
**Release Notes**
> Improvement
> Summary: Improve performance of peak-finding methods.

**What does this PR do? Please describe and/or link to an open issue.**
Improve performance of peak-finding methods as outlined in #580 .
- Speeds up `find_peaks_zaefferer()` method by replacing `np.meshgrid` with `np.mgrid`
- Speeds up `find_peaks_stat()` method using Numba to compile mean/std functions.

**Work in progress**
- [x] Add Numba to requirements
- [x] Add myself to contributors
- [x] Check tests are good on CI with new Numba import
- [x] Coverage

