### PR TITLE
Minor bugfix for plotting vector matching results

### DIFF
--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -1,5 +1,5 @@
 name = "pyxem"
-version = "0.11.0"
+version = "0.11.0dev"
 author = "Duncan Johnstone, Phillip Crout"
 copyright = "Copyright 2017-2020, The pyXem Developers"
 credits = [

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -184,7 +184,7 @@ class VectorMatchingResults(BaseSignal):
         return vectors
 
     def plot_best_matching_results_on_signal(
-        self, signal, library, rank=0, permanent_markers=True, *args, **kwargs
+        self, signal, permanent_markers=True, *args, **kwargs
     ):
         """Plot the best matching diffraction vectors on a signal.
 
@@ -193,10 +193,6 @@ class VectorMatchingResults(BaseSignal):
         signal : ElectronDiffraction2D
             The ElectronDiffraction2D signal object on which to plot the peaks.
             This signal must have the same navigation dimensions as the peaks.
-        library : DiffractionLibrary
-            Diffraction library containing the phases and rotations
-        rank : int
-            Plot results from nth best matching result (default: 0, best match)
         permanent_markers : bool
             Permanently save the peaks as markers on the signal. Default True.
         *args :
@@ -204,9 +200,7 @@ class VectorMatchingResults(BaseSignal):
         **kwargs :
             Keyword arguments passed to signal.plot()
         """
-        match_peaks = self.map(
-            peaks_from_best_vector_match, library=library, inplace=False
-        )
+        match_peaks = self.vectors
         mmx, mmy = generate_marker_inputs_from_peaks(match_peaks)
         signal.plot(*args, **kwargs)
         for mx, my in zip(mmx, mmy):

--- a/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
@@ -194,4 +194,4 @@ def test_plot_best_vector_matching_results_on_signal(structure, rot_list, edc):
         (match_results.data, match_results.data)
     )  # Hyperspy can only add markers to square signals
     dp = ElectronDiffraction2D(2 * [2 * [np.zeros((144, 144))]])
-    match_results.plot_best_matching_results_on_signal(dp, library=library)
+    match_results.plot_best_matching_results_on_signal(dp)


### PR DESCRIPTION
---
name: Minor bugfix for plotting vector matching results
about: The previous workflow generated templates, which seemed inconsistent, this minor fix is hopefully short term as we move over to making better use of `orix`.

---

**Release Notes**
> improvement 
> Summary: `plot_best_match_on_signal` for `VectorMatching` plots vectors rather than a template