### PR TITLE
Changed to account for wavelength given in Angstroms not Meters

### DIFF
--- a/pyxem/signals/electron_diffraction2d.py
+++ b/pyxem/signals/electron_diffraction2d.py
@@ -100,7 +100,7 @@ class ElectronDiffraction2D(Diffraction2D):
         if beam_energy is None and self.beam_energy is not None:
             beam_energy = self.beam_energy
         if beam_energy is not None:
-            wavelength = get_electron_wavelength(self.beam_energy)
+            wavelength = get_electron_wavelength(self.beam_energy) * 1e-10
         else:
             wavelength = None
         integration = super().get_azimuthal_integral1d(
@@ -112,7 +112,7 @@ class ElectronDiffraction2D(Diffraction2D):
         if beam_energy is None and self.beam_energy is not None:
             beam_energy = self.beam_energy
         if beam_energy is not None:
-            wavelength = get_electron_wavelength(self.beam_energy)
+            wavelength = get_electron_wavelength(self.beam_energy) * 1e-10
         else:
             wavelength = None
         integration = super().get_azimuthal_integral2d(


### PR DESCRIPTION
Just a small bug I found when trying to redo demo number 07.  I had assumed that diff sims gave the wavelength in meters and not in angstroms so this is just a small factor of 10 change to the wavelength