### PR TITLE
Change pytest XFAIL to explicitly check correct error is raised

### DIFF
--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -359,8 +359,8 @@ class SubpixelrefinementGenerator:
 
         if np.any(bad_squares):
             warnings.warn(
-                "You have a peak in your pattern that lies on the edge of the square. \
-                          Consider increasing the square size"
+                "You have a peak in your pattern that lies on the edge of the square. "
+                "Consider increasing the square size."
             )
 
         self.last_method = "lg_method"

--- a/pyxem/generators/vdf_generator.py
+++ b/pyxem/generators/vdf_generator.py
@@ -89,7 +89,7 @@ class VDFGenerator:
 
         else:
             raise ValueError(
-                "DiffractionVectors non-specified by user. Please "
+                "DiffractionVectors not specified by user. Please "
                 "initialize VDFGenerator with some vectors. "
             )
 

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -397,11 +397,9 @@ class DiffractionVectors(BaseSignal):
         if distance_threshold == 0:
             if method != "strict":
                 warn(
-                    message="distance_threshold=0 was given, and therefore "
-                    + "a strict comparison is used, even though the "
-                    + "specified method was "
-                    + method
-                    + "."
+                    "distance_threshold=0 was given, and therefore "
+                    "a strict comparison is used, even though the "
+                    "specified method was {}".format(method)
                 )
                 method = "strict"
 

--- a/pyxem/signals/segments.py
+++ b/pyxem/signals/segments.py
@@ -512,7 +512,7 @@ class VDFSegment:
 
         if self.intensities is None:
             raise ValueError(
-                "The VDFSegment does not have the attribute  "
+                "The VDFSegment does not have the attribute "
                 "intensities, required for this method."
             )
         else:

--- a/pyxem/tests/test_generators/test_calibration_generator.py
+++ b/pyxem/tests/test_generators/test_calibration_generator.py
@@ -201,9 +201,11 @@ class TestGetCorrectionMatrix:
             ),
         )
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_no_attributes_correction_matrix(self, calgen):
-        calgen.get_correction_matrix()
+        with pytest.raises(
+            ValueError, match="requires either an affine matrix to correct distortion",
+        ):
+            calgen.get_correction_matrix()
 
 
 @pytest.fixture
@@ -216,41 +218,49 @@ def empty_calgen(request, empty_calibration_library):
     return CalibrationGenerator(calibration_data=empty_calibration_library)
 
 
-@pytest.mark.xfail(raises=ValueError)
 class TestEmptyCalibrationGenerator:
     def test_get_elliptical_distortion(
         self, empty_calgen, input_parameters, affine_answer
     ):
-        empty_calgen.get_elliptical_distortion(
-            mask_radius=10,
-            direct_beam_amplitude=450,
-            scale=95,
-            amplitude=1200,
-            asymmetry=1.5,
-            spread=2.8,
-            rotation=10,
-        )
+        with pytest.raises(ValueError, match="requires an Au X-grating diffraction"):
+            empty_calgen.get_elliptical_distortion(
+                mask_radius=10,
+                direct_beam_amplitude=450,
+                scale=95,
+                amplitude=1200,
+                asymmetry=1.5,
+                spread=2.8,
+                rotation=10,
+            )
 
     def test_get_distortion_residuals_no_data(self, empty_calgen):
-        empty_calgen.get_distortion_residuals(mask_radius=10, spread=2)
+        with pytest.raises(ValueError, match="requires an Au X-grating diffraction"):
+            empty_calgen.get_distortion_residuals(mask_radius=10, spread=2)
 
     def test_get_distortion_residuals_no_affine(self, calgen):
-        calgen.get_distortion_residuals(mask_radius=10, spread=2)
+        with pytest.raises(ValueError, match="requires a distortion matrix"):
+            calgen.get_distortion_residuals(mask_radius=10, spread=2)
 
     def test_plot_corrected_diffraction_pattern_no_data(self, empty_calgen):
-        empty_calgen.plot_corrected_diffraction_pattern()
+        with pytest.raises(ValueError, match="requires an Au X-grating diffraction"):
+            empty_calgen.plot_corrected_diffraction_pattern()
 
     def test_plot_corrected_diffraction_pattern_no_affine(self, calgen):
-        calgen.plot_corrected_diffraction_pattern()
+        with pytest.raises(ValueError, match="requires a distortion matrix"):
+            calgen.plot_corrected_diffraction_pattern()
 
     def test_get_diffraction_calibration_no_data(self, empty_calgen):
-        empty_calgen.get_diffraction_calibration(mask_length=30, linewidth=5)
+        with pytest.raises(ValueError, match="requires an Au X-grating diffraction"):
+            empty_calgen.get_diffraction_calibration(mask_length=30, linewidth=5)
 
     def test_get_diffraction_calibration_no_affine(self, calgen):
-        calgen.get_diffraction_calibration(mask_length=30, linewidth=5)
+        with pytest.raises(ValueError, match="requires a distortion matrix"):
+            calgen.get_diffraction_calibration(mask_length=30, linewidth=5)
 
     def test_get_navigation_calibration_no_data(self, empty_calgen):
         line = Line2DROI(x1=2.5, y1=13.0, x2=193.0, y2=12.5, linewidth=3.5)
-        empty_calgen.get_navigation_calibration(
-            line_roi=line, x1=12.0, x2=172.0, n=1, xspace=500.0
-        )
+
+        with pytest.raises(ValueError, match="requires an Au X-grating image"):
+            empty_calgen.get_navigation_calibration(
+                line_roi=line, x1=12.0, x2=172.0, n=1, xspace=500.0
+            )

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -132,11 +132,15 @@ def test_vector_indexation_generator_init():
     assert vector_indexation_generator.library == vector_library
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_vector_indexation_generator_cartesian_check():
     vectors = DiffractionVectors([[1], [2]])
     vector_library = DiffractionVectorLibrary()
-    vector_indexation_generator = VectorIndexationGenerator(vectors, vector_library)
+
+    with pytest.raises(
+        ValueError,
+        match="Cartesian coordinates are required in order to index diffraction vectors",
+    ):
+        vector_indexation_generator = VectorIndexationGenerator(vectors, vector_library)
 
 
 def test_vector_indexation_generator_index_vectors(vector_match_peaks, vector_library):

--- a/pyxem/tests/test_generators/test_pdf_generator.py
+++ b/pyxem/tests/test_generators/test_pdf_generator.py
@@ -49,10 +49,13 @@ def test_s_limits(reduced_intensity1d):
     assert np.array_equal(pdf.data, pdf2.data)
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_s_limit_failure(reduced_intensity1d):
     pdfgen = PDFGenerator1D(reduced_intensity1d)
-    pdf3 = pdfgen.get_pdf(s_min=0, s_max=15)
+
+    with pytest.raises(
+        ValueError, match="User specified s_max is larger than the maximum"
+    ):
+        pdf3 = pdfgen.get_pdf(s_min=0, s_max=15)
 
 
 def test_signal_size():

--- a/pyxem/tests/test_generators/test_red_intensity_generator.py
+++ b/pyxem/tests/test_generators/test_red_intensity_generator.py
@@ -216,12 +216,14 @@ def test_mask_reduced_intensity(red_int_generator):
     assert np.array_equal(red_int_generator.signal.data, expected)
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_incorrect_mask(red_int_generator):
     mask_pattern = np.ones(10)
     mask_pattern[:4] = 0
     mask_pattern[8] = 2
-    red_int_generator.mask_reduced_intensity(mask_pattern)
+    with pytest.raises(
+        ValueError, match="Masking array does not consist of zeroes and ones"
+    ):
+        red_int_generator.mask_reduced_intensity(mask_pattern)
 
 
 def test_get_reduced_intensity(red_int_generator):

--- a/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/test_generators/test_subpixelrefinement_generator.py
@@ -28,29 +28,45 @@ from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from skimage import draw
 
 
-@pytest.mark.xfail(raises=ValueError)
+# @pytest.mark.xfail(raises=ValueError)
 class Test_init_xfails:
-    """ Tests (both cases) that putting vectors that lie outside of the
-    diffraction patterns raises a ValueError"""
-
     def test_out_of_range_vectors_numpy(self):
+        """Test that putting vectors that lie outside of the
+        diffraction patterns raises a ValueError"""
         vector = np.array([[1, -100]])
         dp = ElectronDiffraction2D(np.ones((20, 20)))
-        sprg = SubpixelrefinementGenerator(dp, vector)
+
+        with pytest.raises(
+            ValueError,
+            match="Some of your vectors do not lie within your diffraction pattern",
+        ):
+            sprg = SubpixelrefinementGenerator(dp, vector)
 
     def test_out_of_range_vectors_DiffractionVectors(self):
+        """Test that putting vectors that lie outside of the
+        diffraction patterns raises a ValueError"""
         vectors = DiffractionVectors(np.array([[1, -100]]))
         dp = ElectronDiffraction2D(np.ones((20, 20)))
-        sprg = SubpixelrefinementGenerator(dp, vectors)
 
-    """ Tests that navigation dimensions must be appropriate too """
+        with pytest.raises(
+            ValueError,
+            match="Some of your vectors do not lie within your diffraction pattern",
+        ):
+            sprg = SubpixelrefinementGenerator(dp, vectors)
 
     def test_wrong_navigation_dimensions(self):
+        """Tests that navigation dimensions must be appropriate too."""
         dp = ElectronDiffraction2D(np.zeros((2, 2, 8, 8)))
         vectors = DiffractionVectors(np.zeros((1, 2)))
         dp.axes_manager.set_signal_dimension(2)
         vectors.axes_manager.set_signal_dimension(0)
-        SPR_generator = SubpixelrefinementGenerator(dp, vectors)
+
+        # Note - uses regex via re.search()
+        with pytest.raises(
+            ValueError,
+            match=r"Vectors with shape .* must have the same navigation shape as .*",
+        ):
+            sprg = SubpixelrefinementGenerator(dp, vectors)
 
 
 class set_up_for_subpixelpeakfinders:
@@ -123,7 +139,12 @@ class Test_subpixelpeakfinders:
         self.x_shift_case(subpixelsfound)
 
     def test_assertioned_log(self, diffraction_vectors):
-        subpixelsfound = self.get_spr(diffraction_vectors).local_gaussian_method(12)
+        with pytest.warns(
+            UserWarning,
+            match="peak in your pattern that lies on the edge of the square",
+        ):
+            subpixelsfound = self.get_spr(diffraction_vectors).local_gaussian_method(12)
+
         self.no_shift_case(subpixelsfound)
         self.x_shift_case(subpixelsfound)
 

--- a/pyxem/tests/test_generators/test_vdf_generator.py
+++ b/pyxem/tests/test_generators/test_vdf_generator.py
@@ -64,10 +64,12 @@ class TestVDFGenerator:
         assert isinstance(vdfgen.signal, ElectronDiffraction2D)
         assert isinstance(vdfgen.vectors, type(None))
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_vector_vdfs_without_vectors(self, diffraction_pattern):
         vdfgen = VDFGenerator(diffraction_pattern)
-        vdfgen.get_vector_vdf_images(radius=2.0)
+        with pytest.raises(
+            ValueError, match="DiffractionVectors not specified by user"
+        ):
+            vdfgen.get_vector_vdf_images(radius=2.0)
 
     @pytest.mark.parametrize("radius, normalize", [(4.0, False), (4.0, True)])
     def test_get_vector_vdf_images(

--- a/pyxem/tests/test_library/test_calibration_library.py
+++ b/pyxem/tests/test_library/test_calibration_library.py
@@ -53,9 +53,9 @@ class TestPlotData:
     def test_plot_moo3_im(self, library):
         library.plot_calibration_data(data_to_plot="moo3_im")
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_plot_invalid(self, library):
-        library.plot_calibration_data(data_to_plot="no_data")
+        with pytest.raises(ValueError, match="Please specify valid data_to_plot"):
+            library.plot_calibration_data(data_to_plot="no_data")
 
     def test_plot_au_x_grating_dp_with_roi(self, library):
         line = Line2DROI(x1=1, y1=1, x2=3, y2=3, linewidth=1.0)

--- a/pyxem/tests/test_signals/test_crystallographic_map.py
+++ b/pyxem/tests/test_signals/test_crystallographic_map.py
@@ -256,18 +256,27 @@ class TestMapCreation:
         metric_map = dp_cryst_map_vector.get_metric_map(metric)
         assert np.allclose(metric_map.isig[0, 0], value)
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_get_metric_map_template_match_bad_metric(self, sp_cryst_map):
-        metric_map = sp_cryst_map.get_metric_map("no metric")
+        # Note - uses regex via re.search()
+        with pytest.raises(
+            ValueError, match=r"metric .* is not valid for template matching"
+        ):
+            metric_map = sp_cryst_map.get_metric_map("no metric")
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_get_metric_map_vector_match_bad_metric(self, dp_cryst_map_vector):
-        metric_map = dp_cryst_map_vector.get_metric_map("no metric")
+        # Note - uses regex via re.search()
+        with pytest.raises(
+            ValueError, match=r"metric .* is not valid for vector matching"
+        ):
+            metric_map = dp_cryst_map_vector.get_metric_map("no metric")
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_get_metric_map_no_method(self):
         crystal_map = CrystallographicMap(np.array([[1]]))
-        metric_map = crystal_map.get_metric_map("no metric")
+
+        with pytest.raises(
+            ValueError, match="crystallographic mapping method must be specified"
+        ):
+            metric_map = crystal_map.get_metric_map("no metric")
 
 
 class TestMTEXIO:

--- a/pyxem/tests/test_signals/test_diffraction_vectors.py
+++ b/pyxem/tests/test_signals/test_diffraction_vectors.py
@@ -115,9 +115,10 @@ def diffraction_vectors_map(request):
 
 
 def test_plot_diffraction_vectors(diffraction_vectors_map):
-    diffraction_vectors_map.plot_diffraction_vectors(
-        xlim=1.0, ylim=1.0, distance_threshold=0
-    )
+    with pytest.warns(UserWarning, match="distance_threshold=0 was given"):
+        diffraction_vectors_map.plot_diffraction_vectors(
+            xlim=1.0, ylim=1.0, distance_threshold=0
+        )
 
 
 def test_plot_diffraction_vectors_on_signal(

--- a/pyxem/tests/test_signals/test_diffraction_vectors.py
+++ b/pyxem/tests/test_signals/test_diffraction_vectors.py
@@ -162,7 +162,6 @@ class TestUniqueVectors:
         unique_vectors = diffraction_vectors_map.get_unique_vectors()
         assert isinstance(unique_vectors, DiffractionVectors)
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_get_unique_vectors_single(self, diffraction_vectors_single):
         diffraction_vectors_single.get_unique_vectors()
 

--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -202,9 +202,11 @@ class TestBackgroundMethods:
         assert bgr.data.shape == diffraction_pattern.data.shape
         assert bgr.max() <= diffraction_pattern.max()
 
-    @pytest.mark.xfail(raises=TypeError)
     def test_no_kwarg(self, diffraction_pattern):
-        bgr = diffraction_pattern.remove_background(method="h-dome")
+        with pytest.raises(
+            TypeError, match="missing 1 required positional argument: 'h'",
+        ):
+            bgr = diffraction_pattern.remove_background(method="h-dome")
 
 
 class TestPeakFinding:
@@ -257,18 +259,31 @@ class TestsAssertionless:
         plt.close("all")
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 class TestNotImplemented:
     def test_failing_run(self, diffraction_pattern):
-        diffraction_pattern.find_peaks(method="no_such_method_exists")
+        # Note - uses regex via re.search()
+        with pytest.raises(
+            NotImplementedError,
+            match=r"The method .* is not implemented. See documentation for available implementations",
+        ):
+            diffraction_pattern.find_peaks(method="no_such_method_exists")
 
     def test_remove_dead_pixels_failing(self, diffraction_pattern):
-        dpr = diffraction_pattern.remove_deadpixels(
-            [[1, 2], [5, 6]], "fake_method", inplace=False, progress_bar=False
-        )
+        with pytest.raises(
+            NotImplementedError,
+            match="The method specified is not implemented. See documentation for available implementations",
+        ):
+            dpr = diffraction_pattern.remove_deadpixels(
+                [[1, 2], [5, 6]], "fake_method", inplace=False, progress_bar=False
+            )
 
     def test_remove_background_fake_method(self, diffraction_pattern):
-        bgr = diffraction_pattern.remove_background(method="fake_method")
+        # Note - uses regex via re.search()
+        with pytest.raises(
+            NotImplementedError,
+            match=r"The method .* is not implemented. See documentation for available implementations",
+        ):
+            bgr = diffraction_pattern.remove_background(method="fake_method")
 
 
 class TestComputeAndAsLazyElectron2D:

--- a/pyxem/tests/test_signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_electron_diffraction2d.py
@@ -85,14 +85,20 @@ class TestSimpleMaps:
 
     def test_apply_affine_transformation_with_casting(self, diffraction_pattern):
         diffraction_pattern.change_dtype("uint8")
-        transformed_dp = ElectronDiffraction2D(
-            diffraction_pattern
-        ).apply_affine_transformation(
-            D=np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.2]]),
-            order=2,
-            keep_dtype=True,
-            inplace=False,
-        )
+
+        with pytest.warns(
+            UserWarning,
+            match="Bi-quadratic interpolation behavior has changed due to a bug in the implementation of scikit-image",
+        ):
+            transformed_dp = ElectronDiffraction2D(
+                diffraction_pattern
+            ).apply_affine_transformation(
+                D=np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.2]]),
+                order=2,
+                keep_dtype=True,
+                inplace=False,
+            )
+
         assert transformed_dp.data.dtype == "uint8"
 
     methods = ["average", "nan"]

--- a/pyxem/tests/test_signals/test_segments.py
+++ b/pyxem/tests/test_signals/test_segments.py
@@ -332,11 +332,14 @@ class TestVDFSegment:
             corr_threshold=0.7, vector_threshold=0, segment_threshold=-1
         )
 
-    @pytest.mark.xfail
-    def test_corelate_segments_bad_thresholds(self, vdf_segments: VDFSegment):
-        corrsegs = vdf_segments.correlate_vdf_segments(
-            vector_threshold=4, segment_threshold=5
-        )
+    def test_correlate_segments_bad_thresholds(self, vdf_segments: VDFSegment):
+        with pytest.raises(
+            ValueError,
+            match="segment_threshold must be smaller than or equal to vector_threshold",
+        ):
+            corrsegs = vdf_segments.correlate_vdf_segments(
+                vector_threshold=4, segment_threshold=5
+            )
 
     def test_get_virtual_electron_diffraction(
         self, vdf_segments: VDFSegment, signal_data
@@ -347,14 +350,17 @@ class TestVDFSegment:
         )
         assert isinstance(vs, ElectronDiffraction2D)
 
-    @pytest.mark.xfail(raises=ValueError)
     def test_get_virtual_electron_diffraction_no_intensities(
         self, vdf_segments: VDFSegment, signal_data
     ):
         vdf_segments.intensities = None
-        vdf_segments.get_virtual_electron_diffraction(
-            calibration=1, sigma=1, shape=signal_data.axes_manager.signal_shape
-        )
+        with pytest.raises(
+            ValueError,
+            match="VDFSegment does not have the attribute intensities, required for this method",
+        ):
+            vdf_segments.get_virtual_electron_diffraction(
+                calibration=1, sigma=1, shape=signal_data.axes_manager.signal_shape
+            )
 
     def test_get_virtual_electron_diffraction_for_single_vectors(
         self, vdf_segments: VDFSegment, signal_data

--- a/pyxem/tests/test_utils/test_big_data_utils.py
+++ b/pyxem/tests/test_utils/test_big_data_utils.py
@@ -25,16 +25,20 @@ import pyxem as pxm
 from pyxem.utils.big_data_utils import chunked_application_of_UDF, _get_chunk_size
 
 
-@pytest.mark.xfail(raises=ValueError, strict=True)
 class Test_bad_xy_lists:
     def test_two_chunksizes(self):
-        _get_chunk_size([0, 10], [0, 5])
+        with pytest.raises(
+            ValueError, match="x_list and y_list need to have the same chunksize"
+        ):
+            _get_chunk_size([0, 10], [0, 5])
 
     def test_bad_x_list(self):
-        _get_chunk_size([0, 2, 5], [0, 2])
+        with pytest.raises(ValueError, match="There is a problem with your x_list"):
+            _get_chunk_size([0, 2, 5], [0, 2])
 
     def test_bad_y_list(self):
-        _get_chunk_size([0, 2], [0, 2, 5])
+        with pytest.raises(ValueError, match="There is a problem with your y_list"):
+            _get_chunk_size([0, 2], [0, 2, 5])
 
 
 """

--- a/pyxem/tests/test_utils/test_subpixel_utils.py
+++ b/pyxem/tests/test_utils/test_subpixel_utils.py
@@ -44,11 +44,11 @@ def test_experimental_square_size(exp_disc):
     assert square.shape[1] == int(6)
 
 
-@pytest.mark.xfail(strict=True)
 def test_failure_for_non_even_entry_to_get_simulated_disc():
-    disc = get_simulated_disc(61, 5)
+    with pytest.raises(ValueError, match="'square_size' must be an even number"):
+        disc = get_simulated_disc(61, 5)
 
 
-@pytest.mark.xfail(strict=True)
 def test_failure_for_non_even_errors_get_experimental_square(exp_disc):
-    square = get_experimental_square(exp_disc, [17, 19], 7)
+    with pytest.raises(ValueError, match="'square_size' must be an even number"):
+        square = get_experimental_square(exp_disc, [17, 19], 7)

--- a/pyxem/tests/test_utils/test_vector_utils.py
+++ b/pyxem/tests/test_utils/test_vector_utils.py
@@ -125,6 +125,10 @@ def test_get_angle_cartesian_vec(a, b, expected_angles):
     np.testing.assert_allclose(angles, expected_angles)
 
 
-@pytest.mark.xfail(raises=ValueError)
+# @pytest.mark.xfail(raises=ValueError)
 def test_get_angle_cartesian_vec_input_validation():
-    get_angle_cartesian_vec(np.empty((2, 3)), np.empty((5, 3)))
+    # Note - uses regex via re.search()
+    with pytest.raises(
+        ValueError, match=r"shape of a .* and b .* must be the same",
+    ):
+        get_angle_cartesian_vec(np.empty((2, 3)), np.empty((5, 3)))


### PR DESCRIPTION
**Release Notes**
> Remove  `@pytest.mark.xfail()` and replace with `pytest.raises` for clearer tests.

**What does this PR do? Please describe and/or link to an open issue.**

I've removed all the instances of `@pytest.mark.xfail()` and replaced them with `with pytest.raises(): ...`, such that the `match` argument can be used to check the correct error message is reported.

According to the [pytest documentation](https://docs.pytest.org/en/latest/assert.html):

> Using `pytest.raises` is likely to be better for cases where you are testing exceptions your own code is deliberately raising, whereas using `@pytest.mark.xfail` with a check function is probably better for something like documenting unfixed bugs (where the test describes what “should” happen) or bugs in dependencies.

There was also a test marked with `xfail` that was passing, and inconsistent use of `strict=True/False` for the others.

I also added some checks for warnings that pyxem itself raises, using `with pytest.warns(): ...`. The remaining warnings are from dependencies such as hyperspy and skimage.

```
Last Travis build on master
===== 476 passed, 32 xfailed, 1 xpassed, 370 warnings in 79.97s (0:01:19) ======

vs. now (this branch):
===== 509 passed, 352 warnings in 71.46s (0:01:11) =====
```