### PR TITLE
Fixed bug in load_mib. (Issue #597).

### DIFF
--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -624,7 +624,7 @@ def _mib_to_daskarr(fp, mmap_mode="r"):
     data_type = data_type.newbyteorder(endian)
 
     data_mem = np.memmap(fp, offset=read_offset, dtype=data_type, mode=mmap_mode)
-    data_da = da.from_array(data_mem)
+    data_da = da.from_array(data_mem, chunks='auto')
     return data_da
 
 


### PR DESCRIPTION
Added chunks='auto' to load_mib da.from_array line as load_mib was giving a 

> TypeError: from_array() missing 1 required positional argument: 'chunks'