### PR TITLE
Pass kwargs to align2D() in center_direct_beam()

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -668,13 +668,13 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Parameters
         ----------
-        method : str,
-            Must be one of 'cross_correlate', 'blur', 'interpolate'
-        half_square_width  : int
+        method : str {'cross_correlate', 'blur', 'interpolate'}
+            Method used to estimate the direct beam position
+        half_square_width : int
             Half the side length of square that captures the direct beam in all
             scans. Means that the centering algorithm is stable against
             diffracted spots brighter than the direct beam.
-        return_shifts : bool
+        return_shifts : bool, default False
             If True, the values of applied shifts are returned
         align_kwargs : dict
             To be passed to .align2D() function
@@ -702,6 +702,11 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         shifts = -1 * shifts.data
         shifts = shifts.reshape(nav_size, 2)
+
+        # Preserve existing behaviour by overriding
+        # crop & fill_value
+        align_kwargs.pop("crop", None)
+        align_kwargs.pop("fill_value", None)
 
         self.align2D(shifts=shifts, crop=False, fill_value=0, **align_kwargs)
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -654,7 +654,13 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return shifts
 
     def center_direct_beam(
-        self, method, half_square_width=None, return_shifts=False, *args, **kwargs
+        self,
+        method,
+        half_square_width=None,
+        return_shifts=False,
+        align_kwargs={},
+        *args,
+        **kwargs
     ):
         """Estimate the direct beam position in each experimentally acquired
         electron diffraction pattern and translate it to the center of the
@@ -670,6 +676,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             diffracted spots brighter than the direct beam.
         return_shifts : bool
             If True, the values of applied shifts are returned
+        align_kwargs : dict
+            To be passed to .align2D() function
         **kwargs:
             To be passed to method function
 
@@ -695,7 +703,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         shifts = -1 * shifts.data
         shifts = shifts.reshape(nav_size, 2)
 
-        self.align2D(shifts=shifts, crop=False, fill_value=0)
+        self.align2D(shifts=shifts, crop=False, fill_value=0, **align_kwargs)
 
         if return_shifts:
             return shifts


### PR DESCRIPTION
**Release Notes**
> Pass kwargs to hyperspy `align2D()`

**What does this PR do? Please describe and/or link to an open issue.**
Allows passing kwargs to `align2D()` when calling `center_direct_beam()`, using the `align_kwargs` dict keyword argument. Related to https://github.com/hyperspy/hyperspy/pull/2391 - it will allow passing, for example, `parallel=True, max_workers=4` to control the number of threads launched in parallel.

`**kwargs` are already used here, passed to the function defined by `method`, so I chose to separate out the arguments for `align2D()`. Existing behaviour is preserved by explicitly setting `crop=False, fill_value=0`.

I noticed that there are already instances of `map()` with the ability to pass `**kwargs`, which the above HyperSpy PR also affects, but that's fine :)