### PR TITLE
full_frame_correlation

### DIFF
--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -167,6 +167,9 @@ class IndexationGenerator:
             shape = signal.data.shape[-2:]
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
+            if not (list(size) == fsize):
+                raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n")
+            
             library_FT_dict = get_library_FT_dict(library, shape, fsize)
 
             matches = signal.map(

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -21,7 +21,6 @@
 """
 
 import numpy as np
-from scipy.fftpack import next_fast_len
 
 from pyxem.signals.indexation_results import TemplateMatchingResults
 from pyxem.signals.indexation_results import VectorMatchingResults
@@ -39,6 +38,7 @@ from pyxem.utils.indexation_utils import (
     OrientationResult,
     get_nth_best_solution,
     correlate_library_from_dict,
+    optimal_fft_size,
 )
 
 
@@ -51,7 +51,7 @@ import lmfit
 def get_fourier_transform(template_coordinates, template_intensities, shape, fsize):
     template = np.zeros((shape))
     template[template_coordinates[:, 1], template_coordinates[:, 0]] = template_intensities[:]
-    template_FT = np.fft.fftshift(np.fft.fftn(template,fsize))
+    template_FT = np.fft.fftshift(np.fft.rfftn(template, fsize))
     template_norm = np.linalg.norm(template)
     return template_FT, template_norm
 
@@ -166,7 +166,7 @@ class IndexationGenerator:
         elif method in ["full_frame_correlation"] :
             shape = signal.data.shape[1:]
             size = 2 * np.array(shape) - 1
-            fsize = [next_fast_len(a) for a in (size)]
+            fsize = [optimal_fft_size(a, real = True) for a in (size)]
             library_FT_dict = get_library_FT_dict(library, shape, fsize)
 
             matches = signal.map(

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -167,7 +167,7 @@ class IndexationGenerator:
             shape = signal.data.shape[-2:]
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
-            if not (list(size) == fsize):
+            if not (list(size) + 1 == fsize):
                 raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n size: {} fsize: {}".format(size, fsize))
 
             library_FT_dict = get_library_FT_dict(library, shape, fsize)

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -167,7 +167,7 @@ class IndexationGenerator:
             shape = signal.data.shape[-2:]
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
-            if not (list(size) + 1 == fsize):
+            if not ([a = x + 1 for x in list(size)] == fsize):
                 raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n size: {} fsize: {}".format(size, fsize))
 
             library_FT_dict = get_library_FT_dict(library, shape, fsize)

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -164,7 +164,7 @@ class IndexationGenerator:
             )
 
         elif method in ["full_frame_correlation"] :
-            shape = signal.data.shape[1:]
+            shape = signal.data.shape[-2:]
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
             library_FT_dict = get_library_FT_dict(library, shape, fsize)
@@ -172,10 +172,10 @@ class IndexationGenerator:
             matches = signal.map(
                 correlate_library_from_dict,
                 template_dict = library_FT_dict,
-                n_largest=n_largest,
-                method=method,
-                mask=mask,
-                inplace=False,
+                n_largest = n_largest,
+                method = method,
+                mask = mask,
+                inplace = False,
                 **kwargs,
             )
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -167,7 +167,7 @@ class IndexationGenerator:
             shape = signal.data.shape[-2:]
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
-            if not ([a = x + 1 for x in list(size)] == fsize):
+            if not (np.asarray(size) + 1 == np.asarray(fsize)).all():
                 raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n size: {} fsize: {}".format(size, fsize))
 
             library_FT_dict = get_library_FT_dict(library, shape, fsize)

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -168,7 +168,7 @@ class IndexationGenerator:
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
             if not (np.asarray(size) + 1 == np.asarray(fsize)).all():
-                raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n size: {} fsize: {}".format(size, fsize))
+                raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n")
 
             library_FT_dict = get_library_FT_dict(library, shape, fsize)
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -38,6 +38,7 @@ from pyxem.utils.indexation_utils import (
     match_vectors,
     OrientationResult,
     get_nth_best_solution,
+    correlate_library_from_dict,
 )
 
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -52,7 +52,7 @@ def get_fourier_transform(template_coordinates, template_intensities, shape, fsi
     template = np.zeros((shape))
     template[template_coordinates[:, 1], template_coordinates[:, 0]] = template_intensities[:]
     template_FT = np.fft.fftshift(np.fft.rfftn(template, fsize))
-    template_norm = np.linalg.norm(template)
+    template_norm = np.sqrt(full_frame_correlation(template_FT, 1, template_FT, 1))
     return template_FT, template_norm
 
 def get_library_FT_dict(template_library, shape, fsize):

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -168,8 +168,8 @@ class IndexationGenerator:
             size = 2 * np.array(shape) - 1
             fsize = [optimal_fft_size(a, real = True) for a in (size)]
             if not (list(size) == fsize):
-                raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n")
-            
+                raise ValueError("Please select input signal and templates of dimensions 2**n X 2**n size: {} fsize: {}".format(size, fsize))
+
             library_FT_dict = get_library_FT_dict(library, shape, fsize)
 
             matches = signal.map(

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -49,6 +49,28 @@ from diffsims.utils.sim_utils import get_electron_wavelength
 import lmfit
 
 def get_fourier_transform(template_coordinates, template_intensities, shape, fsize):
+    """
+    Takes a list of template coordinates and the corresponding list of template intensities, and returns the Fourier
+    transform of the template.
+
+    Parameters
+    ----------
+    template_coordinates: numpy array
+        Array containing coordinates for non-zero intensities in the template
+    template_intensities: list
+        List of intensity values for the template.
+    shape: tuple
+        Dimensions of the signal.
+    fsize: list
+        Dimensions of the Fourier transformed signal.
+
+    Returns
+    -------
+    template_FT: numpy array
+        Fourier transform of the template.
+    template_norm: float
+        Self correlation value for the template.
+    """
     template = np.zeros((shape))
     template[template_coordinates[:, 1], template_coordinates[:, 0]] = template_intensities[:]
     template_FT = np.fft.fftshift(np.fft.rfftn(template, fsize))
@@ -56,6 +78,24 @@ def get_fourier_transform(template_coordinates, template_intensities, shape, fsi
     return template_FT, template_norm
 
 def get_library_FT_dict(template_library, shape, fsize):
+    """
+    Takes a template library and converts it to a dictionary of Fourier transformed templates.
+
+    Parameters:
+    ----------
+    template_library: DiffractionLibrary
+        The library of simulated diffraction patterns for indexation.
+    shape: tuple
+        Dimensions of the signal.
+    fsize: list
+        Dimensions of the Fourier transformed signal.
+
+    Returns:
+    -------
+    library_FT_dict: dict
+        Dictionary containing the fourier transformed template library, together with the corresponding orientations and
+        pattern norms.
+    """
     library_FT_dict = {}
     for entry, library_entry in enumerate(template_library.values()):
         orientations = library_entry["orientations"]

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -127,12 +127,13 @@ def test_profile_indexation_generator_single_indexation(profile_simulation):
 def test_get_fourier_transform():
     shape = (3,3)
     fsize = (5,5)
+    normalization_constant = 0.9278426705718053 #Precomputed normalization. Formula full_frame(template, 1, template, 1)
     template_coordinates = np.asarray([[1,1]])
     template_intensities = np.asarray([1])
     transform, norm = get_fourier_transform(template_coordinates, template_intensities, shape, fsize)
-    test_value = np.real(transform[1,1])
+    test_value = np.real(transform[2,1]) #Center value
     np.testing.assert_approx_equal(test_value, 1)
-    np.testing.assert_approx_equal(norm, 1)
+    np.testing.assert_approx_equal(norm, normalization_constant)
 
 def test_get_library_FT_dict():
     new_template_library = DiffractionLibrary()

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -131,7 +131,7 @@ def test_get_fouriet_transform():
     template_intensities = np.asarray([1])
     transform, norm = get_fourier_transform(template_coordinates, template_intensities, shape, fsize)
     test_value = np.real(transform[1,1])
-    np.testing.assert_approx_equal(test_vale, 1)
+    np.testing.assert_approx_equal(test_value, 1)
     np.testing.assert_approx_equal(norm, 1)
 
 def test_get_library_FT_dict():
@@ -148,7 +148,7 @@ def test_get_library_FT_dict():
             pattern_norms = library_entry["pattern_norms"]
     np.testing.assert_approx_equal(orientations[0][0], 0.0)
     np.testing.assert_approx_equal(np.real(patterns[0][1,1]),1)
-    np.testing.assert_approx_equal(pattern_norms[0][0], 1)
+    np.testing.assert_approx_equal(pattern_norms[0], 1)
 
 
 def test_vector_indexation_generator_init():

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -124,7 +124,7 @@ def test_profile_indexation_generator_single_indexation(profile_simulation):
     indexation = pig.index_peaks(tolerance=0.02)
     np.testing.assert_almost_equal(indexation[0][0], 0.3189193164369)
 
-def test_get_fouriet_transform():
+def test_get_fourier_transform():
     shape = (3,3)
     fsize = (3,3)
     template_coordinates = np.asarray([[1,1]])

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -142,14 +142,15 @@ def test_get_library_FT_dict():
                                     "intensities" : np.array([np.array([1,])])}
     shape = (3,3)
     fsize = (5,5)
+    normalization_constant = 0.9278426705718053
     new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
     for phase_index, library_entry in enumerate(new_template_dict.values()):
-            orientations = library_entry["orientations"]
-            patterns = library_entry["patterns"]
-            pattern_norms = library_entry["pattern_norms"]
+        orientations = library_entry["orientations"]
+        patterns = library_entry["patterns"]
+        pattern_norms = library_entry["pattern_norms"]
     np.testing.assert_approx_equal(orientations[0][0], 0.0)
-    np.testing.assert_approx_equal(np.real(patterns[0][1,1]),1)
-    np.testing.assert_approx_equal(pattern_norms[0], 1)
+    np.testing.assert_approx_equal(np.real(patterns[0][2,1]),1)
+    np.testing.assert_approx_equal(pattern_norms[0], normalization_constant)
 
 
 def test_vector_indexation_generator_init():

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -126,14 +126,13 @@ def test_profile_indexation_generator_single_indexation(profile_simulation):
 
 def test_get_fourier_transform():
     shape = (3,3)
-    fsize = (5,5)
-    normalization_constant = 0.9278426705718053 #Precomputed normalization. Formula full_frame(template, 1, template, 1)
+    fsize = (3,3)
     template_coordinates = np.asarray([[1,1]])
     template_intensities = np.asarray([1])
     transform, norm = get_fourier_transform(template_coordinates, template_intensities, shape, fsize)
-    test_value = np.real(transform[2,1]) #Center value
+    test_value = np.real(transform[1,1])
     np.testing.assert_approx_equal(test_value, 1)
-    np.testing.assert_approx_equal(norm, normalization_constant)
+    np.testing.assert_approx_equal(norm, 1)
 
 def test_get_library_FT_dict():
     new_template_library = DiffractionLibrary()
@@ -142,15 +141,14 @@ def test_get_library_FT_dict():
                                     "intensities" : np.array([np.array([1,])])}
     shape = (3,3)
     fsize = (5,5)
-    normalization_constant = 0.9278426705718053
     new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
     for phase_index, library_entry in enumerate(new_template_dict.values()):
-        orientations = library_entry["orientations"]
-        patterns = library_entry["patterns"]
-        pattern_norms = library_entry["pattern_norms"]
+            orientations = library_entry["orientations"]
+            patterns = library_entry["patterns"]
+            pattern_norms = library_entry["pattern_norms"]
     np.testing.assert_approx_equal(orientations[0][0], 0.0)
-    np.testing.assert_approx_equal(np.real(patterns[0][2,1]),1)
-    np.testing.assert_approx_equal(pattern_norms[0], normalization_constant)
+    np.testing.assert_approx_equal(np.real(patterns[0][1,1]),1)
+    np.testing.assert_approx_equal(pattern_norms[0], 1)
 
 
 def test_vector_indexation_generator_init():

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -21,8 +21,10 @@ import numpy as np
 
 from pyxem.generators.indexation_generator import ProfileIndexationGenerator
 from pyxem.generators.indexation_generator import VectorIndexationGenerator
+from pyxem.generators.indexation_generator import get_fourier_transform, get_library_FT_dict
 
 from diffsims.libraries.vector_library import DiffractionVectorLibrary
+from diffsims.libraries.diffraction_library import DiffractionLibrary
 from diffsims.sims.diffraction_simulation import ProfileSimulation
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 
@@ -100,6 +102,7 @@ def test_profile_indexation_generator_init(profile_simulation):
     assert isinstance(pig, ProfileIndexationGenerator)
 
 
+
 def test_profile_indexation_generator_single_indexation(profile_simulation):
     pig = ProfileIndexationGenerator(
         magnitudes=[
@@ -120,6 +123,32 @@ def test_profile_indexation_generator_single_indexation(profile_simulation):
     )
     indexation = pig.index_peaks(tolerance=0.02)
     np.testing.assert_almost_equal(indexation[0][0], 0.3189193164369)
+
+def test_get_fouriet_transform():
+    shape = (3,3)
+    fsize = (3,3)
+    template_coordinates = np.asarray([[1,1]])
+    template_intensities = np.asarray([1])
+    transform, norm = get_fourier_transform(template_coordinates, template_intensities, shape, fsize)
+    test_value = np.real(transform[1,1])
+    np.testing.assert_approx_equal(test_vale, 1)
+    np.testing.assert_approx_equal(norm, 1)
+
+def test_get_library_FT_dict():
+    new_template_library = DiffractionLibrary()
+    new_template_library["GaSb"] = {"orientations" : np.array([[0.0, 0.0, 0.0],]) ,
+                                    "pixel_coords" : np.array([np.asarray([[1,1],])]),
+                                    "intensities" : np.array([np.array([1,])])}
+    shape = (3,3)
+    fsize = (3,3)
+    new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
+    for phase_index, library_entry in enumerate(new_template_dict.values()):
+            orientations = library_entry["orientations"]
+            patterns = library_entry["patterns"]
+            pattern_norms = library_entry["pattern_norms"]
+    np.testing.assert_approx_equal(orientations[0][0], 0.0)
+    np.testing.assert_approx_equal(np.real(patterns[0][1,1]),1)
+    np.testing.assert_approx_equal(pattern_norms[0][0], 1)
 
 
 def test_vector_indexation_generator_init():

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -140,7 +140,7 @@ def test_get_library_FT_dict():
                                     "pixel_coords" : np.array([np.asarray([[1,1],])]),
                                     "intensities" : np.array([np.array([1,])])}
     shape = (3,3)
-    fsize = (3,3)
+    fsize = (5,5)
     new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
     for phase_index, library_entry in enumerate(new_template_dict.values()):
             orientations = library_entry["orientations"]

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -126,7 +126,7 @@ def test_profile_indexation_generator_single_indexation(profile_simulation):
 
 def test_get_fourier_transform():
     shape = (3,3)
-    fsize = (3,3)
+    fsize = (5,5)
     template_coordinates = np.asarray([[1,1]])
     template_intensities = np.asarray([1])
     transform, norm = get_fourier_transform(template_coordinates, template_intensities, shape, fsize)

--- a/pyxem/tests/test_generators/test_indexation_generator.py
+++ b/pyxem/tests/test_generators/test_indexation_generator.py
@@ -124,16 +124,15 @@ def test_profile_indexation_generator_single_indexation(profile_simulation):
     indexation = pig.index_peaks(tolerance=0.02)
     np.testing.assert_almost_equal(indexation[0][0], 0.3189193164369)
 
-def test_get_fourier_transform():
+def test_get_fouriet_transform():
     shape = (3,3)
-    fsize = (5,5)
-    normalization_constant = 0.9278426705718053 #Precomputed normalization. Formula full_frame(template, 1, template, 1)
+    fsize = (3,3)
     template_coordinates = np.asarray([[1,1]])
     template_intensities = np.asarray([1])
     transform, norm = get_fourier_transform(template_coordinates, template_intensities, shape, fsize)
-    test_value = np.real(transform[2,1]) #Center value
-    np.testing.assert_approx_equal(test_value, 1)
-    np.testing.assert_approx_equal(norm, normalization_constant)
+    test_value = np.real(transform[1,1])
+    np.testing.assert_approx_equal(test_vale, 1)
+    np.testing.assert_approx_equal(norm, 1)
 
 def test_get_library_FT_dict():
     new_template_library = DiffractionLibrary()
@@ -141,16 +140,15 @@ def test_get_library_FT_dict():
                                     "pixel_coords" : np.array([np.asarray([[1,1],])]),
                                     "intensities" : np.array([np.array([1,])])}
     shape = (3,3)
-    fsize = (5,5)
-    normalization_constant = 0.9278426705718053
+    fsize = (3,3)
     new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
     for phase_index, library_entry in enumerate(new_template_dict.values()):
-        orientations = library_entry["orientations"]
-        patterns = library_entry["patterns"]
-        pattern_norms = library_entry["pattern_norms"]
+            orientations = library_entry["orientations"]
+            patterns = library_entry["patterns"]
+            pattern_norms = library_entry["pattern_norms"]
     np.testing.assert_approx_equal(orientations[0][0], 0.0)
-    np.testing.assert_approx_equal(np.real(patterns[0][2,1]),1)
-    np.testing.assert_approx_equal(pattern_norms[0], normalization_constant)
+    np.testing.assert_approx_equal(np.real(patterns[0][1,1]),1)
+    np.testing.assert_approx_equal(pattern_norms[0][0], 1)
 
 
 def test_vector_indexation_generator_init():

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -18,19 +18,13 @@
 
 import numpy as np
 
-from diffsims.libraries.diffraction_library import DiffractionLibrary
-
-from pyxem.generators.indexation_generator import get_library_FT_dict
-
 from pyxem.utils.indexation_utils import (
     crystal_from_template_matching,
     crystal_from_vector_matching,
     match_vectors,
     zero_mean_normalized_correlation,
     fast_correlation,
-    full_frame_correlation,
-    optimal_fft_size,
-    correlate_library_from_dict
+    full_frame_correlation
 )
 
 
@@ -54,44 +48,15 @@ def test_fast_correlation():
 def test_full_frame_correlation():
     #Define testing parameters.
     in1 = np.zeros((10,10))
-    in2 = np.zeros((10,10))
-    in1[5,5] = 1
-    in1[7,7] = 1
-    in1[3,7] = 1
-    in1[7,3] = 1
-    in1_FT = np.fft.fftshift(np.fft.rfftn(in1, (20,20)))
-    norm_1 = np.sqrt(np.max(np.real(np.fft.ifftn(in1_FT ** 2))))
-    in2_FT = np.fft.fftshift(np.fft.rfftn(in2, (20,20)))
-    norm_2 = np.sqrt(np.max(np.real(np.fft.ifftn(in2_FT ** 2))))
+    image_norm = np.linalg.norm(in1)
+    next_fast_len = np.array([20, 20])
+    in1_FT = np.fft.fftn(in1, next_fast_len)
     np.testing.assert_approx_equal(
-        full_frame_correlation(in1_FT, norm_1, in1_FT, norm_1), 1
+        full_frame_correlation(in1_FT, image_norm, next_fast_len, np.array([[5, 5],[5, 5]]), [1, 1]), 0.1
     )
     np.testing.assert_approx_equal(
-        full_frame_correlation(in1_FT, norm_1, in2_FT, norm_2), 0
+        full_frame_correlation(in1_FT, image_norm, next_fast_len, np.array([[5, 5], [5, 5]]), [0, 0]), 0
     )
-
-def test_optimal_fft_size():
-    np.testing.assert_approx_equal(
-        optimal_fft_size(8), 8
-    )
-    np.testing.assert_approx_equal(
-        optimal_fft_size(20), 20
-    )
-
-def test_correlate_library_from_dict():
-    new_template_library = DiffractionLibrary()
-    new_template_library["GaSb"] = {"orientations" : np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]) ,
-                                    "pixel_coords" : np.array([np.asarray([[1,1]]), np.asarray([[2,2],[1,1]])]),
-                                    "intensities" : np.array([np.array([1,]), np.array([1, 1])])}
-    shape = (3,3)
-    fsize = (5,5)
-    new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
-    image = np.zeros((3,3))
-    image[1,1] = 1
-    match_results = correlate_library_from_dict(image, new_template_dict,n_largest =  1, method = "full_frame_correlation", mask = 1)
-    np.testing.assert_approx_equal(match_results[0][1][1], 0.0)
-    np.testing.assert_approx_equal(match_results[0][2], 1.0)
-
 
 def test_crystal_from_template_matching_sp(sp_template_match_result):
     # branch single phase

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -18,6 +18,8 @@
 
 import numpy as np
 
+from diffsims.libraries.diffraction_library import DiffractionLibrary
+
 from pyxem.utils.indexation_utils import (
     crystal_from_template_matching,
     crystal_from_vector_matching,

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -18,10 +18,6 @@
 
 import numpy as np
 
-from diffsims.libraries.diffraction_library import DiffractionLibrary
-
-from pyxem.generators.indexation_generator import get_library_FT_dict
-
 from pyxem.utils.indexation_utils import (
     crystal_from_template_matching,
     crystal_from_vector_matching,
@@ -88,7 +84,7 @@ def test_correlate_library_from_dict():
     new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
     image = np.zeros((3,3))
     image[1,1] = 1
-    match_results = correlate_library_from_dict(image, new_template_dict,n_largest =  1, method = "full_frame_correlation", mask = 1)
+    match_result = correlate_library_from_dict(image, new_template_dict,n_largest =  1, method = "full_frame_correlation", mask = 1)
     np.testing.assert_approx_equal(match_results[0][1][1], 0.0)
     np.testing.assert_approx_equal(match_results[0][2], 1.0)
 

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -72,7 +72,7 @@ def test_full_frame_correlation():
 
 def test_optimal_fft_size():
     np.testing.assert_approx_equal(
-        optimal_fft_size(7), 8
+        optimal_fft_size(8), 8
     )
     np.testing.assert_approx_equal(
         optimal_fft_size(20), 20

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -47,7 +47,7 @@ def test_fast_correlation():
 
 def test_full_frame_correlation():
     #Define testing parameters.
-    in1 = np.ones((10,10))
+    in1 = np.zeros((10,10))
     image_norm = np.linalg.norm(in1)
     next_fast_len = np.array([20, 20])
     in1_FT = np.fft.fftn(in1, next_fast_len)

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from diffsims.libraries.diffraction_library import DiffractionLibrary
 
+from pyxem.generators.indexation_generator import get_library_FT_dict
+
 from pyxem.utils.indexation_utils import (
     crystal_from_template_matching,
     crystal_from_vector_matching,

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -24,7 +24,9 @@ from pyxem.utils.indexation_utils import (
     match_vectors,
     zero_mean_normalized_correlation,
     fast_correlation,
-    full_frame_correlation
+    full_frame_correlation,
+    optimal_fft_size,
+    correlate_library_from_dict
 )
 
 
@@ -48,14 +50,44 @@ def test_fast_correlation():
 def test_full_frame_correlation():
     #Define testing parameters.
     in1 = np.zeros((10,10))
-    next_fast_len = np.array([20, 20])
-    in1_FT = np.fft.fftn(in1, next_fast_len)
+    in2 = np.zeros((10,10))
+    in1[5,5] = 1
+    in1[7,7] = 1
+    in1[3,7] = 1
+    in1[7,3] = 1
+    in1_FT = np.fft.fftshift(np.fft.rfftn(in1, (20,20)))
+    norm_1 = np.sqrt(np.max(np.real(np.fft.ifftn(in1_FT ** 2))))
+    in2_FT = np.fft.fftshift(np.fft.rfftn(in2, (20,20)))
+    norm_2 = np.sqrt(np.max(np.real(np.fft.ifftn(in2_FT ** 2))))
     np.testing.assert_approx_equal(
-        full_frame_correlation(in1_FT, image_norm, next_fast_len, np.array([[5, 5],[5, 5]]), [1, 1]), 0.1
+        full_frame_correlation(in1_FT, norm_1, in1_FT, norm_1), 1
     )
     np.testing.assert_approx_equal(
-        full_frame_correlation(in1_FT, image_norm, next_fast_len, np.array([[5, 5], [5, 5]]), [0, 0]), 0
+        full_frame_correlation(in1_FT, norm_1, in2_FT, norm_2), 0
     )
+
+def test_optimal_fft_size():
+    np.testing.assert_approx_equal(
+        optimal_fft_size(7), 8
+    )
+    np.testing.assert_approx_equal(
+        optimal_fft_size(20), 20
+    )
+
+def test_correlate_library_from_dict():
+    new_template_library = DiffractionLibrary()
+    new_template_library["GaSb"] = {"orientations" : np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]) ,
+                                    "pixel_coords" : np.array([np.asarray([[1,1]]), np.asarray([[2,2],[1,1]])]),
+                                    "intensities" : np.array([np.array([1,]), np.array([1, 1])])}
+    shape = (3,3)
+    fsize = (5,5)
+    new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
+    image = np.zeros((3,3))
+    image[1,1] = 1
+    match_result = correlate_library_from_dict(image, new_template_dict,n_largest =  1, method = "full_frame_correlation", mask = 1)
+    np.testing.assert_approx_equal(match_results[0][1][1], 0.0)
+    np.testing.assert_approx_equal(match_results[0][2], 1.0)
+
 
 def test_crystal_from_template_matching_sp(sp_template_match_result):
     # branch single phase

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -48,7 +48,6 @@ def test_fast_correlation():
 def test_full_frame_correlation():
     #Define testing parameters.
     in1 = np.zeros((10,10))
-    image_norm = np.linalg.norm(in1)
     next_fast_len = np.array([20, 20])
     in1_FT = np.fft.fftn(in1, next_fast_len)
     np.testing.assert_approx_equal(

--- a/pyxem/tests/test_utils/test_indexation_utils.py
+++ b/pyxem/tests/test_utils/test_indexation_utils.py
@@ -88,7 +88,7 @@ def test_correlate_library_from_dict():
     new_template_dict = get_library_FT_dict(new_template_library, shape, fsize)
     image = np.zeros((3,3))
     image[1,1] = 1
-    match_result = correlate_library_from_dict(image, new_template_dict,n_largest =  1, method = "full_frame_correlation", mask = 1)
+    match_results = correlate_library_from_dict(image, new_template_dict,n_largest =  1, method = "full_frame_correlation", mask = 1)
     np.testing.assert_approx_equal(match_results[0][1][1], 0.0)
     np.testing.assert_approx_equal(match_results[0][2], 1.0)
 

--- a/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
@@ -139,6 +139,7 @@ def test_orientation_mapping_physical(structure, rot_list, edc):
         )  # always looking down c
 
 @pytest.mark.xfail(raises=ValueError)
+@pytest.mark.parametrize("structure", [create_Ortho(), create_Hex()])
 def test_fullframe_bad_size(structure, rot_list, edc):
     high_scores = get_template_match_results_fullframe_bad_size(structure, edc, rot_list)
 

--- a/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
@@ -123,7 +123,12 @@ def test_orientation_mapping_physical(structure, rot_list, edc):
             match_data[result_number][:2], [90, 90]
         )  # always looking down c
 
-@pytest.mark.parametrize("structure", [create_Ortho(), create_Hex()])
+
+def test_masked_template_matching(default_structure, rot_list, edc):
+    mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
+    M = get_template_match_results(default_structure, edc, rot_list, mask)
+    assert np.all(np.equal(M.inav[0, 1].data, None))
+
 def test_fullframe_orientation_mapping_physical(structure, rot_list, edc):
     M = get_template_match_results_fullframe(structure, edc, rot_list)
     assert np.all(M.inav[0, 0] == M.inav[1, 0])
@@ -133,15 +138,6 @@ def test_fullframe_orientation_mapping_physical(structure, rot_list, edc):
             match_data[result_number][:2], [90, 90]
         )  # always looking down c
 
-def test_masked_template_matching(default_structure, rot_list, edc):
-    mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
-    M = get_template_match_results(default_structure, edc, rot_list, mask)
-    assert np.all(np.equal(M.inav[0, 1].data, None))
-
-def test_masked_fullframe_template_matching(default_structure, rot_list, edc):
-    mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
-    M = get_template_match_results_fullframe(default_structure, edc, rot_list, mask)
-    assert np.all(np.equal(M.inav[0, 1].data, None))
 
 """ Testing Vector Matching Results """
 

--- a/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
@@ -123,12 +123,7 @@ def test_orientation_mapping_physical(structure, rot_list, edc):
             match_data[result_number][:2], [90, 90]
         )  # always looking down c
 
-
-def test_masked_template_matching(default_structure, rot_list, edc):
-    mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
-    M = get_template_match_results(default_structure, edc, rot_list, mask)
-    assert np.all(np.equal(M.inav[0, 1].data, None))
-
+@pytest.mark.parametrize("structure", [create_Ortho(), create_Hex()])
 def test_fullframe_orientation_mapping_physical(structure, rot_list, edc):
     M = get_template_match_results_fullframe(structure, edc, rot_list)
     assert np.all(M.inav[0, 0] == M.inav[1, 0])
@@ -138,6 +133,15 @@ def test_fullframe_orientation_mapping_physical(structure, rot_list, edc):
             match_data[result_number][:2], [90, 90]
         )  # always looking down c
 
+def test_masked_template_matching(default_structure, rot_list, edc):
+    mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
+    M = get_template_match_results(default_structure, edc, rot_list, mask)
+    assert np.all(np.equal(M.inav[0, 1].data, None))
+
+def test_masked_fullframe_template_matching(default_structure, rot_list, edc):
+    mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
+    M = get_template_match_results_fullframe(default_structure, edc, rot_list, mask)
+    assert np.all(np.equal(M.inav[0, 1].data, None))
 
 """ Testing Vector Matching Results """
 

--- a/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
@@ -103,6 +103,12 @@ def get_template_match_results(structure, edc, rot_list, mask=None):
     indexer = IndexationGenerator(dp, library)
     return indexer.correlate(mask=mask, method="zero_mean_normalized_correlation")
 
+def get_template_match_results_fullframe(structure, edc, rot_list, mask=None):
+    dp = generate_diffraction_patterns(structure, edc)
+    library = get_template_library(structure, rot_list, edc)
+    indexer = IndexationGenerator(dp, library)
+    return indexer.correlate(mask=mask, method="full_frame_correlation")
+
 
 """ Tests for template matching """
 
@@ -122,6 +128,15 @@ def test_masked_template_matching(default_structure, rot_list, edc):
     mask = hs.signals.Signal1D(([[[1], [1]], [[0], [1]]]))
     M = get_template_match_results(default_structure, edc, rot_list, mask)
     assert np.all(np.equal(M.inav[0, 1].data, None))
+
+def test_fullframe_orientation_mapping_physical(structure, rot_list, edc):
+    M = get_template_match_results_fullframe(structure, edc, rot_list)
+    assert np.all(M.inav[0, 0] == M.inav[1, 0])
+    match_data = M.inav[0, 0].isig[1].data
+    for result_number in [0, 1, 2]:
+        np.testing.assert_allclose(
+            match_data[result_number][:2], [90, 90]
+        )  # always looking down c
 
 
 """ Testing Vector Matching Results """

--- a/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
+++ b/pyxem/tests/test_workflows/test_orientation_mapping_phys.py
@@ -118,6 +118,12 @@ def get_template_match_results_fullframe(structure, edc, rot_list, mask=None):
     indexer = IndexationGenerator(dp, library)
     return indexer.correlate(mask=mask, method="full_frame_correlation")
 
+def get_template_match_results_fullframe_bad_size(structure, edc, rot_list, mask=None):
+    dp = generate_difficult_diffraction_patterns(structure, edc)
+    library = get_template_library(structure, rot_list, edc)
+    indexer = IndexationGenerator(dp, library)
+    return indexer.correlate(mask=mask, method="full_frame_correlation")
+
 
 """ Tests for template matching """
 
@@ -131,13 +137,11 @@ def test_orientation_mapping_physical(structure, rot_list, edc):
         np.testing.assert_allclose(
             match_data[result_number][:2], [90, 90]
         )  # always looking down c
-    difficult_diff_pattern = generate_difficult_diffraction_patterns(structure, edc)
-    library = get_template_library(structure, rot_list, edc)
-    indexer_test = IndexationGenerator(difficult_diff_pattern, library)
-    with pytest.raises(
-            ValueError, match="Please select input signal and templates of dimensions 2**n X 2**n",
-        ):
-        indexer_test.correlate(method = "full_frame_correlation")
+
+@pytest.mark.xfail(raises=ValueError)
+def test_fullframe_bad_size(structure, rot_list, edc):
+    high_scores = get_template_match_results_fullframe_bad_size(structure, edc, rot_list)
+
 
 
 @pytest.mark.parametrize("structure", [create_Ortho(), create_Hex()])

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -112,7 +112,7 @@ def zero_mean_normalized_correlation(
     image_intensities,
     int_local,
     **kwargs
-):
+    ):
     """
     Computes the correlation score between an image and a template, using the formula
     .. math:: zero_mean_normalized_correlation

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -385,7 +385,7 @@ def correlate_library(image, library, n_largest, method, mask):
     if method == "full_frame_correlation":
         size = 2 * np.array(image.shape) - 1
         fsize = [optimal_fft_size(a, real = True) for a in (size)]
-        image_FT = np.fft.fftshift(np.fft.fftn(image, fsize))
+        image_FT = np.fft.fftshift(np.fft.rfftn(image, fsize))
         image_norm = np.linalg.norm(image)
 
     if mask == 1:

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -200,7 +200,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     fprod = pattern_FT * image_FT
 
-    res_matrix = np.fft.ifftn(fprod)
+    res_matrix = np.fft.fftshift(np.fft.ifftn(fprod))
     fsize = res_matrix.shape
     corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -266,7 +266,7 @@ def correlate_library_from_dict(image, template_dict, n_largest, method, mask):
         size = 2 * np.array(image.shape) - 1
         fsize = [optimal_fft_size(a, real = True) for a in (size)]
         image_FT = np.fft.fftshift(np.fft.rfftn(image, fsize))
-        image_norm = np.linalg.norm(image)
+        image_norm = np.sqrt(full_frame_correlation(image_FT, 1, image_FT, 1))
 
     if mask == 1:
         for phase_index, library_entry in enumerate(template_dict.values()):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -200,9 +200,9 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     fprod = pattern_FT * image_FT
 
-    res_matrix = np.fft.fftshift(np.fft.ifftn(fprod))
+    res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
+    corr_local = np.max(np.real(res_matrix)) #[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,7 +202,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
+    corr_local = np.max(np.real(res_matrix[0:6,0:6]))#[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -251,7 +251,7 @@ def correlate_library_from_dict(image, template_dict, n_largest, method, mask):
                         image_FT,
                         image_norm,
                         pat_local,
-                        px_local
+                        pn_local
                     )
 
                 if corr_local > np.min(corr_saved):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -170,7 +170,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
     corr_local = np.real(np.max(res_matrix[fsize[0]//2-3:fsize[0]//2+3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
-    if (image_norm > 0 and template_norm > 0):
+    if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 
     #Sub-pixel refinement can be done here - Equation (5) in reference article

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -168,6 +168,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
     fprod = pattern_FT * image_FT
 
     res_matrix = np.fft.ifftn(fprod)
+    fsize = res_matrix.shape
     corr_local = np.real(np.max(res_matrix[fsize[0]//2-3:fsize[0]//2+3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and template_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -112,7 +112,7 @@ def zero_mean_normalized_correlation(
     image_intensities,
     int_local,
     **kwargs
-    ):
+):
     """
     Computes the correlation score between an image and a template, using the formula
     .. math:: zero_mean_normalized_correlation
@@ -202,8 +202,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[ max(fsize[0] // 2 - 3, 0) : min(fsize[0] // 2 + 3, fsize[0]),\
-                                        max(fsize[1] // 2 - 3, 0) : min(fsize[1] // 2 + 3, fsize[1])]))
+    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 
@@ -267,7 +266,7 @@ def correlate_library_from_dict(image, template_dict, n_largest, method, mask):
         size = 2 * np.array(image.shape) - 1
         fsize = [optimal_fft_size(a, real = True) for a in (size)]
         image_FT = np.fft.fftshift(np.fft.rfftn(image, fsize))
-        image_norm = np.sqrt(full_frame_correlation(image_FT, 1, image_FT, 1))
+        image_norm = np.linalg.norm(image)
 
     if mask == 1:
         for phase_index, library_entry in enumerate(template_dict.values()):
@@ -869,6 +868,25 @@ def crystal_from_vector_matching(z_matches):
     results_array[2] = metrics
 
     return results_array
+
+
+def get_phase_name_and_index(library):
+
+    """ Get a dictionary of phase names and its corresponding index value in library.keys().
+
+     Parameters
+    ----------
+    library : DiffractionLibrary
+        Diffraction library containing the phases and rotations
+
+    Returns
+    -------
+    phase_name_index_dict : Dictionary {str : int}
+    typically on the form {'phase_name 1' : 0, 'phase_name 2': 1, ...}
+    """
+
+    phase_name_index_dict = dict([(y, x) for x, y in enumerate(list(library.keys()))])
+    return phase_name_index_dict
 
 
 def peaks_from_best_template(single_match_result, library, rank=0):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2020 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #
@@ -202,7 +202,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[fsize[0]//2-5:fsize[0]//2+5, fsize[1] // 2 - 5 : fsize[1] // 2 + 5]))
+    corr_local = np.max(np.real(res_matrix[fsize[0]//2-3:fsize[0]//2+3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -165,12 +165,12 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
      a refined template matching approach" doi: https://doi.org/10.1016/j.ultramic.2019.112845
     """
 
-    fprod = template_FT * image_FT
+    fprod = pattern_FT * image_FT
 
     res_matrix = np.fft.ifftn(fprod)
     corr_local = np.real(np.max(res_matrix[fsize[0]//2-3:fsize[0]//2+3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and template_norm > 0):
-        corr_local = corr_local / (image_norm * template_norm)
+        corr_local = corr_local / (image_norm * pattern_norm)
 
     #Sub-pixel refinement can be done here - Equation (5) in reference article
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,7 +202,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[fsize[0]//2-5:fsize[0]//2+5, fsize[1] // 2 - 5 : fsize[1] // 2 + 5]))
+    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -200,9 +200,9 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     fprod = pattern_FT * image_FT
 
-    res_matrix = np.fft.fftshift(np.fft.ifftn(fprod))
+    res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[fsize[0]//2-3:fsize[0]//2+3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
+    corr_local = np.max(np.real(res_matrix[fsize[0]//2-5:fsize[0]//2+5, fsize[1] // 2 - 5 : fsize[1] // 2 + 5]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -238,21 +238,6 @@ def correlate_library_from_dict(image, template_dict, n_largest, method, mask):
         correlated simulations for the experimental pattern of interest, where
         each entry is on the form [phase index, [z, x, z], correlation].
 
-    See also
-    --------
-    IndexationGenerator.correlate
-
-    Notes
-    -----
-    Correlation results are defined as,
-        phase_index : int
-            Index of the phase, following the ordering of the library keys
-        [z, x, z] : ndarray
-            numpy array of three floats, specifying the orientation in the
-            Bunge convention, in degrees.
-        correlation : float
-            A coefficient of correlation, only normalised to the template
-            intensity. This is in contrast to the reference work.
 
     References
     ----------
@@ -371,9 +356,6 @@ def correlate_library(image, library, n_largest, method, mask):
     Discussion on Normalized cross correlation (xcdskd):
     https://xcdskd.readthedocs.io/en/latest/cross_correlation/cross_correlation_coefficient.html
 
-    full_frame_correlation:
-    A. Foden, D. M. Collins, A. J. Wilkinson and T. B. Britton "Indexing electron backscatter diffraction patterns with
-     a refined template matching approach" doi: https://doi.org/10.1016/j.ultramic.2019.112845
     """
 
     top_matches = np.empty((len(library), n_largest, 3), dtype="object")
@@ -383,14 +365,6 @@ def correlate_library(image, library, n_largest, method, mask):
         average_image_intensity = np.average(image)
         image_std = np.linalg.norm(image - average_image_intensity)
 
-    """
-    Moved to correlate_library_from_dict
-    if method == "full_frame_correlation":
-        size = 2 * np.array(image.shape) - 1
-        fsize = [optimal_fft_size(a, real = True) for a in (size)]
-        image_FT = np.fft.fftshift(np.fft.rfftn(image, fsize))
-        image_norm = np.linalg.norm(image)
-    """
     if mask == 1:
         for phase_index, library_entry in enumerate(library.values()):
             orientations = library_entry["orientations"]
@@ -423,18 +397,6 @@ def correlate_library(image, library, n_largest, method, mask):
                         int_local,
                         pn_local
                     )
-
-                """
-                Moved to correlate_library_from_dict
-                elif method == "full_frame_correlation":
-                    corr_local = full_frame_correlation(
-                        image_FT,
-                        image_norm,
-                        fsize,
-                        px_local,
-                        int_local
-                    )
-                """
 
                 if corr_local > np.min(corr_saved):
                     or_saved[np.argmin(corr_saved)] = or_local

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,8 +202,8 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[ max(fsize[0] // 2 - 3, 0) : min(fsize[0] // 2 + 3, fsize[0]),\
-                                        max(fsize[1] // 2 - 3, 0) : min(fsize[1] // 2 + 3, fsize[1])]))
+    corr_local = np.max(np.real(res_matrix[ max(fsize[0] // 2 - 3, 0) : min(fsize[0] // 2 + 3, fsize[0] - 1),\
+                                        max(fsize[1] // 2 - 3, 0) : min(fsize[1] // 2 + 3, fsize[1] - 1)))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -59,19 +59,19 @@ def optimal_fft_size(target, real = False):
         Optimal FFT size.
     """
 
-    try:
+    try: # pragma: no cover
         from scipy.fft import next_fast_len
 
         support_real = True
 
-    except ImportError:
+    except ImportError: # pragma: no cover
         from scipy.fftpack import next_fast_len
 
         support_real = False
 
-    if support_real:
+    if support_real: # pragma: no cover
         return next_fast_len(target, real)
-    else:
+    else: # pragma: no cover
         return next_fast_len(target)
 
 # Functions used in correlate_library.

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -382,12 +382,14 @@ def correlate_library(image, library, n_largest, method, mask):
         average_image_intensity = np.average(image)
         image_std = np.linalg.norm(image - average_image_intensity)
 
+    """
+    Moved to correlate_library_from_dict
     if method == "full_frame_correlation":
         size = 2 * np.array(image.shape) - 1
         fsize = [optimal_fft_size(a, real = True) for a in (size)]
         image_FT = np.fft.fftshift(np.fft.rfftn(image, fsize))
         image_norm = np.linalg.norm(image)
-
+    """
     if mask == 1:
         for phase_index, library_entry in enumerate(library.values()):
             orientations = library_entry["orientations"]
@@ -421,6 +423,8 @@ def correlate_library(image, library, n_largest, method, mask):
                         pn_local
                     )
 
+                """
+                Moved to correlate_library_from_dict
                 elif method == "full_frame_correlation":
                     corr_local = full_frame_correlation(
                         image_FT,
@@ -429,6 +433,7 @@ def correlate_library(image, library, n_largest, method, mask):
                         px_local,
                         int_local
                     )
+                """
 
                 if corr_local > np.min(corr_saved):
                     or_saved[np.argmin(corr_saved)] = or_local

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,7 +202,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[0:6,0:6]))#[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
+    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -226,7 +226,7 @@ def correlate_library_from_dict(image, template_dict, n_largest, method, mask):
      a refined template matching approach" doi: https://doi.org/10.1016/j.ultramic.2019.112845
     """
 
-    top_matches = np.empty((len(library), n_largest, 3), dtype="object")
+    top_matches = np.empty((len(template_dict), n_largest, 3), dtype="object")
 
     if method == "full_frame_correlation":
         size = 2 * np.array(image.shape) - 1

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,7 +202,8 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
+    corr_local = np.max(np.real(res_matrix[ max(fsize[0] // 2 - 3, 0) : min(fsize[0] // 2 + 3, fsize[0] - 1),\
+                                        max(fsize[1] // 2 - 3, 0) : min(fsize[1] // 2 + 3, fsize[1] - 1)))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -200,7 +200,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     fprod = pattern_FT * image_FT
 
-    res_matrix = np.fft.ifftn(fprod)
+    res_matrix = np.fft.fftshift(np.fft.ifftn(fprod))
     fsize = res_matrix.shape
     corr_local = np.max(np.real(res_matrix[fsize[0]//2-3:fsize[0]//2+3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,8 +202,8 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix[ max(fsize[0] // 2 - 3, 0) : min(fsize[0] // 2 + 3, fsize[0] - 1),\
-                                        max(fsize[1] // 2 - 3, 0) : min(fsize[1] // 2 + 3, fsize[1] - 1)))
+    corr_local = np.max(np.real(res_matrix[ max(fsize[0] // 2 - 3, 0) : min(fsize[0] // 2 + 3, fsize[0]),\
+                                        max(fsize[1] // 2 - 3, 0) : min(fsize[1] // 2 + 3, fsize[1])]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -202,7 +202,7 @@ def full_frame_correlation(image_FT, image_norm, pattern_FT, pattern_norm):
 
     res_matrix = np.fft.ifftn(fprod)
     fsize = res_matrix.shape
-    corr_local = np.max(np.real(res_matrix)) #[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
+    corr_local = np.max(np.real(res_matrix[fsize[0] // 2 - 3 : fsize[0] // 2 + 3, fsize[1] // 2 - 3 : fsize[1] // 2 + 3]))
     if (image_norm > 0 and pattern_norm > 0):
         corr_local = corr_local / (image_norm * pattern_norm)
 


### PR DESCRIPTION
---
name: full_frame_correlation method
about: A method of comparing templates to signal in the frequency domain.

---

**Release Notes**
> new feature 
> Summary: Allows use of method = "full_frame_correlation" in the indexer.correlate() function. Algorithm is found in A. Foden, D. M. Collins, A. J. Wilkinson and T. B. Britton "Indexing electron backscatter diffraction patterns with a refined template matching approach"
doi: https://doi.org/10.1016/j.ultramic.2019.112845 (Eq 3).

**What does this PR do? Please describe and/or link to an open issue.**
Allows for comparison of templates to signal in the Fourier domain.

**Are there any known issues? Do you need help?**
The function works as intended when the next_fast_len() function returns the current length. There is a problem with tracking the direct beam when this is not the case, resulting in errors in the  final result. I have yet to come up with a good solution to this issue.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [] Fix case where the next_fast_len is used. Example: pattern of sides with length 357. 


