### PR TITLE
Radial averaging pixStem cleanup

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1432,9 +1432,6 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             pst._copy_axes_object_metadata(nav_axes, sig_axes)
         return s_adf
 
-    def radial_integration(self):
-        raise Exception("radial_integration has been renamed radial_average")
-
     def radial_average(
         self,
         centre_x=None,


### PR DESCRIPTION
Currently, the functionality for radially averaging (or azimuthal integrating) is duplicated, due to the pixstem/pyxem merge. This pull request aims to resolve this. Much of pixstem's `radial` module depends on this type of basic processing.

pyxem's azimuthal integration implementation is based on PyFAI, which contains a large number of very nice features. So the plan is to make the `radial` module work with the output from `diffraction2d.get_azimuthal_integral1d` or `diffraction2d.get_azimuthal_integral2d`.

**Remaining issues**

- [ ] Make it work with lazy signals
- [ ] Make `radial` module functions work with `get_azimuthal_integral` output
- [ ] Clean up tests

This is currently very much a work in progress, so more issues will probably be added in the future.