### PR TITLE
release 0.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: shell
 
 env:
   global:
-    - DEPS="hyperspy-base diffsims lmfit pyfai ipywidgets"
+    - DEPS="hyperspy-base==1.5.2 diffsims lmfit pyfai ipywidgets"
     - TEST_DEPS="pytest>=5.0 pytest-cov>=2.8.1 coveralls>=1.10 coverage>=5.0"
 
 matrix:

--- a/pyxem/dummy_data/__init__.py
+++ b/pyxem/dummy_data/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2020 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.

--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -1,5 +1,5 @@
 name = "pyxem"
-version = "0.13.0dev"
+version = "0.12.1"
 author = "Duncan Johnstone, Phillip Crout, Magnus Nord"
 copyright = "Copyright 2016-2020, The pyXem Developers"
 credits = [

--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -1,5 +1,5 @@
 name = "pyxem"
-version = "0.12.0"
+version = "0.13.0dev"
 author = "Duncan Johnstone, Phillip Crout, Magnus Nord"
 copyright = "Copyright 2016-2020, The pyXem Developers"
 credits = [

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "scikit-image >= 0.15.0",  # exclude_border argument in peak_finder laplacian (PR #436)
         "matplotlib >= 3.1.1",  # 3.1.0 failed
         "scikit-learn >= 0.19",  # reason unknown
-        "hyperspy >= 1.5.2",  # earlier versions incompatible with numpy >= 1.17.0
+        "hyperspy == 1.5.2",  # earlier versions incompatible with numpy >= 1.17.0 and hyperspy == 1.6.0 has a histogram bug
         "diffsims >= 0.2.3",  # Makes use of functionality introduced in this release
         "lmfit >= 0.9.12",
         "pyfai",


### PR DESCRIPTION
Patch release to deal with not packaging `dummy_data` correctly and to deal with any issues related to hyperspy-1.6.0 updates.