### PR TITLE
Add xrd

### DIFF
--- a/pyxem/__init__.py
+++ b/pyxem/__init__.py
@@ -45,6 +45,10 @@ from .signals.electron_diffraction1d import ElectronDiffraction1D
 from .signals.electron_diffraction2d import ElectronDiffraction2D
 from .signals.electron_diffraction1d import LazyElectronDiffraction1D
 from .signals.electron_diffraction2d import LazyElectronDiffraction2D
+from .signals.xray_diffraction1d import XrayDiffraction1D
+from .signals.xray_diffraction2d import XrayDiffraction2D
+from .signals.xray_diffraction1d import LazyXrayDiffraction1D
+from .signals.xray_diffraction2d import LazyXrayDiffraction2D
 from .signals.polar_diffraction2d import PolarDiffraction2D
 from .signals.polar_diffraction2d import LazyPolarDiffraction2D
 

--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -53,6 +53,18 @@ signals:
     dtype: real
     lazy: False
     module: pyxem.signals.electron_diffraction2d
+  XrayDiffraction1D:
+    signal_type: xray_diffraction
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    module: pyxem.signals.xray_diffraction1d
+  XrayDiffraction2D:
+    signal_type: xray_diffraction
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    module: pyxem.signals.xray_diffraction2d
   PolarDiffraction2D:
     signal_type: polar_diffraction
     signal_dimension: 2
@@ -71,6 +83,18 @@ signals:
     dtype: real
     lazy: True
     module: pyxem.signals.electron_diffraction2d
+  LazyXrayDiffraction1D:
+    signal_type: xray_diffraction
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: pyxem.signals.xray_diffraction1d
+  LazyXrayDiffraction2D:
+    signal_type: xray_diffraction
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: pyxem.signals.xray_diffraction2d
   LazyPolarDiffraction2D:
     signal_type: polar_diffraction
     signal_dimension: 2

--- a/pyxem/signals/electron_diffraction1d.py
+++ b/pyxem/signals/electron_diffraction1d.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
-"""Signal class for Electron Diffraction radial profiles
+"""Signal class for one-dimensional electron diffraction data.
 
 """
 from hyperspy._signals.lazy import LazySignal

--- a/pyxem/signals/xray_diffraction1d.py
+++ b/pyxem/signals/xray_diffraction1d.py
@@ -26,10 +26,9 @@ from pyxem.signals.diffraction1d import Diffraction1D
 class XrayDiffraction1D(Diffraction1D):
     _signal_type = "xray_diffraction"
 
-    def set_experimental_parameters(self,
-                                    beam_energy=None,
-                                    camera_length=None,
-                                    exposure_time=None):
+    def set_experimental_parameters(
+        self, beam_energy=None, camera_length=None, exposure_time=None
+    ):
         """Set experimental parameters in metadata.
 
         Parameters
@@ -44,16 +43,17 @@ class XrayDiffraction1D(Diffraction1D):
         md = self.metadata
 
         if beam_energy is not None:
-            md.set_item("Acquisition_instrument.I14.beam_energy",
-                        beam_energy)
+            md.set_item("Acquisition_instrument.I14.beam_energy", beam_energy)
         if camera_length is not None:
             md.set_item(
                 "Acquisition_instrument.I14.Detector.Diffraction.camera_length",
-                camera_length)
+                camera_length,
+            )
         if exposure_time is not None:
             md.set_item(
                 "Acquisition_instrument.I14.Detector.Diffraction.exposure_time",
-                exposure_time)
+                exposure_time,
+            )
 
     def set_scan_calibration(self, calibration):
         """Set scan pixel size in nanometres.
@@ -66,13 +66,13 @@ class XrayDiffraction1D(Diffraction1D):
         x = self.axes_manager.navigation_axes[0]
         y = self.axes_manager.navigation_axes[1]
 
-        x.name = 'x'
+        x.name = "x"
         x.scale = calibration
-        x.units = 'nm'
+        x.units = "nm"
 
-        y.name = 'y'
+        y.name = "y"
         y.scale = calibration
-        y.units = 'nm'
+        y.units = "nm"
 
 
 class LazyXrayDiffraction1D(LazySignal, XrayDiffraction1D):

--- a/pyxem/signals/xray_diffraction1d.py
+++ b/pyxem/signals/xray_diffraction1d.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
-"""Signal class for Electron Diffraction radial profiles
+"""Signal class for one-dimensional X-ray diffraction data.
 
 """
 from hyperspy._signals.lazy import LazySignal
@@ -25,25 +25,7 @@ from pyxem.signals.diffraction1d import Diffraction1D
 
 
 class XrayDiffraction1D(Diffraction1D):
-    _signal_type = "xray_diffraction1d"
-
-    def __init__(self, *args, **kwargs):
-        self, args, kwargs = push_metadata_through(self, *args, **kwargs)
-        super().__init__(*args, **kwargs)
-
-        # Set default attributes
-        if 'Acquisition_instrument' in self.metadata.as_dictionary():
-            if 'SEM' in self.metadata.as_dictionary()['Acquisition_instrument']:
-                self.metadata.set_item(
-                    "Acquisition_instrument.I14",
-                    self.metadata.Acquisition_instrument.SEM)
-                del self.metadata.Acquisition_instrument.SEM
-            if 'REM' in self.metadata.as_dictionary()['Acquisition_instrument']:
-                self.metadata.set_item(
-                    "Acquisition_instrument.I14",
-                    self.metadata.Acquisition_instrument.TEM)
-                del self.metadata.Acquisition_instrument.TEM
-        self.decomposition.__func__.__doc__ = BaseSignal.decomposition.__doc__
+    _signal_type = "xray_diffraction"
 
     def set_experimental_parameters(self,
                                     beam_energy=None,
@@ -73,16 +55,6 @@ class XrayDiffraction1D(Diffraction1D):
                 "Acquisition_instrument.I14.Detector.Diffraction.exposure_time",
                 exposure_time)
 
-    def set_diffraction_calibration(self, calibration):
-        """Set diffraction profile channel size in reciprocal Angstroms.
-
-        Parameters
-        ----------
-        calibration : float
-            Diffraction profile calibration in reciprocal Angstroms per pixel.
-        """
-        pass
-
     def set_scan_calibration(self, calibration):
         """Set scan pixel size in nanometres.
 
@@ -102,43 +74,7 @@ class XrayDiffraction1D(Diffraction1D):
         y.scale = calibration
         y.units = 'nm'
 
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the XrayDiffraction1D object as a
-        :py:class:`~pyxem.signals.xray_diffraction1d.LazyXrayDiffraction1D`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original XrayDiffraction1D object is
-            copied to the new LazyXrayDiffraction1D object.
-
-        Returns
-        -------
-        res : :py:class:`~pyxem.signals.xray_diffraction1d.LazyXrayDiffraction1D`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyXrayDiffraction1D
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = XrayDiffraction1D
-
 
 class LazyXrayDiffraction1D(LazySignal, XrayDiffraction1D):
 
-    _lazy = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = XrayDiffraction1D
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyXrayDiffraction1D
+    pass

--- a/pyxem/signals/xray_diffraction1d.py
+++ b/pyxem/signals/xray_diffraction1d.py
@@ -20,7 +20,6 @@
 """
 from hyperspy._signals.lazy import LazySignal
 
-from pyxem.signals import push_metadata_through
 from pyxem.signals.diffraction1d import Diffraction1D
 
 
@@ -29,6 +28,7 @@ class XrayDiffraction1D(Diffraction1D):
 
     def set_experimental_parameters(self,
                                     beam_energy=None,
+                                    camera_length=None,
                                     exposure_time=None):
         """Set experimental parameters in metadata.
 
@@ -45,7 +45,7 @@ class XrayDiffraction1D(Diffraction1D):
 
         if beam_energy is not None:
             md.set_item("Acquisition_instrument.I14.beam_energy",
-                        accelerating_voltage)
+                        beam_energy)
         if camera_length is not None:
             md.set_item(
                 "Acquisition_instrument.I14.Detector.Diffraction.camera_length",

--- a/pyxem/signals/xray_diffraction1d.py
+++ b/pyxem/signals/xray_diffraction1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #

--- a/pyxem/signals/xray_diffraction2d.py
+++ b/pyxem/signals/xray_diffraction2d.py
@@ -28,37 +28,9 @@ from pyxem.signals.diffraction2d import Diffraction2D
 class XrayDiffraction2D(Diffraction2D):
     _signal_type = "xray_diffraction"
 
-    def __init__(self, *args, **kwargs):
-        """
-        Create an XrayDiffraction2D object from an numpy.ndarray.
-
-        Parameters
-        ----------
-        *args :
-            Passed to the __init__ of Diffraction2D. The first arg should be
-            either a numpy.ndarray or a Signal2D
-        **kwargs :
-            Passed to the __init__ of Diffraction2D
-        """
-        self, args, kwargs = push_metadata_through(self, *args, **kwargs)
-        super().__init__(*args, **kwargs)
-
-        # Set default attributes
-        if 'Acquisition_instrument' in self.metadata.as_dictionary():
-            if 'SEM' in self.metadata.as_dictionary()['Acquisition_instrument']:
-                self.metadata.set_item(
-                    "Acquisition_instrument.I14",
-                    self.metadata.Acquisition_instrument.SEM)
-                del self.metadata.Acquisition_instrument.SEM
-            if 'REM' in self.metadata.as_dictionary()['Acquisition_instrument']:
-                self.metadata.set_item(
-                    "Acquisition_instrument.I14",
-                    self.metadata.Acquisition_instrument.TEM)
-                del self.metadata.Acquisition_instrument.TEM
-        self.decomposition.__func__.__doc__ = BaseSignal.decomposition.__doc__
-
     def set_experimental_parameters(self,
                                     beam_energy=None,
+                                    camera_length=None,
                                     exposure_time=None):
         """Set experimental parameters in metadata.
 
@@ -75,7 +47,7 @@ class XrayDiffraction2D(Diffraction2D):
 
         if beam_energy is not None:
             md.set_item("Acquisition_instrument.I14.beam_energy",
-                        accelerating_voltage)
+                        beam_energy)
         if camera_length is not None:
             md.set_item(
                 "Acquisition_instrument.I14.Detector.Diffraction.camera_length",

--- a/pyxem/signals/xray_diffraction2d.py
+++ b/pyxem/signals/xray_diffraction2d.py
@@ -22,7 +22,6 @@ import numpy as np
 from hyperspy.signals import BaseSignal
 from hyperspy._signals.lazy import LazySignal
 
-from pyxem.signals import push_metadata_through
 from pyxem.signals.diffraction2d import Diffraction2D
 
 

--- a/pyxem/signals/xray_diffraction2d.py
+++ b/pyxem/signals/xray_diffraction2d.py
@@ -28,10 +28,9 @@ from pyxem.signals.diffraction2d import Diffraction2D
 class XrayDiffraction2D(Diffraction2D):
     _signal_type = "xray_diffraction"
 
-    def set_experimental_parameters(self,
-                                    beam_energy=None,
-                                    camera_length=None,
-                                    exposure_time=None):
+    def set_experimental_parameters(
+        self, beam_energy=None, camera_length=None, exposure_time=None
+    ):
         """Set experimental parameters in metadata.
 
         Parameters
@@ -46,16 +45,17 @@ class XrayDiffraction2D(Diffraction2D):
         md = self.metadata
 
         if beam_energy is not None:
-            md.set_item("Acquisition_instrument.I14.beam_energy",
-                        beam_energy)
+            md.set_item("Acquisition_instrument.I14.beam_energy", beam_energy)
         if camera_length is not None:
             md.set_item(
                 "Acquisition_instrument.I14.Detector.Diffraction.camera_length",
-                camera_length)
+                camera_length,
+            )
         if exposure_time is not None:
             md.set_item(
                 "Acquisition_instrument.I14.Detector.Diffraction.exposure_time",
-                exposure_time)
+                exposure_time,
+            )
 
     def set_scan_calibration(self, calibration):
         """Set scan pixel size in nanometres.
@@ -68,13 +68,13 @@ class XrayDiffraction2D(Diffraction2D):
         x = self.axes_manager.navigation_axes[0]
         y = self.axes_manager.navigation_axes[1]
 
-        x.name = 'x'
+        x.name = "x"
         x.scale = calibration
-        x.units = 'nm'
+        x.units = "nm"
 
-        y.name = 'y'
+        y.name = "y"
         y.scale = calibration
-        y.units = 'nm'
+        y.units = "nm"
 
 
 class LazyXrayDiffraction2D(LazySignal, XrayDiffraction2D):

--- a/pyxem/signals/xray_diffraction2d.py
+++ b/pyxem/signals/xray_diffraction2d.py
@@ -27,11 +27,11 @@ from pyxem.signals.diffraction2d import Diffraction2D
 
 
 class XrayDiffraction2D(Diffraction2D):
-    _signal_type = "xray_diffraction2d"
+    _signal_type = "xray_diffraction"
 
     def __init__(self, *args, **kwargs):
         """
-        Create an XrayDiffraction2D object from a hs.Signal2D or np.array.
+        Create an XrayDiffraction2D object from an numpy.ndarray.
 
         Parameters
         ----------
@@ -86,20 +86,6 @@ class XrayDiffraction2D(Diffraction2D):
                 "Acquisition_instrument.I14.Detector.Diffraction.exposure_time",
                 exposure_time)
 
-    def set_diffraction_calibration(self, calibration, center=None):
-        """Set diffraction pattern pixel size in reciprocal Angstroms and origin
-        location.
-
-        Parameters
-        ----------
-        calibration : float
-            Diffraction pattern calibration in reciprocal Angstroms per pixel.
-        center : tuple
-            Position of the direct beam center, in pixels. If None the center of
-            the data array is assumed to be the center of the pattern.
-        """
-        pass
-
     def set_scan_calibration(self, calibration):
         """Set scan pixel size in nanometres.
 
@@ -119,43 +105,7 @@ class XrayDiffraction2D(Diffraction2D):
         y.scale = calibration
         y.units = 'nm'
 
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the XrayDiffraction2D object as a
-        :py:class:`~pyxem.signals.xray_diffraction2d.LazyXrayDiffraction2D`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original XrayDiffraction2D object is
-            copied to the new LazyXrayDiffraction2D object.
-
-        Returns
-        -------
-        res : :py:class:`~pyxem.signals.xray_diffraction2d.LazyXrayDiffraction2D`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyXrayDiffraction2D
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = XrayDiffraction2D
-
 
 class LazyXrayDiffraction2D(LazySignal, XrayDiffraction2D):
 
-    _lazy = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = XrayDiffraction2D
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyXrayDiffraction2D
+    pass

--- a/pyxem/signals/xray_diffraction2d.py
+++ b/pyxem/signals/xray_diffraction2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #

--- a/pyxem/signals/xray_diffraction2d.py
+++ b/pyxem/signals/xray_diffraction2d.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
-"""Signal class for two-dimensional electron diffraction data.
+"""Signal class for two-dimensional X-ray diffraction data.
 """
 
 import numpy as np
@@ -118,7 +118,7 @@ class XrayDiffraction2D(Diffraction2D):
         y.name = 'y'
         y.scale = calibration
         y.units = 'nm'
-        
+
     def as_lazy(self, *args, **kwargs):
         """Create a copy of the XrayDiffraction2D object as a
         :py:class:`~pyxem.signals.xray_diffraction2d.LazyXrayDiffraction2D`.

--- a/pyxem/tests/conftest.py
+++ b/pyxem/tests/conftest.py
@@ -29,6 +29,8 @@ from transforms3d.euler import euler2mat
 from pyxem.signals.diffraction2d import Diffraction2D
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from pyxem.signals.electron_diffraction1d import ElectronDiffraction1D
+from pyxem.signals.xray_diffraction2d import XrayDiffraction2D
+from pyxem.signals.xray_diffraction1d import XrayDiffraction1D
 from diffsims.libraries.vector_library import DiffractionVectorLibrary
 
 from pyxem.utils.indexation_utils import OrientationResult
@@ -138,6 +140,21 @@ def electron_diffraction1d():
     )
 
     return ElectronDiffraction1D(data)
+
+
+@pytest.fixture
+def xray_diffraction1d():
+    """A simple, multiuse diffraction profile, with dimensions:
+    XrayDiffraction1D <2,2|12>
+    """
+    data = np.array(
+        [
+            [[1.0, 0.25, 0.0, 0.0, 0.0], [1.0, 0.25, 0.0, 0.0, 0.0]],
+            [[1.0, 0.25, 0.0, 0.0, 0.16666667], [1.5, 0.5, 0.0, 0.0, 0.0]],
+        ]
+    )
+
+    return XrayDiffraction1D(data)
 
 
 @pytest.fixture

--- a/pyxem/tests/test_signals/test_lazy_xray_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_lazy_xray_diffraction1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #

--- a/pyxem/tests/test_signals/test_lazy_xray_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_lazy_xray_diffraction2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #

--- a/pyxem/tests/test_signals/test_xray_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_xray_diffraction1d.py
@@ -28,9 +28,9 @@ class TestSimpleHyperspy:
     # Tests functions that assign to hyperspy metadata
 
     def test_set_experimental_parameters(self, xray_diffraction1d):
-        xray_diffraction1d.set_experimental_parameters(beam_energy=3,
-                                                       camera_length=3,
-                                                       exposure_time=1)
+        xray_diffraction1d.set_experimental_parameters(
+            beam_energy=3, camera_length=3, exposure_time=1
+        )
         assert isinstance(xray_diffraction1d, XrayDiffraction1D)
 
     def test_set_scan_calibration(self, xray_diffraction1d):
@@ -39,25 +39,23 @@ class TestSimpleHyperspy:
 
 
 class TestComputeAndAsLazyXray1D:
-
     def test_2d_data_compute(self):
         dask_array = da.random.random((100, 150), chunks=(50, 50))
         s = LazyXrayDiffraction1D(dask_array)
-        scale0, scale1, metadata_string = 0.5, 1.5, 'test'
+        scale0, scale1, metadata_string = 0.5, 1.5, "test"
         s.axes_manager[0].scale = scale0
         s.axes_manager[1].scale = scale1
         s.metadata.Test = metadata_string
         s.compute()
         assert s.__class__ == XrayDiffraction1D
-        assert not hasattr(s.data, 'compute')
+        assert not hasattr(s.data, "compute")
         assert s.axes_manager[0].scale == scale0
         assert s.axes_manager[1].scale == scale1
         assert s.metadata.Test == metadata_string
         assert dask_array.shape == s.data.shape
 
     def test_3d_data_compute(self):
-        dask_array = da.random.random((4, 10, 15),
-                                      chunks=(1, 10, 15))
+        dask_array = da.random.random((4, 10, 15), chunks=(1, 10, 15))
         s = LazyXrayDiffraction1D(dask_array)
         s.compute()
         assert s.__class__ == XrayDiffraction1D
@@ -66,13 +64,13 @@ class TestComputeAndAsLazyXray1D:
     def test_2d_data_as_lazy(self):
         data = np.random.random((100, 150))
         s = XrayDiffraction1D(data)
-        scale0, scale1, metadata_string = 0.5, 1.5, 'test'
+        scale0, scale1, metadata_string = 0.5, 1.5, "test"
         s.axes_manager[0].scale = scale0
         s.axes_manager[1].scale = scale1
         s.metadata.Test = metadata_string
         s_lazy = s.as_lazy()
         assert s_lazy.__class__ == LazyXrayDiffraction1D
-        assert hasattr(s_lazy.data, 'compute')
+        assert hasattr(s_lazy.data, "compute")
         assert s_lazy.axes_manager[0].scale == scale0
         assert s_lazy.axes_manager[1].scale == scale1
         assert s_lazy.metadata.Test == metadata_string

--- a/pyxem/tests/test_signals/test_xray_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_xray_diffraction1d.py
@@ -27,26 +27,15 @@ from pyxem.signals.xray_diffraction1d import LazyXrayDiffraction1D
 class TestSimpleHyperspy:
     # Tests functions that assign to hyperspy metadata
 
-    def test_set_experimental_parameters(self, electron_diffraction1d):
-        xray_diffraction1d = XrayDiffraction1D(electron_diffraction1d)
+    def test_set_experimental_parameters(self, xray_diffraction1d):
         xray_diffraction1d.set_experimental_parameters(beam_energy=3,
                                                        camera_length=3,
                                                        exposure_time=1)
         assert isinstance(xray_diffraction1d, XrayDiffraction1D)
 
-    def test_set_scan_calibration(self, electron_diffraction1d):
-        xray_diffraction1d = XrayDiffraction1D(electron_diffraction1d)
+    def test_set_scan_calibration(self, xray_diffraction1d):
         xray_diffraction1d.set_scan_calibration(19)
-        assert isinstance(electron_diffraction1d, XrayDiffraction1D)
-
-    @pytest.mark.parametrize('calibration', [1, 0.017, 0.5, ])
-    def test_set_diffraction_calibration(self,
-                                         electron_diffraction1d,
-                                         calibration):
-        xray_diffraction1d = XrayDiffraction1D(electron_diffraction1d)
-        xray_diffraction1d.set_diffraction_calibration(calibration)
-        dx = xray_diffraction1d.axes_manager.signal_axes[0]
-        assert dx.scale == calibration
+        assert isinstance(xray_diffraction1d, XrayDiffraction1D)
 
 
 class TestComputeAndAsLazyXray1D:
@@ -99,6 +88,5 @@ class TestComputeAndAsLazyXray1D:
 
 class TestDecomposition:
     def test_decomposition_class_assignment(self, xray_diffraction1d):
-        xray_diffraction1d = XrayDiffraction1D(electron_diffraction1d)
         xray_diffraction1d.decomposition()
         assert isinstance(xray_diffraction1d, XrayDiffraction1D)

--- a/pyxem/tests/test_signals/test_xray_diffraction1d.py
+++ b/pyxem/tests/test_signals/test_xray_diffraction1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #

--- a/pyxem/tests/test_signals/test_xray_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_xray_diffraction2d.py
@@ -47,22 +47,6 @@ class TestSimpleHyperspy:
         diffraction_pattern.set_scan_calibration(19)
         assert isinstance(diffraction_pattern, XrayDiffraction2D)
 
-    @pytest.mark.parametrize('calibration, center', [
-        (1, (4, 4),),
-        (0.017, (3, 3)),
-        (0.5, None,), ])
-    def test_set_diffraction_calibration(self,
-                                         diffraction_pattern,
-                                         calibration, center):
-        diffraction_pattern = XrayDiffraction2D(diffraction_pattern)
-        calibrated_center = calibration * np.array(center) if center is not None else center
-        diffraction_pattern.set_diffraction_calibration(calibration, center=calibrated_center)
-        dx, dy = diffraction_pattern.axes_manager.signal_axes
-        assert dx.scale == calibration and dy.scale == calibration
-        if center is not None:
-            assert np.all(diffraction_pattern.isig[0., 0.].data ==
-                          diffraction_pattern.isig[center[0], center[1]].data)
-
 
 class TestComputeAndAsLazyXray2D:
 

--- a/pyxem/tests/test_signals/test_xray_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_xray_diffraction2d.py
@@ -29,7 +29,9 @@ from pyxem.signals.xray_diffraction2d import LazyXrayDiffraction2D
 
 def test_init():
     z = np.zeros((2, 2, 2, 2))
-    dp = XrayDiffraction2D(z, metadata={'Acquisition_instrument': {'SEM': 'Expensive-SEM'}})
+    dp = XrayDiffraction2D(
+        z, metadata={"Acquisition_instrument": {"SEM": "Expensive-SEM"}}
+    )
 
 
 class TestSimpleHyperspy:
@@ -37,9 +39,9 @@ class TestSimpleHyperspy:
 
     def test_set_experimental_parameters(self, diffraction_pattern):
         diffraction_pattern = XrayDiffraction2D(diffraction_pattern)
-        diffraction_pattern.set_experimental_parameters(beam_energy=3,
-                                                        camera_length=3,
-                                                        exposure_time=1)
+        diffraction_pattern.set_experimental_parameters(
+            beam_energy=3, camera_length=3, exposure_time=1
+        )
         assert isinstance(diffraction_pattern, XrayDiffraction2D)
 
     def test_set_scan_calibration(self, diffraction_pattern):
@@ -49,25 +51,23 @@ class TestSimpleHyperspy:
 
 
 class TestComputeAndAsLazyXray2D:
-
     def test_2d_data_compute(self):
         dask_array = da.random.random((100, 150), chunks=(50, 50))
         s = LazyXrayDiffraction2D(dask_array)
-        scale0, scale1, metadata_string = 0.5, 1.5, 'test'
+        scale0, scale1, metadata_string = 0.5, 1.5, "test"
         s.axes_manager[0].scale = scale0
         s.axes_manager[1].scale = scale1
         s.metadata.Test = metadata_string
         s.compute()
         assert s.__class__ == XrayDiffraction2D
-        assert not hasattr(s.data, 'compute')
+        assert not hasattr(s.data, "compute")
         assert s.axes_manager[0].scale == scale0
         assert s.axes_manager[1].scale == scale1
         assert s.metadata.Test == metadata_string
         assert dask_array.shape == s.data.shape
 
     def test_4d_data_compute(self):
-        dask_array = da.random.random((4, 4, 10, 15),
-                                      chunks=(1, 1, 10, 15))
+        dask_array = da.random.random((4, 4, 10, 15), chunks=(1, 1, 10, 15))
         s = LazyXrayDiffraction2D(dask_array)
         s.compute()
         assert s.__class__ == XrayDiffraction2D
@@ -76,13 +76,13 @@ class TestComputeAndAsLazyXray2D:
     def test_2d_data_as_lazy(self):
         data = np.random.random((100, 150))
         s = XrayDiffraction2D(data)
-        scale0, scale1, metadata_string = 0.5, 1.5, 'test'
+        scale0, scale1, metadata_string = 0.5, 1.5, "test"
         s.axes_manager[0].scale = scale0
         s.axes_manager[1].scale = scale1
         s.metadata.Test = metadata_string
         s_lazy = s.as_lazy()
         assert s_lazy.__class__ == LazyXrayDiffraction2D
-        assert hasattr(s_lazy.data, 'compute')
+        assert hasattr(s_lazy.data, "compute")
         assert s_lazy.axes_manager[0].scale == scale0
         assert s_lazy.axes_manager[1].scale == scale1
         assert s_lazy.metadata.Test == metadata_string

--- a/pyxem/tests/test_signals/test_xray_diffraction2d.py
+++ b/pyxem/tests/test_signals/test_xray_diffraction2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The pyXem developers
+# Copyright 2016-2020 The pyXem developers
 #
 # This file is part of pyXem.
 #


### PR DESCRIPTION
This adds `XrayDiffraction1D` and `XrayDiffraction2D` classes to pyxem. We probably need to make some decisions regarding metadata/attributes/properties which has become a bit of a mess in `Diffraction` and `ElectronDiffraction` classes. 

We should maybe also consider having a `Detector` object in metadata/attributes/properties to define more of the experimental geometry - or we could leave that in workflow...

@pquinn-dls and @ptim0626 will hopefully have some opinions about what's important here.