### PR TITLE
Move testing to python versions 3.9 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,45 +2,45 @@ language: shell
 
 env:
   global:
-    - DEPS="scikit-image>=0.15.0 matplotlib>=3.1.1 scikit-learn>=0.19 hyperspy-base==1.5.2 diffsims>=0.3 lmfit>=0.9.12 ipywidgets pyfai-base numba"
+    - DEPS="scikit-image>=0.15.0 matplotlib-base>=3.1.1 scikit-learn>=0.19 hyperspy-base==1.5.2 diffsims>=0.3 lmfit>=0.9.12 ipywidgets pyfai-base numba"
     - TEST_DEPS="pytest>=5.0 pytest-cov>=2.8.1 coveralls>=1.10 coverage>=5.0"
 
 matrix:
   include:
+  - name: "Python 3.9 on Linux"
+    env: export PYTHON=3.9; PIPONLY="false"
+    before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+
   - name: "Python 3.8 on Linux"
     env: export PYTHON=3.8; PIPONLY="false"
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
-  - name: "Python 3.7 on Linux"
-    env: export PYTHON=3.7; PIPONLY="false"
+  - name: "3.9, Linux, pip"
+    env: export PYTHON=3.9; PIPONLY="true"
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
   - name: "3.8, Linux, pip"
     env: export PYTHON=3.8; PIPONLY="true"
     before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
-  - name: "3.7, Linux, pip"
-    env: export PYTHON=3.7; PIPONLY="true"
-    before_install: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - name: "Python 3.9 on MacOS"
+    os: osx
+    env: export PYTHON=3.9; PIPONLY="false"
+    before_install: wget "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -O miniconda.sh
 
   - name: "Python 3.8 on MacOS"
     os: osx
     env: export PYTHON=3.8; PIPONLY="false"
     before_install: wget "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -O miniconda.sh
 
-  - name: "Python 3.7 on MacOS"
-    os: osx
-    env: export PYTHON=3.7; PIPONLY="false"
-    before_install: wget "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -O miniconda.sh
+  - name: "Python 3.9 on Windows"
+    os: windows
+    env: EXPORT PYTHON=3.9; PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"; PIPONLY="false"
+    before_install: choco install -y miniconda3 openssl.light
 
   - name: "Python 3.8 on Windows"
     os: windows
     env: EXPORT PYTHON=3.8; PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"; PIPONLY="false"
-    before_install: choco install -y miniconda3 openssl.light
-
-  - name: "Python 3.7 on Windows"
-    os: windows
-    env: EXPORT PYTHON=3.7; PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH"; PIPONLY="false"
     before_install: choco install -y miniconda3 openssl.light
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Azimuthal integration has been refactored (see PR #625 for details)
+- Testing now runs for python version 3.9 and 3.8
 
 ### Removed
 - The local_gaussian_method for subpixel refinement


### PR DESCRIPTION
---
name: Move testing to python versions 3.9 and 3.8
about: See #650

---

**Checklist**
- [x] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
For the bleeding edge version, testing will now be of 3.9 and 3.8. Also while I was there I made the test-suite matplotlib install consistent with what we get from `conda`.

**Describe alternatives you've considered**
Keeping 3.7 in some form, but as pyxem is a long way from a minor release this seems like overkill. If 3.9 shows issues, I'll make a backport for 0.12.x which support `.7`,`.8 `and `.9`