### PR TITLE
scikit-image dependency update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: shell
 
 env:
   global:
-    - DEPS="scikit-image>=0.15.0 matplotlib>=3.1.1 scikit-learn>=0.19 hyperspy-base==1.5.2 diffsims>=0.3 lmfit>=0.9.12 ipywidgets pyfai-base numba"
+    - DEPS="scikit-image>=0.17 matplotlib>=3.1.1 scikit-learn>=0.19 hyperspy-base==1.5.2 diffsims>=0.3 lmfit>=0.9.12 ipywidgets pyfai-base numba"
     - TEST_DEPS="pytest>=5.0 pytest-cov>=2.8.1 coveralls>=1.10 coverage>=5.0"
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Azimuthal integration has been refactored (see PR #625 for details)
+- scikit-image dependancy is now version 0.17 and up
 
 ### Removed
 - The local_gaussian_method for subpixel refinement

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(),
     # adjust the tabbing
     install_requires=[
-        "scikit-image >= 0.15.0, < 0.17",  # 0.17 is currently not avaliable on conda
+        "scikit-image >= 0.17",  # 0.17 is currently not avaliable on conda
         "matplotlib >= 3.1.1",  # 3.1.0 failed
         "scikit-learn >= 0.19",  # reason unknown
         "hyperspy == 1.5.2",  # earlier versions incompatible with numpy >= 1.17.0 and hyperspy == 1.6.0 has a histogram bug


### PR DESCRIPTION
---
name: scikit-image dependency update
about: The 0.12.x series is locked to an older version of scikit image, as conda had been misbehaving, this PR attempts to bring us up to speed.

---

**Checklist**
- [x] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**Work in progress?**
If you know there is more to do, make a checklist here:
- [ ] Make API adjustments so that tests pass
- [ ] Configure travis so that it can find suitable versions
