### PR TITLE
Change order of shifts in get_direct_beam_position from [y, x] to [x, y]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Azimuthal integration has been refactored (see PR #625 for details)
+- get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
 
 ### Removed
 - The local_gaussian_method for subpixel refinement

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -926,11 +926,12 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         Returns
         -------
         s_shifts : HyperSpy Signal1D
-            Array containing the shifts for each SED pattern.
+            Array containing the shifts for each SED pattern, with the first
+            signal index being the x-shift and the second the y-shift.
 
         """
 
-        signal_shape = self.axes_manager.signal_shape[::-1]
+        signal_shape = self.axes_manager.signal_shape
         origin_coordinates = np.array(signal_shape) / 2
 
         method_dict = {
@@ -1040,7 +1041,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         else:
             shifts = self.get_direct_beam_position(method=method, **kwargs)
 
-        shifts = -1 * shifts.data
+        shifts = -1 * np.flip(shifts.data, -1)
         shifts = shifts.reshape(nav_size, 2)
 
         # Preserve existing behaviour by overriding

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -453,8 +453,8 @@ class TestGetDirectBeamPosition:
         s, x_pos_list, y_pos_list = self.s, self.x_pos_list, self.y_pos_list
         s_shift = s.get_direct_beam_position(method="blur", sigma=1)
         assert s.axes_manager.navigation_shape == s_shift.axes_manager.navigation_shape
-        assert (-(x_pos_list - dx / 2) == s_shift.isig[1].data[0]).all()
-        assert (-(y_pos_list - dy / 2) == s_shift.isig[0].data[:, 0]).all()
+        assert (-(x_pos_list - dx / 2) == s_shift.isig[0].data[0]).all()
+        assert (-(y_pos_list - dy / 2) == s_shift.isig[1].data[:, 0]).all()
 
     def test_interpolate(self):
         dx, dy = self.dx, self.dy
@@ -463,8 +463,8 @@ class TestGetDirectBeamPosition:
             method="interpolate", sigma=1, upsample_factor=2, kind="nearest",
         )
         assert s.axes_manager.navigation_shape == s_shift.axes_manager.navigation_shape
-        assert (-(x_pos_list - dx / 2) == s_shift.isig[1].data[0]).all()
-        assert (-(y_pos_list - dy / 2) == s_shift.isig[0].data[:, 0]).all()
+        assert (-(x_pos_list - dx / 2) == s_shift.isig[0].data[0]).all()
+        assert (-(y_pos_list - dy / 2) == s_shift.isig[1].data[:, 0]).all()
 
     def test_cross_correlate(self):
         s = self.s

--- a/pyxem/tests/utils/test_expt_utils.py
+++ b/pyxem/tests/utils/test_expt_utils.py
@@ -152,7 +152,7 @@ class TestCenteringAlgorithm:
         shifts = find_beam_offset_cross_correlation(z, 1, 4)
         assert np.allclose(shifts, shifts_expected, atol=0.2)
 
-    @pytest.mark.parametrize("shifts_expected", [(-3.5, +0.5)])
+    @pytest.mark.parametrize("shifts_expected", [(+0.5, -3.5)])
     @pytest.mark.parametrize("sigma", [1, 2, 3])
     def test_single_pixel_spot(self, shifts_expected, sigma):
         z = np.zeros((50, 50))
@@ -161,7 +161,7 @@ class TestCenteringAlgorithm:
         shifts = find_beam_offset_cross_correlation(z, 1, 6)
         assert np.allclose(shifts, shifts_expected, atol=0.2)
 
-    @pytest.mark.parametrize("shifts_expected", [(-4.5, -0.5)])
+    @pytest.mark.parametrize("shifts_expected", [(-0.5, -4.5)])
     def test_broader_starting_square_spot(self, shifts_expected):
         z = np.zeros((50, 50))
         z[28:31, 24:27] = 1
@@ -170,7 +170,7 @@ class TestCenteringAlgorithm:
         assert np.allclose(shifts, shifts_expected, atol=0.2)
 
 
-@pytest.mark.parametrize("center_expected", [(29, 25)])
+@pytest.mark.parametrize("center_expected", [(25, 29)])
 @pytest.mark.parametrize("sigma", [1, 2, 3])
 def test_find_beam_center_blur(center_expected, sigma):
     z = np.zeros((50, 50))
@@ -180,7 +180,7 @@ def test_find_beam_center_blur(center_expected, sigma):
     assert np.allclose(shifts, center_expected, atol=0.2)
 
 
-@pytest.mark.parametrize("center_expected", [(29.52, 25.97)])
+@pytest.mark.parametrize("center_expected", [(25.97, 29.52)])
 @pytest.mark.parametrize("sigma", [1, 2, 3])
 def test_find_beam_center_interpolate_1(center_expected, sigma):
     z = np.zeros((50, 50))
@@ -190,7 +190,7 @@ def test_find_beam_center_interpolate_1(center_expected, sigma):
     assert np.allclose(centers, center_expected, atol=0.2)
 
 
-@pytest.mark.parametrize("center_expected", [(9, 44)])
+@pytest.mark.parametrize("center_expected", [(44, 9)])
 @pytest.mark.parametrize("sigma", [2])
 def test_find_beam_center_interpolate_2(center_expected, sigma):
     """Cover unlikely case when beam is close to the edge"""

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -629,7 +629,7 @@ def find_beam_center_interpolate(z, sigma, upsample_factor, kind):
     Returns
     -------
     center : np.array
-        np.array containing indices of estimated direct beam positon.
+        np.array, [y, x] containing indices of estimated direct beam positon
     """
     xx = np.sum(z, axis=1)
     yy = np.sum(z, axis=0)
@@ -637,7 +637,7 @@ def find_beam_center_interpolate(z, sigma, upsample_factor, kind):
     cx = _find_peak_max(xx, sigma, upsample_factor=upsample_factor, kind=kind)
     cy = _find_peak_max(yy, sigma, upsample_factor=upsample_factor, kind=kind)
 
-    center = np.array([cx, cy])
+    center = np.array([cy, cx])
     return center
 
 
@@ -653,10 +653,10 @@ def find_beam_center_blur(z, sigma):
     Returns
     -------
     center : np.array
-        np.array containing indices of estimated direct beam positon.
+        np.array [y, x] containing indices of estimated direct beam positon.
     """
     blurred = ndi.gaussian_filter(z, sigma, mode="wrap")
-    center = np.unravel_index(blurred.argmax(), blurred.shape)
+    center = np.unravel_index(blurred.argmax(), blurred.shape)[::-1]
     return np.array(center)
 
 
@@ -679,7 +679,7 @@ def find_beam_offset_cross_correlation(z, radius_start, radius_finish):
     Returns
     -------
     shift: np.array
-        np.array containing offset (from center) of the direct beam positon.
+        np.array [y, x] containing offset (from center) of the direct beam positon.
     """
     radiusList = np.arange(radius_start, radius_finish)
     errRecord = np.zeros_like(radiusList, dtype="single")
@@ -709,6 +709,7 @@ def find_beam_offset_cross_correlation(z, radius_start, radius_finish):
     im = hann2d * z
     shift, error, diffphase = register_translation(ref, im, 100)
 
+    shift = shift[::-1]
     return shift - 0.5
 
 


### PR DESCRIPTION
As mentioned in https://github.com/pyxem/pyxem/pull/648, the `x`- and `y`-shift output from `s.get_direct_beam_position` is currently in the `[y, x]` order in the HyperSpy signal. In other words, `s_shift_x = s_shift.isig[1]` and `s_shift_y = s_shift.isig[0]`.

This pull request reverses this, putting the `x`- and `y`-shifts in the `[x, y]` order, meaning: `s_shift_x = s_shift.isig[0]` and `s_shift_y = s_shift.isig[1]`.

**Todos**
- [x]  Switch order in `s.get_direct_beam_position`
- [x]  Update `s.center_direct_beam`
- [x]  Update unit tests
- [x]  Update CHANGELOG.md

**Next step**
Adding lazy version of `s.center_direct_beam`