### PR TITLE
Improve plotting of large LazyDiffraction2D signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Azimuthal integration has been refactored (see PR #625 for details)
 - get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
+- Plotting large, lazy, datasets will be much faster now (#655)
 
 ### Removed
 - The local_gaussian_method for subpixel refinement

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -2670,7 +2670,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             y = round(self.axes_manager.signal_shape[1] / 2)
             if self._lazy:
                 isig_slice = get_signal_dimension_host_chunk_slice(
-                    x, y, self.data.chunks)
+                    x, y, self.data.chunks
+                )
             else:
                 isig_slice = np.s_[x, y]
             s = self.isig[isig_slice]

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -83,7 +83,7 @@ from pyxem.utils.peakfinders2D import (
 from pyxem.utils.dask_tools import (
     _process_dask_array,
     _get_dask_array,
-    get_host_chunk_slice,
+    get_signal_dimension_host_chunk_slice,
 )
 
 from pyxem.utils import peakfinder2D_gui
@@ -2669,7 +2669,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             x = round(self.axes_manager.signal_shape[0] / 2)
             y = round(self.axes_manager.signal_shape[1] / 2)
             if self._lazy:
-                isig_slice = get_host_chunk_slice(x, y, self.data.chunks)
+                isig_slice = get_signal_dimension_host_chunk_slice(
+                    x, y, self.data.chunks)
             else:
                 isig_slice = np.s_[x, y]
             s = self.isig[isig_slice]

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -2660,9 +2660,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return s_bad_pixel_removed
 
     def make_probe_navigation(self, method="fast"):
-        if self.axes_manager.navigation_dimension > 2:
+        nav_dim = self.axes_manager.navigation_dimension
+        if (0 == nav_dim) or (nav_dim > 2):
             raise ValueError(
-                "Probe navigation can only be made for signals with 2 or less "
+                "Probe navigation can only be made for signals with 1 or 2 "
                 "navigation dimensions"
             )
         if method == "fast":
@@ -2686,6 +2687,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         if "navigator" in kwargs:
             super().plot(*args, **kwargs)
         elif self.axes_manager.navigation_dimension > 2:
+            super().plot(*args, **kwargs)
+        elif self.axes_manager.navigation_dimension == 0:
             super().plot(*args, **kwargs)
         else:
             if hasattr(self, "_navigator_probe"):

--- a/pyxem/signals/electron_diffraction2d.py
+++ b/pyxem/signals/electron_diffraction2d.py
@@ -24,7 +24,7 @@ import numpy as np
 from hyperspy.signals import BaseSignal
 from hyperspy._signals.lazy import LazySignal
 
-from pyxem.signals.diffraction2d import Diffraction2D
+from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
 from diffsims.utils.sim_utils import get_electron_wavelength
 
 
@@ -217,6 +217,6 @@ class ElectronDiffraction2D(Diffraction2D):
         y.units = "nm"
 
 
-class LazyElectronDiffraction2D(LazySignal, ElectronDiffraction2D):
+class LazyElectronDiffraction2D(LazyDiffraction2D, ElectronDiffraction2D):
 
     pass

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -550,3 +550,38 @@ class TestMakeProbeNavigation:
         s = Diffraction2D(np.ones(shape))
         with pytest.raises(ValueError):
             s.make_probe_navigation(method="fast")
+
+
+class TestPlotNavigator:
+    @pytest.mark.parametrize(
+        "shape", [(9, 8), (5, 9, 8), (4, 5, 9, 8), (8, 4, 5, 9, 8), (9, 8, 4, 5, 9, 8)]
+    )
+    def test_non_lazy(self, shape):
+        s = Diffraction2D(np.random.randint(0, 256, shape), dtype=np.uint8)
+        plt.ion()  # To make plotting non-blocking
+        s.plot()
+        plt.close("all")
+
+    @pytest.mark.parametrize(
+        "shape", [(9, 8), (5, 9, 8), (4, 5, 9, 8), (8, 4, 5, 9, 8), (9, 8, 4, 5, 9, 8)]
+    )
+    def test_lazy(self, shape):
+        s = LazyDiffraction2D(da.random.randint(0, 256, shape), dtype=np.uint8)
+        plt.ion()  # To make plotting non-blocking
+        s.plot()
+        plt.close("all")
+
+    def test_navigator_kwarg(self):
+        s = Diffraction2D(np.random.randint(0, 256, (8, 9, 10, 30), dtype=np.uint8))
+        plt.ion()  # To make plotting non-blocking
+        s_nav = Diffraction2D(np.zeros((8, 9)))
+        s.plot(navigator=s_nav)
+        plt.close("all")
+
+    def test_wrong_navigator_shape_kwarg(self):
+        s = Diffraction2D(np.random.randint(0, 256, (8, 9, 10, 30), dtype=np.uint8))
+        plt.ion()  # To make plotting non-blocking
+        s_nav = Diffraction2D(np.zeros((2, 19)))
+        s._navigator_probe = s_nav
+        with pytest.raises(ValueError):
+            s.plot()

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -489,3 +489,58 @@ class TestGetDirectBeamPosition:
         s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
         assert hasattr(s_shift.data, "compute")
         s_shift.compute()
+
+
+class TestMakeProbeNavigation:
+    def test_fast(self):
+        s = Diffraction2D(np.ones((6, 5, 12, 10)))
+        s.make_probe_navigation(method="fast")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+        assert np.all(s_nav.data == 1)
+
+    def test_slow(self):
+        s = Diffraction2D(np.ones((5, 5, 12, 10)))
+        s.make_probe_navigation(method="slow")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+        assert np.all(s_nav.data == 120)
+
+    def test_fast_lazy(self):
+        s = LazyDiffraction2D(da.ones((6, 4, 60, 50), chunks=(2, 2, 10, 10)))
+        s.make_probe_navigation(method="fast")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+        assert np.all(s_nav.data == 100)
+
+    def test_slow_lazy(self):
+        s = LazyDiffraction2D(da.ones((6, 4, 60, 50), chunks=(2, 2, 10, 10)))
+        s.make_probe_navigation(method="slow")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+        assert np.all(s_nav.data == 3000)
+
+    def test_very_asymmetric_size(self):
+        s = Diffraction2D(np.ones((50, 2, 120, 10)))
+        s.make_probe_navigation(method="fast")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+
+    def test_very_asymmetric_size_lazy(self):
+        s = LazyDiffraction2D(da.ones((50, 2, 120, 10), chunks=(2, 2, 5, 5)))
+        s.make_probe_navigation(method="fast")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+
+    @pytest.mark.parametrize("shape", [(2, 10, 10), (3, 2, 10, 10)])
+    def test_different_shapes(self, shape):
+        s = Diffraction2D(np.ones(shape))
+        s.make_probe_navigation(method="fast")
+        s_nav = s._navigator_probe
+        assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
+
+    def test_0_dimension_navigation_shape(self):
+        s = Diffraction2D(np.ones((10, 20)))
+        s.make_probe_navigation(method="fast")
+        s_nav = s._navigator_probe
+        assert (1,) == s_nav.axes_manager.signal_shape

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -544,3 +544,9 @@ class TestMakeProbeNavigation:
         s.make_probe_navigation(method="fast")
         s_nav = s._navigator_probe
         assert (1,) == s_nav.axes_manager.signal_shape
+
+    @pytest.mark.parametrize("shape", [(2, 3, 4, 5, 6), (2, 3, 4, 5, 6, 7)])
+    def test_too_many_navigation_dimensions(self, shape):
+        s = Diffraction2D(np.ones(shape))
+        with pytest.raises(ValueError):
+            s.make_probe_navigation(method="fast")

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -539,14 +539,8 @@ class TestMakeProbeNavigation:
         s_nav = s._navigator_probe
         assert s.axes_manager.navigation_shape == s_nav.axes_manager.signal_shape
 
-    def test_0_dimension_navigation_shape(self):
-        s = Diffraction2D(np.ones((10, 20)))
-        s.make_probe_navigation(method="fast")
-        s_nav = s._navigator_probe
-        assert (1,) == s_nav.axes_manager.signal_shape
-
-    @pytest.mark.parametrize("shape", [(2, 3, 4, 5, 6), (2, 3, 4, 5, 6, 7)])
-    def test_too_many_navigation_dimensions(self, shape):
+    @pytest.mark.parametrize("shape", [(10, 20), (2, 3, 4, 5, 6), (2, 3, 4, 5, 6, 7)])
+    def test_wrong_navigation_dimensions(self, shape):
         s = Diffraction2D(np.ones(shape))
         with pytest.raises(ValueError):
             s.make_probe_navigation(method="fast")

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -560,6 +560,7 @@ class TestPlotNavigator:
         s = Diffraction2D(np.random.randint(0, 256, shape), dtype=np.uint8)
         plt.ion()  # To make plotting non-blocking
         s.plot()
+        s.plot()
         plt.close("all")
 
     @pytest.mark.parametrize(
@@ -568,6 +569,7 @@ class TestPlotNavigator:
     def test_lazy(self, shape):
         s = LazyDiffraction2D(da.random.randint(0, 256, shape), dtype=np.uint8)
         plt.ion()  # To make plotting non-blocking
+        s.plot()
         s.plot()
         plt.close("all")
 

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -24,25 +24,23 @@ import scipy.ndimage as ndi
 from skimage import morphology
 
 
-def get_chunk_slice_list(chunks):
-    sig_y_chunk_list, sig_x_chunk_list = chunks[-2:]
+def get_signal_dimension_chunk_slice_list(chunks):
+    """Convenience function for getting the signal chunks as slices
 
+    The slices are assumed to be used on a HyperSpy signal object.
+    Thus the input will be in the Dask chunk order (y, x), while the
+    output will be in the HyperSpy order (x, y).
+
+    """
+    chunk_slice_raw_list = da.core.slices_from_chunks(chunks[-2:])
     chunk_slice_list = []
-    y_pos = 0
-    for sig_y_chunk in sig_y_chunk_list:
-        x_pos = 0
-        for sig_x_chunk in sig_x_chunk_list:
-            chunk_slice = np.s_[
-                x_pos : x_pos + sig_x_chunk, y_pos : y_pos + sig_y_chunk
-            ]
-            x_pos += sig_x_chunk
-            chunk_slice_list.append(chunk_slice)
-        y_pos += sig_y_chunk
+    for chunk_slice_raw in chunk_slice_raw_list:
+        chunk_slice_list.append((chunk_slice_raw[1], chunk_slice_raw[0]))
     return chunk_slice_list
 
 
-def get_host_chunk_slice(x, y, chunks):
-    chunk_slice_list = get_chunk_slice_list(chunks)
+def get_signal_dimension_host_chunk_slice(x, y, chunks):
+    chunk_slice_list = get_signal_dimension_chunk_slice_list(chunks)
     for chunk_slice in chunk_slice_list:
         x_slice, y_slice = chunk_slice
         if y_slice.start <= y < y_slice.stop:

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -33,7 +33,7 @@ def get_chunk_slice_list(chunks):
         x_pos = 0
         for sig_x_chunk in sig_x_chunk_list:
             chunk_slice = np.s_[
-                y_pos : y_pos + sig_y_chunk, x_pos : x_pos + sig_x_chunk
+                x_pos : x_pos + sig_x_chunk, y_pos : y_pos + sig_y_chunk
             ]
             x_pos += sig_x_chunk
             chunk_slice_list.append(chunk_slice)
@@ -44,7 +44,7 @@ def get_chunk_slice_list(chunks):
 def get_host_chunk_slice(x, y, chunks):
     chunk_slice_list = get_chunk_slice_list(chunks)
     for chunk_slice in chunk_slice_list:
-        y_slice, x_slice = chunk_slice
+        x_slice, y_slice = chunk_slice
         if y_slice.start <= y < y_slice.stop:
             if x_slice.start <= x < x_slice.stop:
                 return chunk_slice

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -24,6 +24,33 @@ import scipy.ndimage as ndi
 from skimage import morphology
 
 
+def get_chunk_slice_list(chunks):
+    sig_y_chunk_list, sig_x_chunk_list = chunks[-2:]
+
+    chunk_slice_list = []
+    y_pos = 0
+    for sig_y_chunk in sig_y_chunk_list:
+        x_pos = 0
+        for sig_x_chunk in sig_x_chunk_list:
+            chunk_slice = np.s_[
+                y_pos : y_pos + sig_y_chunk, x_pos : x_pos + sig_x_chunk
+            ]
+            x_pos += sig_x_chunk
+            chunk_slice_list.append(chunk_slice)
+        y_pos += sig_y_chunk
+    return chunk_slice_list
+
+
+def get_host_chunk_slice(x, y, chunks):
+    chunk_slice_list = get_chunk_slice_list(chunks)
+    for chunk_slice in chunk_slice_list:
+        y_slice, x_slice = chunk_slice
+        if y_slice.start <= y < y_slice.stop:
+            if x_slice.start <= x < x_slice.stop:
+                return chunk_slice
+    return False
+
+
 def _rechunk_signal2d_dim_one_chunk(dask_array):
     array_dims = len(dask_array.shape)
     if array_dims < 2:


### PR DESCRIPTION
Currently, plotting large lazy signals with pyXem (and HyperSpy) is really slow. This is due to the navigation image being calculated, which can take a long time. There are some ways to make it run much, much quicker, but this functionality is "hidden" a bit. So users not familiar with lazy processing with pyXem/HyperSpy, will use `s.plot()`, followed by nothing happening for several minutes, before the plot pops up.

The main "hidden" trick is `s.plot(navigator=s_nav)`. With this, a precomputed navigation signal can be used for navigation. For example, for a `(200, 800, 250, 250)` dataset with chunking `(16, 16, 16, 16)`:

```python
s.plot() # Takes 7 minutes
s_nav = s.isig[125, 125].T
s_nav.compute() # Takes 1.9 seconds
s.plot(navigator=s_nav) # Instant
```

This pull requests makes this the default for plotting with the `LazyDiffraction2D` class, by adding a new metadata field: `Navigators`:

## Changes

- Overloading the `s.plot()` function, to check if the signal has `s.metadata.Navigators.Probe`
- If it has, use this as `navigator` in `s.plot`
- If it does not, run the new `s.make_probe_navigation` method.
    - This function has two modes: `fast` or `slow`.
    - `fast` calculates the sum of the diffraction chunk containing the centre point in the diffraction pattern. While it could use only the centre point, summing the whole chunk is just as fast, giving (probably) better signal-to-noise.
    - `slow` calculates the sum from the full diffraction pattern
    - Both calculations show a progress bar
    - This navigation signal is then saved in `s.metadata.Navigators.Probe`

So this results in a big speed boost compared to the old way:

```python
s.plot() # Takes 7 minutes
s.plot() # Takes 7 minutes
```

New way:

```python
s.plot() # Takes 1.9 seconds
s.plot() # Instant
```

Note that this speed increase really depends on the chunking of the data in the signal dimension. If the whole diffraction pattern is one chunk, there will be no speed increase. As all the data will have to be loaded into memory at some point. However, since there is a progress bar, the users will at least see that something is happening. Thus, I also want to change the default chunking for `Diffraction2D` to (32, 32, 32, 32) when using `s.save`. Currently it inherent the default behavior from HyperSpy, which is having as much as possible of the signal dimensions in the same chunk.

The big issue now is that saving NumPy arrays or HyperSpy signals in the metadata, while specifying the chunk size when saving (`s.save("test.hpsy", chunks=(32, 32, 32, 32))`) does not work.

## Todos

- [x]  Figure out how to save the navigation signal. Metadata? Attribute? Attribute means it won't be saved, but this can be a stop-gap solution before the underlying issue in HyperSpy is resolved.
- [x]  `LazyDiffraction2D` or `LazyElectronDiffraction2D`?
- [x]  Write unit test
- [x]  Changelog