### PR TITLE
Add lazy version of Diffraction2D.center_direct_beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a setup.cfg
 - get_direct_beam_position now supports lazy proccessing (#648)
+- center_direct_beam now supports lazily processing (#658)
+- Several functions for processing large datasets using dask (#648, #658)
 
 ### Changed
 - Calibration workflow has been altered (see PR #640 for details)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a setup.cfg
 - get_direct_beam_position now supports lazy proccessing (#648)
-- center_direct_beam now supports lazily processing (#658)
+- center_direct_beam now supports lazy processing (#658)
 - Several functions for processing large datasets using dask (#648, #658)
 
 ### Changed

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1071,11 +1071,11 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 **kwargs,
             )
 
-        if not 'order' in align_kwargs:
+        if not "order" in align_kwargs:
             if subpixel:
-                align_kwargs['order'] = 1
+                align_kwargs["order"] = 1
             else:
-                align_kwargs['order'] = 0
+                align_kwargs["order"] = 0
 
         data_dask_array = _get_dask_array(self)
         shifts_dask_array = _get_dask_array(shifts)
@@ -1095,11 +1095,13 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         else:
             if self._lazy:
                 self.data = np.empty(
-                    output_dask_array.shape, dtype=output_dask_array.dtype)
+                    output_dask_array.shape, dtype=output_dask_array.dtype
+                )
                 self._lazy = False
                 self._assign_subclass()
             shifts.data = np.empty(
-                shifts_dask_array.shape, dtype=shifts_dask_array.dtype)
+                shifts_dask_array.shape, dtype=shifts_dask_array.dtype
+            )
             shifts._lazy = False
             shifts._assign_subclass()
             with ProgressBar():

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1002,9 +1002,9 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         half_square_width=None,
         shifts=None,
         return_shifts=False,
-        align_kwargs=None,
         subpixel=True,
         lazy_result=None,
+        align_kwargs=None,
         *args,
         **kwargs,
     ):
@@ -1044,6 +1044,9 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             If True, the result will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is lazy, the result will also be lazy.
             If the signal is non-lazy, the result will be non-lazy.
+        align_kwargs : dict
+            Parameters passed to the alignment function. See scipy.ndimage.shift
+            for more information about the parameters.
         *args, **kwargs :
             Passed to the function which estimate the direct beam position
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1061,6 +1061,13 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         use a float dtype, which can be done by s.change_dtype('float32', rechunk=False).
 
         """
+        if (shifts is None) and (method is None):
+            raise ValueError("Either method or shifts parameter must be specified")
+        if (shifts is not None) and (method is not None):
+            raise ValueError(
+                "Only one of the shifts or method parameters should be specified, "
+                "not both"
+            )
         if lazy_result is None:
             lazy_result = self._lazy
         if align_kwargs is None:

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1012,34 +1012,27 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         electron diffraction pattern and translate it to the center of the
         image square.
 
-        The direct beam position can either be passed to the method with the shifts
-        parameter, or the function can calculate it on its own.
-
-        Note: if the signal has an integer dtype, and subpixel=True is used (the default)
-        the total intensity in the diffraction images will most likely not be preserved.
-        This is due to subpixel=True utilizing interpolation. To keep the total intensity
-        use a float dtype, which can be done by s.change_dtype('float32', rechunk=False).
-
         Parameters
         ----------
         method : str {'cross_correlate', 'blur', 'interpolate'}
-            Method used to estimate the direct beam position
+            Method used to estimate the direct beam position. The direct
+            beam position can also be passed directly with the shifts parameter.
         half_square_width : int
             Half the side length of square that captures the direct beam in all
             scans. Means that the centering algorithm is stable against
             diffracted spots brighter than the direct beam.
         shifts : Signal, optional
-            Position of the direct beam, for each navigation position in the signal
-            which should be shifted. Both shifts and the signal need to have the
-            same navigation shape, and shifts needs to have one signal dimension
-            with size 2.
+            The position of the direct beam, which can either be passed with this
+            parameter (shifts), or calculated on its own.
+            Both shifts and the signal need to have the same navigation shape, and
+            shifts needs to have one signal dimension with size 2.
         return_shifts : bool, default False
             If True, the values of applied shifts are returned
         subpixel : bool, optional
             If True, the data will be interpolated, allowing for subpixel shifts of
             the diffraction patterns. This can lead to changes in the total intensity
-            of the diffraction images. If False, the data is not interpolated.
-            Default True.
+            of the diffraction images, see Notes for more information. If False, the
+            data is not interpolated. Default True.
         lazy_result : optional
             If True, the result will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is lazy, the result will also be lazy.
@@ -1049,6 +1042,23 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             for more information about the parameters.
         *args, **kwargs :
             Passed to the function which estimate the direct beam position
+
+        Example
+        -------
+        >>> s.center_direct_beam(method='blur', sigma=1)
+
+        Using the shifts parameter
+
+        >>> s_shifts = s.get_direct_beam_position(
+        ...    method="interpolate", sigma=1, upsample_factor=2, kind="nearest")
+        >>> s.center_direct_beam(shifts=s_shifts)
+
+        Notes
+        -----
+        If the signal has an integer dtype, and subpixel=True is used (the default)
+        the total intensity in the diffraction images will most likely not be preserved.
+        This is due to subpixel=True utilizing interpolation. To keep the total intensity
+        use a float dtype, which can be done by s.change_dtype('float32', rechunk=False).
 
         """
         if lazy_result is None:

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -491,6 +491,150 @@ class TestGetDirectBeamPosition:
         s_shift.compute()
 
 
+class TestCenterDirectBeam:
+    def setup_method(self):
+        data = np.zeros((8, 6, 20, 16), dtype=np.int16)
+        x_pos_list = np.random.randint(8 - 2, 8 + 2, 6, dtype=np.int16)
+        x_pos_list[x_pos_list == 8] = 9
+        y_pos_list = np.random.randint(10 - 2, 10 + 2, 8, dtype=np.int16)
+        for ix in range(len(x_pos_list)):
+            for iy in range(len(y_pos_list)):
+                data[iy, ix, y_pos_list[iy], x_pos_list[ix]] = 9
+        x_pos_list = x_pos_list
+        y_pos_list = y_pos_list
+        s = Diffraction2D(data)
+        s.axes_manager[0].scale = 0.5
+        s.axes_manager[1].scale = 0.6
+        s.axes_manager[2].scale = 3
+        s.axes_manager[3].scale = 4
+        s_lazy = s.as_lazy()
+        self.s = s
+        self.s_lazy = s_lazy
+        self.x_pos_list = x_pos_list
+        self.y_pos_list = y_pos_list
+
+    def test_non_lazy(self):
+        s = self.s
+        s.center_direct_beam(method="blur", sigma=1)
+        assert s._lazy is False
+        assert (s.data[:, :, 10, 8] == 9).all()
+        s.data[:, :, 10, 8] = 0
+        assert not s.data.any()
+
+    def test_non_lazy_lazy_result(self):
+        s = self.s
+        s.center_direct_beam(method="blur", sigma=1, lazy_result=True)
+        assert s._lazy is True
+        s.compute()
+        assert (s.data[:, :, 10, 8] == 9).all()
+        s.data[:, :, 10, 8] = 0
+        assert not s.data.any()
+
+    def test_lazy(self):
+        s_lazy = self.s_lazy
+        s_lazy.center_direct_beam(method="blur", sigma=1)
+        assert s_lazy._lazy is True
+        s_lazy.compute()
+        assert (s_lazy.data[:, :, 10, 8] == 9).all()
+        s_lazy.data[:, :, 10, 8] = 0
+        assert not s_lazy.data.any()
+
+    def test_lazy_not_lazy_result(self):
+        s_lazy = self.s_lazy
+        s_lazy.center_direct_beam(method="blur", sigma=1, lazy_result=False)
+        assert s_lazy._lazy is False
+        assert (s_lazy.data[:, :, 10, 8] == 9).all()
+        s_lazy.data[:, :, 10, 8] = 0
+        assert not s_lazy.data.any()
+
+    def test_return_shifts_non_lazy(self):
+        s = self.s
+        s_shifts = s.center_direct_beam(method="blur", sigma=1, return_shifts=True)
+        assert s_shifts._lazy is False
+        nav_dim = s.axes_manager.navigation_dimension
+        assert nav_dim == s_shifts.axes_manager.navigation_dimension
+        x_pos_list, y_pos_list = self.x_pos_list, self.y_pos_list
+        assert ((8 - x_pos_list) == s_shifts.isig[0].data[0]).all()
+        assert ((10 - y_pos_list) == s_shifts.isig[1].data[:, 0]).all()
+
+    def test_return_shifts_lazy(self):
+        s_lazy = self.s_lazy
+        s_shifts = s_lazy.center_direct_beam(method="blur", sigma=1, return_shifts=True)
+        assert s_shifts._lazy is True
+        s_shifts.compute()
+        x_pos_list, y_pos_list = self.x_pos_list, self.y_pos_list
+        assert ((8 - x_pos_list) == s_shifts.isig[0].data[0]).all()
+        assert ((10 - y_pos_list) == s_shifts.isig[1].data[:, 0]).all()
+
+    def test_return_axes_manager(self):
+        s = self.s
+        s.center_direct_beam(method="blur", sigma=1)
+        assert s.axes_manager[0].scale == 0.5
+        assert s.axes_manager[1].scale == 0.6
+        assert s.axes_manager[2].scale == 3
+        assert s.axes_manager[3].scale == 4
+
+    def test_shifts_input(self):
+        s = self.s
+        s_shifts = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=False)
+        s.center_direct_beam(shifts=s_shifts)
+        assert (s.data[:, :, 10, 8] == 9).all()
+        s.data[:, :, 10, 8] = 0
+        assert not s.data.any()
+
+    def test_shifts_input_lazy(self):
+        s = self.s
+        s_shifts = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
+        s.center_direct_beam(shifts=s_shifts)
+        assert (s.data[:, :, 10, 8] == 9).all()
+        s.data[:, :, 10, 8] = 0
+        assert not s.data.any()
+
+    def test_subpixel(self):
+        s = self.s
+        s_shifts = s.get_direct_beam_position(method="blur", sigma=1)
+        s_shifts += 0.5
+        s.change_dtype("float32")
+        s.center_direct_beam(shifts=s_shifts, subpixel=True)
+        assert (s.data[:, :, 10:12, 8:10] == 9 / 4).all()
+        s.data[:, :, 10:12, 8:10] = 0.0
+        assert not s.data.any()
+
+    @pytest.mark.parametrize(
+        "shape", [(20, 20), (10, 20, 20), (8, 10, 20, 20), (6, 8, 10, 20, 20)]
+    )
+    def test_different_dimensions(self, shape):
+        s = Diffraction2D(np.random.randint(0, 256, size=shape))
+        s.center_direct_beam(method="blur", sigma=1)
+        assert s.data.shape == shape
+
+    def test_half_square_width(self):
+        s = self.s.isig[:, 2:-2]
+        s.data[:, :, 1, -1] = 1000
+        s1 = s.deepcopy()
+        s.center_direct_beam(method="blur", sigma=1)
+        assert (s.data[:, :, 8, 8] == 1000).all()
+        s1.center_direct_beam(method="blur", sigma=1, half_square_width=5)
+        assert (s1.data[:, :, 8, 8] == 9).all()
+
+    def test_align_kwargs(self):
+        s = self.s
+        s.data += 1
+        s1 = s.deepcopy()
+        s.center_direct_beam(method="blur", sigma=1)
+        assert (s.data == 0).any()
+        s1.center_direct_beam(method="blur", sigma=1, align_kwargs={"mode": "wrap"})
+        assert not (s1.data == 0).any()
+
+    def test_method_interpolate(self):
+        s = self.s
+        s.center_direct_beam(method="interpolate", sigma=1, upsample_factor=10, kind=1)
+
+    def test_method_interpolate(self):
+        s = self.s
+        s.center_direct_beam(method="cross_correlate", radius_start=0, radius_finish=2)
+
+
 class TestMakeProbeNavigation:
     def test_fast(self):
         s = Diffraction2D(np.ones((6, 5, 12, 10)))

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -500,8 +500,6 @@ class TestCenterDirectBeam:
         for ix in range(len(x_pos_list)):
             for iy in range(len(y_pos_list)):
                 data[iy, ix, y_pos_list[iy], x_pos_list[ix]] = 9
-        x_pos_list = x_pos_list
-        y_pos_list = y_pos_list
         s = Diffraction2D(data)
         s.axes_manager[0].scale = 0.5
         s.axes_manager[1].scale = 0.6
@@ -518,6 +516,7 @@ class TestCenterDirectBeam:
         s.center_direct_beam(method="blur", sigma=1)
         assert s._lazy is False
         assert (s.data[:, :, 10, 8] == 9).all()
+        # Make sure only the pixel we expect to change, has actually changed
         s.data[:, :, 10, 8] = 0
         assert not s.data.any()
 
@@ -643,6 +642,16 @@ class TestCenterDirectBeam:
     def test_method_cross_correlate(self):
         s = self.s
         s.center_direct_beam(method="cross_correlate", radius_start=0, radius_finish=2)
+
+    def test_parameter_both_method_and_shifts(self):
+        s = self.s
+        with pytest.raises(ValueError):
+            s.center_direct_beam(method="blur", sigma=1, shifts=np.ones((8, 6, 2)))
+
+    def test_parameter_neither_method_and_shifts(self):
+        s = self.s
+        with pytest.raises(ValueError):
+            s.center_direct_beam()
 
 
 class TestMakeProbeNavigation:

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -600,6 +600,16 @@ class TestCenterDirectBeam:
         s.data[:, :, 10:12, 8:10] = 0.0
         assert not s.data.any()
 
+    def test_not_subpixel(self):
+        s = self.s
+        s_shifts = s.get_direct_beam_position(method="blur", sigma=1)
+        s_shifts += 0.3
+        s.change_dtype("float32")
+        s.center_direct_beam(shifts=s_shifts, subpixel=False)
+        assert (s.data[:, :, 10, 8] == 9).all()
+        s.data[:, :, 10, 8] = 0.0
+        assert not s.data.any()
+
     @pytest.mark.parametrize(
         "shape", [(20, 20), (10, 20, 20), (8, 10, 20, 20), (6, 8, 10, 20, 20)]
     )
@@ -630,7 +640,7 @@ class TestCenterDirectBeam:
         s = self.s
         s.center_direct_beam(method="interpolate", sigma=1, upsample_factor=10, kind=1)
 
-    def test_method_interpolate(self):
+    def test_method_cross_correlate(self):
         s = self.s
         s.center_direct_beam(method="cross_correlate", radius_start=0, radius_finish=2)
 

--- a/pyxem/tests/signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/signals/test_electron_diffraction2d.py
@@ -53,14 +53,14 @@ class TestSimpleMaps:
             radius_finish=3,
             return_shifts=True,
         )
-        ans = np.array([[-0.45, -0.45], [0.57, 0.57], [-0.45, -0.45], [0.52, 0.52]])
+        ans = np.array([[[0.45, 0.45], [-0.57, -0.57]], [[0.45, 0.45], [-0.52, -0.52]]])
         np.testing.assert_almost_equal(shifts, ans)
 
     def test_center_direct_beam_blur_return_shifts(self, diffraction_pattern):
         shifts = diffraction_pattern.center_direct_beam(
             method="blur", sigma=5, half_square_width=3, return_shifts=True
         )
-        ans = np.array([[-1.0, -1.0], [-0.0, -0.0], [-1.0, -1.0], [-0.0, -0.0]])
+        ans = np.array([[[1.0, 1.0], [0.0, 0.0]], [[1.0, 1.0], [0.0, 0.0]]])
         np.testing.assert_almost_equal(shifts, ans)
 
     def test_center_direct_beam_in_small_region(self, diffraction_pattern):

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -70,6 +70,22 @@ class TestSignalDimensionGetChunkSliceList:
         assert chunk_slice_list[0] == np.s_[0:20, 0:20]
 
 
+@pytest.mark.parametrize(
+    "input_shape,iter_shape",
+    [
+        [(9, 8, 6, 6), (9, 8, 2)],
+        [(9, 8, 6, 6), (9, 8, 2, 2)],
+        [(9, 8, 6), (9, 8)],
+        [(9, 8, 6, 20, 20), (9, 8)],
+    ],
+)
+def test_expand_iter_dimensions(input_shape, iter_shape):
+    data_dask = da.zeros(input_shape, chunks=[2] * len(input_shape))
+    iter_dask = da.zeros(iter_shape, chunks=[2] * len(iter_shape))
+    output_array = dt._expand_iter_dimensions(iter_dask, len(data_dask.shape))
+    assert len(data_dask.shape) == len(output_array.shape)
+
+
 class TestGetSignalDimensionHostChunkSlice:
     @pytest.mark.parametrize(
         "xy, sig_slice, xchunk, ychunk",

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -273,10 +273,7 @@ class TestProcessChunk:
         chunk_input = np.zeros((3, 4, 10, 8), dtype=dtype)
         iter_array = np.random.randint(0, 256, (3, 5, 1, 1))
         block_info = {None: {"dtype": dtype}}
-
-        def test_function(image, value):
-            return value
-
+        test_function = lambda a: 1
         with pytest.raises(ValueError):
             chunk_output = dt._process_chunk(
                 chunk_input,
@@ -412,6 +409,12 @@ class TestProcessDaskArray:
         dask_output = dt._process_dask_array(dask_input, test_function)
         array_output = dask_output.compute()
         assert dask_input.shape == array_output.shape
+
+    def test_dask_array_wrong_type(self):
+        array_input = np.zeros((4, 6, 10, 10))
+        test_function = lambda a: 1
+        with pytest.raises(AttributeError):
+            dt._process_dask_array(array_input, test_function)
 
     @pytest.mark.parametrize(
         "dask_shape,iter_shape",

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -204,8 +204,7 @@ def _process_dask_array(
         dtype = dask_array.dtype
     dask_array_rechunked = _rechunk_signal2d_dim_one_chunk(dask_array)
     if iter_array is not None:
-        iter_array = _expand_iter_dimensions(
-            iter_array, len(dask_array.shape))
+        iter_array = _expand_iter_dimensions(iter_array, len(dask_array.shape))
     output_array = da.map_blocks(
         _process_chunk,
         dask_array_rechunked,

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -56,6 +56,10 @@ def get_signal_dimension_host_chunk_slice(x, y, chunks):
 
 def _rechunk_signal2d_dim_one_chunk(dask_array):
     array_dims = len(dask_array.shape)
+    if not hasattr(dask_array, "chunks"):
+        raise AttributeError(
+            "dask_array must be a dask array, not {0}".format(type(dask_array))
+        )
     if array_dims < 2:
         raise ValueError(
             "dask_array must be at least two dimensions, not {0}".format(array_dims)
@@ -99,6 +103,14 @@ def _process_chunk(
     kwargs_process=None,
     block_info=None,
 ):
+    if iter_array is not None:
+        nav_shape = data.shape[:-2]
+        iter_nav_shape = iter_array.shape[: len(nav_shape)]
+        if nav_shape != iter_nav_shape:
+            raise ValueError(
+                "iter_array nav shape {0} must be the same as the navigation shape as "
+                "the data {1}".format(iter_nav_shape, nav_shape)
+            )
     dtype = block_info[None]["dtype"]
     if args_process is None:
         args_process = []

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -24,6 +24,22 @@ import scipy.ndimage as ndi
 from skimage import morphology
 
 
+def align_single_frame(image, shifts):
+    """Not subpixel"""
+    shift_y, shift_x = shifts
+    shift_x = int(round(shift_x))
+    shift_y = int(round(shift_y))
+    temp_image = np.roll(image, shift_x, axis=0)
+    temp_image = np.roll(temp_image, shift_y, axis=1)
+    return temp_image
+
+
+def align_single_frame_subpixel(image, shifts, order=3):
+    """Subpixel"""
+    temp_image = ndi.shift(image, shifts[::-1], order=order)
+    return temp_image
+
+
 def get_signal_dimension_chunk_slice_list(chunks):
     """Convenience function for getting the signal chunks as slices
 

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -24,19 +24,8 @@ import scipy.ndimage as ndi
 from skimage import morphology
 
 
-def align_single_frame(image, shifts):
-    """Not subpixel"""
-    shift_y, shift_x = shifts
-    shift_x = int(round(shift_x))
-    shift_y = int(round(shift_y))
-    temp_image = np.roll(image, shift_x, axis=0)
-    temp_image = np.roll(temp_image, shift_y, axis=1)
-    return temp_image
-
-
-def align_single_frame_subpixel(image, shifts, order=3):
-    """Subpixel"""
-    temp_image = ndi.shift(image, shifts[::-1], order=order)
+def align_single_frame(image, shifts, **kwargs):
+    temp_image = ndi.shift(image, shifts[::-1], **kwargs)
     return temp_image
 
 


### PR DESCRIPTION
This pull request adds a "lazy" version of `Diffraction2D.center_direct_beam`. This is a step in the plan for making pyXem capable of processing datasets which are larger than the available computer memory, this will be done utilizing `dask.array`. These changes enables the whole pipeline from finding the direct beam, moving it to the center, and (for example) doing azimuthal integration to be done without ever having to load the full dataset into memory at the same time. Thus, very large datasets can be processed on standard computers.

The pull request includes:

- Modifications in `dask_tools` to `_process_dask_array` and `_process_chunk` to handle itererating dask arguments
- Changes to `center_direct_beam` to make it work lazily
- Adding two simple functions to shift the diffraction patterns

### Dask tools

The general changes here are extending `_process_dask_array` to handle the iterating dask arrays. These are arguments which can be different for each probe position.

There are also two functions for aligning a single diffraction pattern, one for subpixel and one for non-subpixel shifts, where the latter interpolates the image data. Not sure if they should go here (`dask_tools`), or some other place.

### `center_direct_beam`

The major change here is calling `_process_dask_array`, instead of `self.align2d`, and preparing the various parameters needed for `_process_dask_array`. Also, `shifts` can now be passed as a parameter. This is useful for more tricky cases, where for example the position of the direct beam requires some additional processing.

One question is what the default behaviour of this function should be. Should it work as before, where it operates in-place? Or return the new signal? I'm fine with either, and doing the in-place route is maybe the smartest (currently the pull request returns a signal, but this can easily be changed).

## Testing this

Generating a test dataset

```python
import numpy as np
from tqdm import tqdm
import h5py
import dask.array as da
import pyxem as pxm

#################################################
f = h5py.File("001_test_data_256x256.hdf5", mode='w')
data = f.create_dataset(
        'data', shape=(256, 256, 256, 256), dtype=np.uint16, chunks=(32, 32, 32, 32),
        compression='gzip')

x_pos_list = np.linspace(128-20, 128+20, 256, dtype=np.uint16)
y_pos_list = np.linspace(128-40, 128+40, 256, dtype=np.uint16)

image = np.zeros((256, 256), dtype=np.uint16)
pbar = tqdm(total=256*256)

for ix_cube in range(8):
    for iy_cube in range(8):
        data_cube = np.zeros((32, 32, 256, 256), dtype=np.uint16)
        for ix in range(32):
            for iy in range(32):
                ix_pos = ix_cube * 32 + ix
                iy_pos = iy_cube * 32 + iy
                x_pos = x_pos_list[ix_pos]
                y_pos = y_pos_list[iy_pos]
                image[x_pos, y_pos] = 10
                data_cube[ix, iy, :, :] = image
                image[x_pos, y_pos] = 0
                pbar.update(1)
        data[ix_cube*32:(ix_cube+1)*32, iy_cube*32:(iy_cube+1)*32, :, :] = data_cube
        del data_cube

f.close()

#################################################
dask_array = da.from_array(h5py.File("001_test_data_256x256.hdf5")['data'], chunks=(32, 32, 32, 32))
s = pxm.LazyDiffraction2D(dask_array)
s.save("001_test_data_256x256.hspy", chunks=(32, 32, 32, 32), overwrite=True)
```

Running the test data

```python
import pyxem as pxm
s = pxm.load("001_test_data_256x256.hspy", signal_type='diffraction', lazy=True)
s1 = s.center_direct_beam(method='blur', sigma=1)
```
With getting the shifts first, and altering `s_shifts`:
```python
s = pxm.load("001_test_data_256x256.hspy", signal_type='diffraction', lazy=True)
s_shifts = s.get_direct_beam_position(method='blur', sigma=1, lazy_result=True)
s_shifts.data += 1.5
s1 = s.center_direct_beam(shifts=s_shifts, subpixel=True, lazy_result=True)
s1.compute()
```

### Todo

- [x]  ~~Add "cropping" functionality~~ This is not in the current implementation, and is actually pretty difficult to implement for a lazy version, since we don't know how much will be cropped until the calculation is done. Rather, zero-filling of the edges is used.
- [x]  ~~Add fill value to non-subpixel shift function~~ Only one align function was necessary, since the `scipy.ndimage.shift` function can be switched between subpixel and non-subpixel by using the `order` parameter
- [x]  Add unit tests
- [x]  Update docstring
- [x]  Update changelog

### Future work

- `scipy.ndimage.shift`: this could potentially accept a whole "chunk", which might be faster? This should be checked after this pull request is merged. Such a change should be "invisible" for the user, since it would be in the processing "backend".