### PR TITLE
get_direct_beam_position default behavior

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -914,7 +914,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         return integration
 
-    def get_direct_beam_position(self, method, lazy_result=False, **kwargs):
+    def get_direct_beam_position(self, method, lazy_result=None, **kwargs):
         """Estimate the direct beam position in each experimentally acquired
         electron diffraction pattern.
 
@@ -922,8 +922,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         ----------
         method : str,
             Must be one of "cross_correlate", "blur" or "interpolate"
-        lazy_result : bool
-            If True, will return a LazySignal1D.
+        lazy_result : optional
+            If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
+            By default, if the signal is lazy, the result will also be lazy.
+            If the signal is non-lazy, the result will be non-lazy.
         **kwargs:
             Keyword arguments to be passed to the method function.
 
@@ -934,6 +936,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             signal index being the x-shift and the second the y-shift.
 
         """
+        if lazy_result is None:
+            lazy_result = self._lazy
 
         signal_shape = self.axes_manager.signal_shape
         origin_coordinates = np.array(signal_shape) / 2

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -924,8 +924,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             Must be one of "cross_correlate", "blur" or "interpolate"
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
-            By default, if the signal is lazy, the result will also be lazy.
-            If the signal is non-lazy, the result will be non-lazy.
+            By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
         **kwargs:
             Keyword arguments to be passed to the method function.
 

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -460,7 +460,10 @@ class TestGetDirectBeamPosition:
         dx, dy = self.dx, self.dy
         s, x_pos_list, y_pos_list = self.s, self.x_pos_list, self.y_pos_list
         s_shift = s.get_direct_beam_position(
-            method="interpolate", sigma=1, upsample_factor=2, kind="nearest",
+            method="interpolate",
+            sigma=1,
+            upsample_factor=2,
+            kind="nearest",
         )
         assert s.axes_manager.navigation_shape == s_shift.axes_manager.navigation_shape
         assert (-(x_pos_list - dx / 2) == s_shift.isig[0].data[0]).all()

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -472,6 +472,16 @@ class TestGetDirectBeamPosition:
             method="cross_correlate", radius_start=0, radius_finish=1
         )
 
+    def test_lazy_result_none_non_lazy_signal(self):
+        s = self.s
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        assert not s_shift._lazy
+
+    def test_lazy_result_none_lazy_signal(self):
+        s = self.s.as_lazy()
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        assert s_shift._lazy
+
     def test_lazy_result(self):
         s = self.s
         s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)


### PR DESCRIPTION
This pull request changes the default behavior of the `Diffraction2D.get_direct_beam_position` method. Previously, it always returned a non-lazy signal, unless the user specified `lazy_result=True`.

Now, this will depend on the type of signal: a lazy signal will return a lazy result, a non-lazy signal will return a non-lazy result. This return type can still be specified with the `lazy_result` parameter.

To test this:
```python
import numpy as np
import pyxem as pxm
s = pxm.Diffraction2D(np.random.randint(0, 256, (4, 6, 20, 20)))
s_shifts = s.get_direct_beam_position(method='blur', sigma=1) # Gives a Signal1D
s_lazy = s.as_lazy()
s_lazy_shifts = s_lazy.get_direct_beam_position(method='blur', sigma=1) # Gives a LazySignal1D
```

Since this changes the behavior for an unreleased functionality, I'm not sure if there is a need to add it to the changelog?

- [x]  Add unit tests
- [x]  Update docstring