### PR TITLE
Retrieve phase from DPC signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Azimuthal integration has been refactored (see PR #625 for details)
 - get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
 - Plotting large, lazy, datasets will be much faster now (#655)
+- Methods to retrieve phase from DPC signal are added (#662)
 
 ### Removed
 - The local_gaussian_method for subpixel refinement

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -271,8 +271,7 @@ class DPCSignal2D(Signal2D):
         pst._copy_signal2d_axes_manager_metadata(self, signal)
         return signal
 
-    def phase_retrieval(self, method='kottler', mirroring=False,
-                        mirror_flip=False):
+    def phase_retrieval(self, method="kottler", mirroring=False, mirror_flip=False):
         """Retrieve the phase from two orthogonal phase gradients.
 
         Parameters
@@ -324,9 +323,11 @@ class DPCSignal2D(Signal2D):
         """
 
         method = method.lower()
-        if method not in ('kottler', 'arnison', 'frankot'):
-            raise ValueError("Method '{}' not recognised. 'kottler', 'arnison'"
-                             " and 'frankot' are available.".format(method))
+        if method not in ("kottler", "arnison", "frankot"):
+            raise ValueError(
+                "Method '{}' not recognised. 'kottler', 'arnison'"
+                " and 'frankot' are available.".format(method)
+            )
 
         # get x and y phase gradient
         dx = self.inav[0].data
@@ -359,32 +360,34 @@ class DPCSignal2D(Signal2D):
         calY = np.diff(self.axes_manager.signal_axes[1].axis).mean()
 
         # construct Fourier-space grids
-        kx = (2*np.pi) * np.fft.fftshift(np.fft.fftfreq(nc))
-        ky = (2*np.pi) * np.fft.fftshift(np.fft.fftfreq(nr))
+        kx = (2 * np.pi) * np.fft.fftshift(np.fft.fftfreq(nc))
+        ky = (2 * np.pi) * np.fft.fftshift(np.fft.fftfreq(nr))
         kx_grid, ky_grid = np.meshgrid(kx, ky)
 
-        if method == 'kottler':
-            gxy = dx + 1j*dy
+        if method == "kottler":
+            gxy = dx + 1j * dy
             numerator = np.fft.fftshift(np.fft.fft2(gxy))
-            denominator = 2*np.pi*1j*(kx_grid + 1j*ky_grid)
-        elif method == 'arnison':
-            gxy = dx + 1j*dy
+            denominator = 2 * np.pi * 1j * (kx_grid + 1j * ky_grid)
+        elif method == "arnison":
+            gxy = dx + 1j * dy
             numerator = np.fft.fftshift(np.fft.fft2(gxy))
-            denominator = 2j*(np.sin(2*np.pi*calX*kx_grid) +
-                              1j*np.sin(2*np.pi*calY*ky_grid))
-        elif method == 'frankot':
+            denominator = 2j * (
+                np.sin(2 * np.pi * calX * kx_grid)
+                + 1j * np.sin(2 * np.pi * calY * ky_grid)
+            )
+        elif method == "frankot":
             kx_grid /= calX
             ky_grid /= calY
             fx = np.fft.fftshift(np.fft.fft2(dx))
             fy = np.fft.fftshift(np.fft.fft2(dy))
             wx, wy = 0.5, 0.5
 
-            numerator = -1j*(wx*kx_grid*fx + wy*ky_grid*fy)
-            denominator = wx*kx_grid**2 + wy*ky_grid**2
+            numerator = -1j * (wx * kx_grid * fx + wy * ky_grid * fy)
+            denominator = wx * kx_grid ** 2 + wy * ky_grid ** 2
 
         # handle the division by zero in the central pixel
         # set the undefined/infinity pixel to 0
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             res = numerator / denominator
         res = np.nan_to_num(res, nan=0, posinf=0, neginf=0)
 
@@ -393,7 +396,7 @@ class DPCSignal2D(Signal2D):
         # get 1/4 of the result if mirroring
         if mirroring:
             M, N = retrieved.shape
-            retrieved = retrieved[:M//2, :N//2]
+            retrieved = retrieved[: M // 2, : N // 2]
 
         signal = Signal2D(retrieved)
         pst._copy_signal2d_axes_manager_metadata(self, signal)

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -275,27 +275,11 @@ class DPCSignal2D(Signal2D):
                         mirror_flip=False):
         """Retrieve the phase from two orthogonal phase gradients.
 
-        The formulae taken for different methods are from the following refs:
-
-        'kottler' --- Equation 4
-        C. Kottler, C. David, F. Pfeiffer, and O. Bunk, "A two-directional
-        approach for grating based differential phase contrast imaging using
-        hard x-rays," Opt. Express 15, 1175-1181, 2007
-
-        'arnison' --- Equation 6
-        Arnison MR, Larkin KG, Sheppard CJ, Smith NI, Cogswell CJ. Linear
-        phase imaging using differential interference contrast microscopy.
-        J Microsc. 2004 Apr;214(Pt 1):7-12.
-
-        'frankot' --- Equation 21
-        R. T. Frankot and R. Chellappa, "A method for enforcing integrability
-        in shape from shading algorithms," in IEEE Transactions on Pattern
-        Analysis and Machine Intelligence, vol. 10, no. 4, pp. 439-451, 1988
-
         Parameters
         ----------
-        method : string, optional
-            the formula to use. The default is 'kottler'.
+        method : 'kottler', 'arnison' or 'frankot', optional
+            the formula to use, 'kottler'[1], 'arnison'[2] and 'frankot'[3]
+            are available. The default is 'kottler'.
         mirroring : bool, optional
             whether to mirror the phase gradients before Fourier transformed.
             Attempt to reduce boundary effect. The default is False.
@@ -314,6 +298,22 @@ class DPCSignal2D(Signal2D):
         -------
         signal : HyperSpy 2D signal
             the phase retrieved.
+
+        References
+        ----------
+        .. [1] Kottler, C., David, C., Pfeiffer, F. and Bunk, O., 2007. A
+        two-directional approach for grating based differential phase contrast
+        imaging using hard x-rays. Optics Express, 15(3), p.1175. (Equation 4)
+
+        .. [2] Arnison, M., Larkin, K., Sheppard, C., Smith, N. and
+        Cogswell, C., 2004. Linear phase imaging using differential
+        interference contrast microscopy. Journal of Microscopy, 214(1),
+        pp.7-12. (Equation 6)
+
+        .. [3] Frankot, R. and Chellappa, R., 1988. A method for enforcing
+        integrability in shape from shading algorithms.
+        IEEE Transactions on Pattern Analysis and Machine Intelligence,
+        10(4), pp.439-451. (Equation 21)
 
         Examples
         --------

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -529,6 +529,23 @@ class TestPhaseRetrieval:
 
         assert np.isclose(self.surface, recon).all()
 
+    def test_mirror_flip(self):
+        s_noflip = self.s.phase_retrieval('kottler', mirroring=True, 
+                                          mirror_flip=False)
+        s_flip = self.s.phase_retrieval('kottler', mirroring=True, 
+                                        mirror_flip=True)
+        noflip = s_noflip.data
+        noflip -= noflip.min()
+        noflip /= noflip.max()
+        flip = s_flip.data
+        flip -= flip.min()
+        flip /= flip.max()
+        
+        noflip_sum_diff = np.abs(self.surface - noflip).sum()
+        flip_sum_diff = np.abs(self.surface - flip).sum()
+        
+        assert (noflip_sum_diff != flip_sum_diff)
+
     def test_unavailable_method(self):
         with pytest.raises(ValueError):
             self.s.phase_retrieval('magic!')

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -32,6 +32,7 @@ import pyxem.dummy_data.dummy_data as dd
 import pyxem.utils.pixelated_stem_tools as pst
 import pyxem as pxm
 
+
 class TestMakeBivariateHistogram:
     def test_single_x(self):
         size = 100
@@ -62,6 +63,7 @@ class TestMakeBivariateHistogram:
         assert s.data[hist_iY, hist_iX] == size
         s.data[hist_iY, hist_iX] = 0
         assert not s.data.any()
+
 
 class TestDpcBasesignalCreate:
     def test_create(self):
@@ -470,19 +472,23 @@ class TestDpcsignalIo:
         assert s_load.axes_manager[1].name == "e"
         assert s_load.axes_manager[2].name == "f"
 
-class TestPhaseRetrieval:
 
+class TestPhaseRetrieval:
     def setup_method(self):
         # construct the surface, two point with Gaussian distribution
-        coords = np.linspace(-20,10,num=512)
+        coords = np.linspace(-20, 10, num=512)
         x, y = np.meshgrid(coords, coords)
-        surface = np.exp(-(x**2+y**2)/2) + np.exp(-((x-2)**2+(y+4)**2)/2)
+        surface = np.exp(-(x ** 2 + y ** 2) / 2) + np.exp(
+            -((x - 2) ** 2 + (y + 4) ** 2) / 2
+        )
 
         # x and y phase gradient of the Gaussians, analytical form
-        dx = x*(-np.exp(-x**2/2 - y**2/2)) +\
-            (x-2)*-np.exp((-0.5*(x-2)**2-0.5*(y+4)**2))
-        dy = y*(-np.exp(-x**2/2 - y**2/2)) +\
-            (y+4)*-np.exp((-0.5*(x-2)**2-0.5*(y+4)**2))
+        dx = x * (-np.exp(-(x ** 2) / 2 - y ** 2 / 2)) + (x - 2) * -np.exp(
+            (-0.5 * (x - 2) ** 2 - 0.5 * (y + 4) ** 2)
+        )
+        dy = y * (-np.exp(-(x ** 2) / 2 - y ** 2 / 2)) + (y + 4) * -np.exp(
+            (-0.5 * (x - 2) ** 2 - 0.5 * (y + 4) ** 2)
+        )
 
         data = np.empty((2, 512, 512))
         data[0] = dx
@@ -496,7 +502,7 @@ class TestPhaseRetrieval:
         surface /= surface.std()
         self.surface = surface
 
-    @pytest.mark.parametrize('method', ['kottler', 'arnison', 'frankot'])
+    @pytest.mark.parametrize("method", ["kottler", "arnison", "frankot"])
     def test_kottler(self, method):
         s_recon = self.s.phase_retrieval(method=method)
         recon = s_recon.data
@@ -505,7 +511,7 @@ class TestPhaseRetrieval:
 
         assert np.isclose(self.surface, recon, atol=1e-3).all()
 
-    @pytest.mark.parametrize('method', ['kottler', 'arnison', 'frankot'])
+    @pytest.mark.parametrize("method", ["kottler", "arnison", "frankot"])
     def test_mirroring(self, method):
         s_recon = self.s.phase_retrieval(method, mirroring=True)
         recon = s_recon.data
@@ -514,12 +520,10 @@ class TestPhaseRetrieval:
 
         assert np.isclose(self.surface, recon, atol=1e-3).all()
 
-    @pytest.mark.parametrize('method', ['kottler', 'arnison', 'frankot'])
+    @pytest.mark.parametrize("method", ["kottler", "arnison", "frankot"])
     def test_mirror_flip(self, method):
-        s_noflip = self.s.phase_retrieval(method, mirroring=True,
-                                          mirror_flip=False)
-        s_flip = self.s.phase_retrieval(method, mirroring=True,
-                                        mirror_flip=True)
+        s_noflip = self.s.phase_retrieval(method, mirroring=True, mirror_flip=False)
+        s_flip = self.s.phase_retrieval(method, mirroring=True, mirror_flip=True)
         noflip = s_noflip.data
         noflip -= noflip.mean()
         noflip /= noflip.std()
@@ -530,8 +534,8 @@ class TestPhaseRetrieval:
         noflip_sum_diff = np.abs(self.surface - noflip).sum()
         flip_sum_diff = np.abs(self.surface - flip).sum()
 
-        assert (noflip_sum_diff != flip_sum_diff)
+        assert noflip_sum_diff != flip_sum_diff
 
     @pytest.mark.xfail(reason="invalid_method")
     def test_unavailable_method(self):
-        self.s.phase_retrieval('magic!')
+        self.s.phase_retrieval("magic!")


### PR DESCRIPTION
---
name: Retrieve phase from DPC signal
about: Added method to retrieve phase from DPC signal, usually the beam shifts and they are proportional to the phase gradient, so integration can be performed to recover the phase. Three formulae from literature were implemented.

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
It added method to retrieve the phase from DPC signal, three integration formulae from literature were included. Signal mirroring can be enabled to reduce boundary effects.
