### PR TITLE
Apply affine transform order default changed from 3 ---> 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
 - Plotting large, lazy, datasets will be much faster now (#655)
 - Methods to retrieve phase from DPC signal are added (#662)
+- .apply_affine_transform now uses a default order of 1 (changed from 3)
 
 ### Removed
 - The local_gaussian_method for subpixel refinement

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -380,6 +380,7 @@ class DPCSignal2D(Signal2D):
             ky_grid /= calY
             fx = np.fft.fftshift(np.fft.fft2(dx))
             fy = np.fft.fftshift(np.fft.fft2(dy))
+            # weights in x,y directins, currently hardcoded, but easy to extend if required
             wx, wy = 0.5, 0.5
 
             numerator = -1j * (wx * kx_grid * fx + wy * ky_grid * fy)

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -185,7 +185,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return signal_mask
 
     def apply_affine_transformation(
-        self, D, order=3, keep_dtype=False, inplace=True, *args, **kwargs
+        self, D, order=1, keep_dtype=False, inplace=True, *args, **kwargs
     ):
         """Correct geometric distortion by applying an affine transformation.
 
@@ -195,7 +195,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             3x3 np.array (or Signal2D thereof) specifying the affine transform
             to be applied.
         order : 1,2,3,4 or 5
-            The order of interpolation on the transform. Default is 3.
+            The order of interpolation on the transform. Default is 1.
         keep_dtype : bool
             If True dtype of returned ElectronDiffraction2D Signal is that of
             the input, if False, casting to higher precision may occur.


### PR DESCRIPTION
---
name: Apply affine transform order default changed from 3 ---> 1
about: It does what it says in the title, and also adds a comment that didn't quiet make it into #662

---

**Checklist**
- [x] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
affine transform order was defaulted to 3 (cubic), but this runs a lot slower than 1 (linear) and the improvement is very marginal (/non-existent), I've been setting order=1 for about 18 months now, so it seemed as good a time as any to make the change.