### PR TITLE
Tidying up the class arrangement for "ai"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Calibration workflow has been altered (see PR #640 for details)
-- Azimuthal integration has been refactored (see PR #625 for details)
+- Azimuthal integration has been refactored (see PRs #625,#676 for details)
 - get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
 - Plotting large, lazy, datasets will be much faster now (#655)
 - Methods to retrieve phase from DPC signal are added (#662)

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -113,12 +113,6 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         except (AttributeError):
             raise ValueError("ai property is not currently set")
 
-    @ai.setter
-    def ai(self, ai):
-        """ Sets the Azimuthal Integrator property.  See ~pyFAI.AzimuthalIntegrator for more.
-        """
-        self.metadata.set_item("Signal.ai", ai)
-
     def set_ai(
         self, center=None, wavelength=None, affine=None, radial_range=None, **kwargs
     ):
@@ -137,17 +131,20 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         radial_range: (start,stop)
             The start and stop of the radial range in real units
 
+        Returns
+        -------
+        None :
+            The metadata item Signal.ai is set
+
         """
+        if wavelength is None and self.unit not in ["2th_deg", "2th_rad"]:
+            raise ValueError('if the unit is not \'2th_deg\' or \'2th_rad\' then a wavelength must be given.')
+
         pixel_scale = [
             self.axes_manager.signal_axes[0].scale,
             self.axes_manager.signal_axes[1].scale,
         ]
-        if wavelength is None and self.unit not in ["2th_deg", "2th_rad"]:
-            print(
-                'if the unit is not "2th_deg", "2th_rad"'
-                "then a wavelength must be given. "
-            )
-            return None
+
         unit = to_unit(self.unit)
         sig_shape = self.axes_manager.signal_shape
         setup = _get_setup(wavelength, self.unit, pixel_scale, radial_range)
@@ -161,8 +158,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             wavelength=wavelength,
             **kwargs,
         )
-        self.ai = ai
-        return ai
+        self.metadata.set_item("Signal.ai", ai)
+        return None
 
     def get_direct_beam_mask(self, radius):
         """Generate a signal mask for the direct beam.

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -304,7 +304,6 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         radial_range=None,
         azimuth_range=None,
         wavelength=None,
-        unit="k_nm^-1",
         inplace=False,
         method="splitpixel",
         sum=False,
@@ -336,9 +335,6 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         wavelength: None or float
             The wavelength of for the microscope. Has to be in the same units as the pyxem units if you want
             it to properly work.
-        unit: str
-            The unit can be "pyxem" to use the pyxem units and “q_nm^-1”, “q_A^-1”, “2th_deg”, “2th_rad”, “r_mm”
-            if pyFAI is used for unit handling
         inplace: bool
             If the signal is overwritten or copied to a new signal
         method: str

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -111,7 +111,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         try:
             return self.metadata.Signal["ai"]
         except (AttributeError):
-            return None
+            raise ValueError("ai property is not currently set")
 
     @ai.setter
     def ai(self, ai):

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -309,15 +309,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         sum=False,
         **kwargs,
     ):
-        """Creates a polar reprojection using pyFAI's azimuthal integrate 2d.
-
-        This function is designed to be fairly flexible to account for 2 different cases:
-
-        1 - If the unit is "pyxem" then it lets pyXEM take the lead. If wavelength is none in that case
-        it doesn't account for the Ewald sphere.
-
-        2 - If unit is any of the options from pyFAI then detector cannot be None and the handling of
-        units is passed to pyxem and those units are used.
+        """Creates a polar reprojection using pyFAI's azimuthal integrate 2d. This method is designed
+        with 2 cases in mind. (1) the signal has pyxem style units, if a wavelength is not provided
+        no account is made for the curvature of the Ewald sphere. (2) the signal has pyFAI style units,
+        in which case the detector kwarg must be provided.
 
         Parameters
         ----------
@@ -437,15 +432,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         correctSolidAngle=True,
         **kwargs,
     ):
-        """Creates a polar reprojection using pyFAI's azimuthal integrate 2d.
-
-        This function is designed to be fairly flexible to account for 2 different cases:
-
-        1 - If the unit is "pyxem" then it lets pyXEM take the lead. If wavelength is none in that case
-        it doesn't account for the Ewald sphere.
-
-        2 - If unit is any of the options from pyFAI then detector cannot be None and the handling of
-        units is passed to pyxem and those units are used.
+        """Creates a polar reprojection using pyFAI's azimuthal integrate 2d. This method is designed
+        with 2 cases in mind. (1) the signal has pyxem style units, if a wavelength is not provided
+        no account is made for the curvature of the Ewald sphere. (2) the signal has pyFAI style units,
+        in which case the detector kwarg must be provided.
 
         Parameters
         ----------

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -420,14 +420,16 @@ class TestAzimuthalIntegrator:
         ones_diff.unit = "2th_deg"
         return ones_diff
 
+    @pytest.mark.xfail()
     def test_set_ai_fail(self, ones):
+        # Not enough parameters fed into .set_ai()
         ones.unit = "k_nm^-1"
         ai = ones.set_ai()
-        assert ai is None
 
+    @pytest.mark.xfail()
     def test_return_ai_fail(self, ones):
+        # .ai hasn't been set 
         ai = ones.ai
-        assert ai is None
 
 
 class TestGetDirectBeamPosition:


### PR DESCRIPTION
---
name: Tidying up the class arrangement for "ai"
about: Adapt the `@property` of ai to be more pythonic

---

**Checklist**
- [x] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
- fixes #641 by changing the `except` block for `dp.ai` when `ai` has not been set 
- tackles #642 by removing the `unit` kwarg

**Describe alternatives you've considered**
This section of the code still needs quiet a lot of work, but this will fix a few problems