### PR TITLE
Fix bug in get_direct_beam_position: non-uniform chunks

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -954,7 +954,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         drop_axis = (len(self.axes_manager.shape) - 2, len(self.axes_manager.shape) - 1)
         new_axis = self.axes_manager.navigation_dimension
-        chunks_output = dask_array.chunksize[:-2] + (2,)
+        chunks_output = dask_array.chunks[:-2] + ((2,),)
 
         if method == "cross_correlate":
             shifts = _process_dask_array(

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -503,6 +503,14 @@ class TestGetDirectBeamPosition:
         assert hasattr(s_shift.data, "compute")
         s_shift.compute()
 
+    def test_non_uniform_chunks(self):
+        s = LazyDiffraction2D(da.from_array(self.s.data, chunks=(8, 7, 10, 12)))
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
+        shift_data_shape = s.data.shape[:-2] + (2,)
+        assert s_shift.data.shape == shift_data_shape
+        s_shift.compute()
+        assert s_shift.data.shape == shift_data_shape
+
 
 class TestCenterDirectBeam:
     def setup_method(self):
@@ -558,6 +566,18 @@ class TestCenterDirectBeam:
         assert (s_lazy.data[:, :, 10, 8] == 9).all()
         s_lazy.data[:, :, 10, 8] = 0
         assert not s_lazy.data.any()
+
+    def test_non_uniform_chunks(self):
+        s_lazy = self.s_lazy
+        s_lazy.data = s_lazy.data.rechunk((5, 4, 12, 14))
+        s_lazy_shape = s_lazy.axes_manager.shape
+        data_lazy_shape = s_lazy.data.shape
+        s_lazy.center_direct_beam(method="blur", sigma=1, lazy_result=True)
+        assert s_lazy.axes_manager.shape == s_lazy_shape
+        assert s_lazy.data.shape == data_lazy_shape
+        s_lazy.compute()
+        assert s_lazy.axes_manager.shape == s_lazy_shape
+        assert s_lazy.data.shape == data_lazy_shape
 
     def test_return_shifts_non_lazy(self):
         s = self.s


### PR DESCRIPTION
This pull request fixes the bug reported in #675.

Essentially if the chunks were non-uniform and a modulus(?) of the data size, `da.map_blocks` would return the wrong `output_array` size.

This only affected the dask array itself. If `output_array.compute()` was run, it became the correct size.

This pull request fixes this by using `dask_array.chunks` instead of `dask_array.chunksize`.

Thanks to Niels Cautaerts (@din14970) for reporting this!

-------------------------
Incidentally, by solving this bug, I also figured out how to fix the problem I was having in https://github.com/pyxem/pyxem/pull/668, which was also related to the size of `output_array`.

**Checklist**
- [x] Fix the bug
- [x] Add tests