### PR TITLE
Improve tests for differential phase contrast functionality

### DIFF
--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -244,6 +244,20 @@ class TestBivariateHistogram:
         s_random = DPCSignal2D(data_random)
         s_random.get_bivariate_histogram()
 
+    def test_masked_get_bivariate_histogram(self):
+        s = pxm.DPCSignal2D(np.zeros((2, 5, 5)))
+        value = 3
+        s.data[0, 0, 0] = value
+        s_hist = s.get_bivariate_histogram(bins=10, histogram_range=(-5, 5))
+        assert s_hist.isig[3.0, 0.0] == float(value)
+
+        masked = np.zeros((11, 11), dtype=np.bool)
+        masked[0, 0] = True
+        s_hist = s.get_bivariate_histogram(
+            bins=10, histogram_range=(-5, 5), masked=masked
+        )
+        assert s_hist.isig[3.0, 0.0] == 0.0
+
     def test_make_bivariate_histogram(self):
         x, y = np.ones((100, 100)), np.ones((100, 100))
         make_bivariate_histogram(

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -226,18 +226,6 @@ class TestGetDpcSignal:
             scalebar_size=10,
         )
         s.get_color_image_with_indicator(only_phase=True)
-
-    def test_get_color_image_with_indicator(self):
-        s = DPCSignal2D(np.random.random(size=(2, 100, 100)))
-        s.get_color_image_with_indicator()
-        s.get_color_image_with_indicator(
-            phase_rotation=45,
-            indicator_rotation=10,
-            autolim=True,
-            autolim_sigma=1,
-            scalebar_size=10,
-        )
-        s.get_color_image_with_indicator(only_phase=True)
         fig, ax = subplots()
         s.get_color_image_with_indicator(ax=ax)
 


### PR DESCRIPTION
This pull request is a small clean-up of the tests in `signals/test_differential_phase_contrast.py`: reorder the tests slightly, and getting the coverage of `signals/differential_phase_contrast.py` up to 100%.

--------------------------------
### TODO
- [x]  Add test for all parameters in `make_bivariate_histogram`