### PR TITLE
Add unit tests for Diffraction2D class

### DIFF
--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -377,6 +377,10 @@ class TestVariance:
         # This fails at small radii and might still fail because it is random...
         np.testing.assert_array_almost_equal(bulls_eye_variance.data[6:], np.zeros(19), decimal=1)
 
+    def test_not_existing_method(self, ones):
+        with pytest.raises(ValueError):
+            ones.get_variance(npt=5, method="magic")
+
 
 class TestAzimuthalIntegral2d:
     @pytest.fixture
@@ -884,6 +888,11 @@ class TestDiffraction2DFindPeaksLazy:
         s = Diffraction2D(np.random.randint(100, size=(3, 2, 10, 20)))
         peak_array = s.find_peaks_lazy(method=methods)
 
+    def test_not_existing_method(self):
+        s = LazyDiffraction2D(da.zeros((2, 2, 5, 5), chunks=(1, 1, 5, 5)))
+        with pytest.raises(ValueError):
+            s.find_peaks_lazy(method="magic")
+
     @pytest.mark.parametrize("methods", method1)
     def test_lazy_input(self, methods):
         data = np.random.randint(100, size=(3, 2, 10, 20))
@@ -952,11 +961,11 @@ class TestDiffraction2DPeakPositionRefinement:
         assert s.data.shape[:2] == refined_peak_array.shape
         assert hasattr(refined_peak_array, "compute")
 
-    @pytest.mark.xfail(reason="Designed failure")
     def test_wrong_square_size(self):
         s = Diffraction2D(np.random.randint(100, size=(3, 2, 10, 20)))
-        peak_array = s.find_peaks()
-        s.peak_position_refinement_com(peak_array, square_size=5)
+        peak_array = s.find_peaks(interactive=False)
+        with pytest.raises(ValueError):
+            s.peak_position_refinement_com(peak_array, square_size=5)
 
     def test_lazy_input(self):
         data = np.random.randint(100, size=(3, 2, 10, 20))

--- a/pyxem/tests/signals/test_pixelated_stem_class.py
+++ b/pyxem/tests/signals/test_pixelated_stem_class.py
@@ -596,6 +596,17 @@ class TestDiffraction2DCenterOfMass:
         s_lazy = LazyDiffraction2D(data)
         s_lazy_com = s_lazy.center_of_mass(lazy_result=True)
         assert s_lazy_com._lazy
+        assert s_lazy_com.axes_manager.signal_shape == (10, 10)
+
+        s_lazy_1d = s_lazy.inav[0]
+        s_lazy_1d_com = s_lazy_1d.center_of_mass(lazy_result=True)
+        assert s_lazy_1d_com._lazy
+        assert s_lazy_1d_com.axes_manager.signal_shape == (10,)
+
+        s_lazy_0d = s_lazy.inav[0, 0]
+        s_lazy_0d_com = s_lazy_0d.center_of_mass(lazy_result=True)
+        assert s_lazy_0d_com._lazy
+        assert s_lazy_0d_com.axes_manager.signal_shape == ()
 
 
 class TestDiffraction2DRadialAverage:


### PR DESCRIPTION
This pull requests add several unit tests which checks the functionality in the Diffraction2D class, getting the coverage for `diffraction2d.py` to 100%.

----------------------------------------------------

One note about `@pytest.mark.xfail(raises=ValueError)` vs `with pytest.raises(ValueError)`.

For example, previously the test `test_wrong_square_size` did not work as expected https://github.com/pyxem/pyxem/blob/3673b8e2aa74efdf520fa1a38b4e5696bb80dcca/pyxem/tests/signals/test_diffraction2d.py#L955-L959
```python
@pytest.mark.xfail(reason="Designed failure")
def test_wrong_square_size(self):
        s = Diffraction2D(np.random.randint(100, size=(3, 2, 10, 20)))
        peak_array = s.find_peaks()
        s.peak_position_refinement_com(peak_array, square_size=5)
```
Since it had `@pytest.mark.xfail(reason="Designed failure")` defined for the whole `test_wrong_square_size` function, it caught the exception raised by `s.find_peaks()` (for not finding a toolkit), rather than the exception we wanted to catch in `peak_position_refinement_com`.

So for these types of expected exceptions, I think using `with pytest.raises` at the exact line which is expected to raise the exception is the best choice.
