### PR TITLE
Restoring VectorMatching workflow to its v0.12 state

### DIFF
--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -71,37 +71,6 @@ def crystal_from_vector_matching(z_matches):
     metrics["ehkls"] = best_match.error_hkls
     metrics["total_error"] = best_match.total_error
 
-    # get second highest correlation phase for phase_reliability (if present)
-    other_phase_matches = [
-        match for match in z_matches if match.phase_index != best_match.phase_index
-    ]
-
-    if other_phase_matches:
-        second_best_phase = sorted(
-            other_phase_matches, key=attrgetter("total_error"), reverse=False
-        )[0]
-
-        metrics["phase_reliability"] = 100 * (
-            1 - best_match.total_error / second_best_phase.total_error
-        )
-
-        # get second best matching orientation for orientation_reliability
-        same_phase_matches = [
-            match for match in z_matches if match.phase_index == best_match.phase_index
-        ]
-        second_match = sorted(
-            same_phase_matches, key=attrgetter("total_error"), reverse=False
-        )[1]
-    else:
-        # get second best matching orientation for orientation_reliability
-        second_match = get_nth_best_solution(
-            z_matches, "vector", rank=1, key="total_error", descending=False
-        )
-
-    metrics["orientation_reliability"] = 100 * (
-        1 - best_match.total_error / (second_match.total_error or 1.0)
-    )
-
     results_array[2] = metrics
 
     return results_array
@@ -272,60 +241,31 @@ class VectorMatchingResults(BaseSignal):
         self.vectors = None
         self.hkls = None
 
-    def to_crystal_map(self):
+    def get_crystallographic_map(self, *args, **kwargs):
         """Obtain a crystallographic map specifying the best matching phase and
         orientation at each probe position with corresponding metrics.
 
-        Raises
+        Returns
         -------
-        ValueError("Currently under development")
+        cryst_map : Signal2D
+            Crystallographic mapping results containing the best matching phase
+            and orientation at each navigation position with associated metrics.
+            The Signal at each navigation position is an array of,
+                            [phase, np.array((z,x,z)), dict(metrics)]
+            which defines the phase, orientation as Euler angles in the zxz
+            convention and metrics associated with the matching.
+            Metrics for template matching results are
+                'match_rate'
+                'total_error'
+                'orientation_reliability'
+                'phase_reliability'
         """
+        crystal_map = self.map(
+            crystal_from_vector_matching, inplace=False, *args, **kwargs
+        )
 
-        raise ValueError("Currently under development")
-
-        _s = self.map(
-            crystal_from_vector_matching, inplace=False)
-
-        """ Gets phase, the easy bit """
-        phase_id = _s.isig[0].data.flatten()
-
-        """ Deals with the properties, hard coded as of v0.13 """
-        # need to invert an array of dicts into a dict of arrays
-        def _map_to_get_property(prop):
-            return d[prop]
-
-        # assume same properties at every point of the signal
-        key_list = []
-        for key in _s.inav[0,0].isig[2]:
-            key_list.append(key)
-
-        properties = {}
-        for key in key_list:
-            _key_signal = _s.isig[2].map(_map_to_get_property,prop=key,inplace=False)
-            properties[key] = _key_signal
-
-        """ Deal with the rotations """
-        def _map_for_alpha_beta_gamma(ix):
-            return z[ix]
-
-        alpha = _s.isig[1].map(_map_for_alpha_beta_gamma,ix=0,inplace=False)
-        beta =  _s.isig[1].map(_map_for_alpha_beta_gamma,ix=1,inplace=False)
-        gamma = _s.isig[1].map(_map_for_alpha_beta_gamma,ix=2,inplace=False)
-
-        euler = np.vstack((alpha,beta,gamma)).T
-        rotations = Rotation.from_euler(euler,convention="bunge", direction="crystal2lab")
-
-        """ Gets navigation placements """
-        xy = np.indices(_s.data.shape[:2])
-        x = xy[1].flatten()
-        y = xy[0].flatten()
-
-        return CrystalMap(
-                rotations=rotations,
-                phase_id=phase_id,
-                x=x,
-                y=y,
-                prop=properties)
+        crystal_map = transfer_navigation_axes(crystal_map, self)
+        return crystal_map
 
     def get_indexed_diffraction_vectors(
         self, vectors, overwrite=False, *args, **kwargs

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -101,13 +101,11 @@ def dp_vector_match_result():
     )
     return VectorMatchingResults(res)
 
-@pytest.mark.skip(reason="Under development")
-def test_single_vector_to_crystal_map(sp_vector_match_result):
-    _ = sp_vector_match_result.to_crystal_map()
+def test_single_vector_get_crystallographic_map(sp_vector_match_result):
+    _ = sp_vector_match_result.get_crystallographic_map()
 
-@pytest.mark.skip(reason="Under development")
-def test_double_vector_to_crystal_map(dp_vector_match_result):
-    _ = dp_vector_match_result.to_crystal_map()
+def test_double_vector_get_crystallographic_map(dp_vector_match_result):
+    _ = dp_vector_match_result.get_crystallographic_map()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
---
name: Restoring VectorMatching workflow to its 0.12 state
about: This is the simplest course of action for now (see #660) - a rewrite is on some sort of horizon.

---

**Checklist**
- [ ] Updated CHANGELOG.md (n/a here)
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
Vector matching now works as previously, and the results can't be exported to orix.
