### PR TITLE
Add roi mesh VirtualImageGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - center_direct_beam now supports lazy processing (#658)
 - Several functions for processing large datasets using dask (#648, #658)
 - Methods to retrieve phase from DPC signal are added (#662)
+- Add VirtualImageGenerator.set_ROI_mesh method to set mesh of CircleROI (#700)
 
 ### Changed
 - Calibration workflow has been altered (see PR #640 for details)
 - Azimuthal integration has been refactored (see PRs #625,#676 for details)
-- get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
+- get_direct_beam_position now has reversed order of the shifts [y, x] to [x, y] (#653)
 - Plotting large, lazy, datasets will be much faster now (#655)
 - .apply_affine_transform now uses a default order of 1 (changed from 3)
 - find_peaks is now provided by hyperspy, method 'xc' now called 'template_matching'

--- a/pyxem/generators/virtual_image_generator.py
+++ b/pyxem/generators/virtual_image_generator.py
@@ -220,7 +220,7 @@ class VirtualImageGenerator:
         vdfim.set_signal_type("virtual_dark_field")
 
         if vdfim.metadata.has_item('Diffraction.integrated_range'):
-            del vdfs.metadata.Diffraction.integrated_range
+            del vdfim.metadata.Diffraction.integrated_range
         vdfim.metadata.set_item('Diffraction.roi_list',
                                 [f"{roi}" for roi in self.roi_list]
                                 )
@@ -231,7 +231,7 @@ class VirtualImageGenerator:
             setattr(new_axis, k, v)
 
         if normalize:
-            vdfim.map(normalize_virtual_images)
+            vdfim.map(normalize_virtual_images, show_progressbar=False)
 
         return vdfim
 

--- a/pyxem/signals/common_diffraction.py
+++ b/pyxem/signals/common_diffraction.py
@@ -23,6 +23,12 @@ from hyperspy.api import interactive
 from traits.trait_base import Undefined
 
 
+OUT_SIGNAL_AXES_DOCSTRING = """out_signal_axes : None, iterable of int or string
+            Specify which navigation axes to use as signal axes in the virtual
+            image. If None, the two first navigation axis are used.
+        """
+
+
 class CommonDiffraction:
     @property
     def unit(self):
@@ -128,9 +134,7 @@ class CommonDiffraction:
         ----------
         roi : :obj:`hyperspy.roi.BaseInteractiveROI`
             Any interactive ROI detailed in HyperSpy.
-        out_signal_axes : None, iterable of int or string
-            Specify which navigation axes to use as signal axes in the virtual
-            image. If None, the two first navigation axis are used.
+        %s
 
         Returns
         -------
@@ -162,6 +166,8 @@ class CommonDiffraction:
         dark_field_sum.metadata.set_item("Diffraction.intergrated_range", roi_info)
 
         return dark_field_sum
+
+    get_integrated_intensity.__doc__ %= (OUT_SIGNAL_AXES_DOCSTRING)
 
 
     def add_navigation_signal(self, data, name="nav1", unit=None, nav_plot=False):

--- a/pyxem/signals/common_diffraction.py
+++ b/pyxem/signals/common_diffraction.py
@@ -163,7 +163,7 @@ class CommonDiffraction:
         roi_info = f"{roi}"
         if self.metadata.get_item("General.title") not in ("", None):
             roi_info += f" of {self.metadata.General.title}"
-        dark_field_sum.metadata.set_item("Diffraction.intergrated_range", roi_info)
+        dark_field_sum.metadata.set_item("Diffraction.integrated_range", roi_info)
 
         return dark_field_sum
 

--- a/pyxem/tests/generators/test_virtual_image_generator.py
+++ b/pyxem/tests/generators/test_virtual_image_generator.py
@@ -149,7 +149,7 @@ def test_vi_generator_set_ROI_mesh(diffraction_pattern):
 
 @pytest.mark.parametrize('nav_shape', [[2], [2, 4]])
 def test_vi_generator_get_virtual_images_from_mesh(nav_shape):
-    n = np.multiply(*nav_shape)*32**2 if len(nav_shape) > 1 else nav_shape[0]*32**2
+    n = np.prod(nav_shape)*32**2
     s = Diffraction2D(np.arange(n).reshape((*nav_shape, 32, 32)))
     vi_generator = VirtualImageGenerator(s)
 
@@ -167,6 +167,10 @@ def test_vi_generator_get_virtual_images_from_mesh(nav_shape):
     assert vi_nav_axis.size == 21
     assert vi_nav_axis.name == 'ROI index'
     assert vi_nav_axis.scale == 1.0
+    assert len(vi_generator.roi_list) == 21
+
+    vi_generator.set_ROI_mesh(0.5, 0.6, 1.0)
+    assert len(vi_generator.roi_list) == 11
 
     vi = vi_generator.get_virtual_images_from_mesh(normalize=True)
 

--- a/pyxem/tests/generators/test_virtual_image_generator.py
+++ b/pyxem/tests/generators/test_virtual_image_generator.py
@@ -18,6 +18,7 @@
 
 import pytest
 import numpy as np
+import hyperspy.api as hs
 
 from pyxem.generators.virtual_image_generator import (VirtualImageGenerator,
                                                       VirtualDarkFieldGenerator)
@@ -49,6 +50,7 @@ def virtual_image_generator(diffraction_pattern):
         diffraction_pattern.data == 0, 0.01, diffraction_pattern.data
     )  # avoid divide by zeroes
     return VirtualDarkFieldGenerator(diffraction_pattern)
+
 
 class TestVirtualDarkFieldGenerator:
     def test_vdf_generator_init_with_vectors(self, diffraction_pattern):
@@ -135,3 +137,54 @@ def test_vdf_generator_from_map(diffraction_pattern):
 
     vdfgen = VirtualImageGenerator(diffraction_pattern, dvm)
     assert isinstance(vdfgen, VirtualImageGenerator)
+
+
+def test_vi_generator_set_ROI_mesh(diffraction_pattern):
+    vi_generator = VirtualImageGenerator(diffraction_pattern)
+    diffraction_pattern.plot()
+    vi_generator.set_ROI_mesh(1.0, 1.2, 1.0)
+    assert len(vi_generator.roi_list) == 3
+    assert isinstance(vi_generator.roi_list[0], hs.roi.CircleROI)
+
+
+@pytest.mark.parametrize('nav_shape', [[2], [2, 4]])
+def test_vi_generator_get_virtual_images_from_mesh(nav_shape):
+    n = np.multiply(*nav_shape)*32**2 if len(nav_shape) > 1 else nav_shape[0]*32**2
+    s = Diffraction2D(np.arange(n).reshape((*nav_shape, 32, 32)))
+    vi_generator = VirtualImageGenerator(s)
+
+    with pytest.raises(ValueError):
+        vi_generator.get_virtual_images_from_mesh()
+
+    for axis in s.axes_manager.signal_axes:
+        axis.scale = 0.1
+        axis.offset = -1.6
+        axis.units = '1/nm'
+
+    vi_generator.set_ROI_mesh(0.5, 0.6, 1.4)
+    vi = vi_generator.get_virtual_images_from_mesh()
+    vi_nav_axis = vi.axes_manager.navigation_axes[0]
+    assert vi_nav_axis.size == 21
+    assert vi_nav_axis.name == 'ROI index'
+    assert vi_nav_axis.scale == 1.0
+
+    vi = vi_generator.get_virtual_images_from_mesh(normalize=True)
+
+
+def test_vi_generator_get_virtual_images_from_mesh_nav_dim3():
+    s = Diffraction2D(np.arange(2*4*10*32**2).reshape((2, 4, 10, 32, 32)))
+    for axis in s.axes_manager.signal_axes:
+        axis.scale = 0.1
+        axis.offset = -1.6
+        axis.units = '1/nm'
+    vi_generator = VirtualImageGenerator(s)
+
+    vi_generator.set_ROI_mesh(0.5, 0.6, 0.6)
+    vi = vi_generator.get_virtual_images_from_mesh()
+
+    assert vi.axes_manager.navigation_shape == (2, 5)
+
+    vi = vi_generator.get_virtual_images_from_mesh(out_signal_axes=[1, 2])
+
+    assert vi.axes_manager.navigation_shape == (10, 5)
+

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -25,7 +25,6 @@ from numpy.random import default_rng
 
 from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
 from pyxem.signals.polar_diffraction2d import PolarDiffraction2D
-from pyxem.detectors.generic_flat_detector import GenericFlatDetector
 from pyxem.signals.diffraction1d import Diffraction1D
 
 
@@ -579,7 +578,7 @@ class TestVirtualImaging:
         assert vi.axes_manager.navigation_dimension == 0
         assert vi.metadata.General.title == "Integrated intensity"
         assert (
-            vi.metadata.Diffraction.intergrated_range
+            vi.metadata.Diffraction.integrated_range
             == "CircleROI(cx=3, cy=3, r=5) of Stack of "
         )
 
@@ -598,7 +597,7 @@ class TestVirtualImaging:
         assert vi.data.shape == (2,)
         assert vi.axes_manager.signal_dimension == 1
         assert vi.axes_manager.navigation_dimension == 0
-        assert vi.metadata.Diffraction.intergrated_range == "CircleROI(cx=3, cy=3, r=5)"
+        assert vi.metadata.Diffraction.integrated_range == "CircleROI(cx=3, cy=3, r=5)"
 
 
 class TestAzimuthalIntegrator:
@@ -1148,7 +1147,7 @@ class TestSubtractingDiffractionBackground:
 class TestFindHotPixels:
     @pytest.fixture()
     def hot_pixel_data_2d(self):
-        """ Values are 50, except [21, 11] and [5, 38]
+        """ Values are 50, except [21, 11] and [5, 38]
         being 50000 (to represent a "hot pixel").
         """
         data = np.ones((40, 50)) * 50
@@ -1204,7 +1203,7 @@ class TestFindHotPixels:
 class TestFindDeadPixels:
     @pytest.fixture()
     def dead_pixel_data_2d(self):
-        """Values are 50, except [14, 42] and [2, 12]
+        """Values are 50, except [14, 42] and [2, 12]
         being 0 (to represent a "dead pixel").
         """
         data = np.ones((40, 50)) * 50

--- a/pyxem/tests/utils/test_virtual_images.py
+++ b/pyxem/tests/utils/test_virtual_images.py
@@ -17,6 +17,7 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
 
 from pyxem.utils.virtual_images_utils import get_vectors_mesh
 
@@ -69,3 +70,6 @@ def test_get_vectors_mesh():
 
     mesh = get_vectors_mesh(1.0, 1.2, g_norm_max=1.5, angle=30.0, shear=0.1)
     np.testing.assert_allclose(mesh, mesh4)
+
+    with pytest.raises(ValueError):
+        get_vectors_mesh(1.0, 1.0, g_norm_max=1.5, angle=0.0, shear=2.0)

--- a/pyxem/tests/utils/test_virtual_images.py
+++ b/pyxem/tests/utils/test_virtual_images.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from pyxem.utils.virtual_images_utils import get_vectors_mesh
+
+
+def test_get_vectors_mesh():
+    mesh1 = np.array([[-1., -1.],
+       [ 0., -1.],
+       [ 1., -1.],
+       [-1.,  0.],
+       [ 0.,  0.],
+       [ 1.,  0.],
+       [-1.,  1.],
+       [ 0.,  1.],
+       [ 1.,  1.]])
+    mesh = get_vectors_mesh(1.0, 1.0, g_norm_max=1.5, angle=0.0, shear=0.0)
+    np.testing.assert_allclose(mesh, mesh1)
+
+    mesh = get_vectors_mesh(2.0, 2.0, g_norm_max=3.0, angle=0.0, shear=0.0)
+    np.testing.assert_allclose(mesh, mesh1*2)
+
+    mesh = get_vectors_mesh(1.5, 1.0, g_norm_max=1.9, angle=0.0, shear=0.0)
+    np.testing.assert_allclose(mesh.T[0], mesh1.T[0]*1.5)
+    np.testing.assert_allclose(mesh.T[1], mesh1.T[1])
+
+    mesh2 = np.array([[ 0.5      , -0.8660254],
+       [-0.8660254, -0.5      ],
+       [ 0.       ,  0.       ],
+       [ 0.8660254,  0.5      ],
+       [-0.5      ,  0.8660254]])
+
+    mesh = get_vectors_mesh(1.0, 1.0, g_norm_max=1.0, angle=30, shear=0.0)
+    np.testing.assert_allclose(mesh, mesh2)
+
+    mesh3 = np.array([[-0.1, -1. ],
+       [-1. ,  0. ],
+       [ 0. ,  0. ],
+       [ 1. ,  0. ],
+       [ 0.1,  1. ]])
+
+    mesh = get_vectors_mesh(1.0, 1.0, g_norm_max=1.2, angle=0.0, shear=0.1)
+    np.testing.assert_allclose(mesh, mesh3)
+
+    mesh4 = np.array([[ 0.49607695, -1.09923048],
+       [ 1.36210236, -0.59923048],
+       [-0.8660254 , -0.5       ],
+       [ 0.        ,  0.        ],
+       [ 0.8660254 ,  0.5       ],
+       [-1.36210236,  0.59923048],
+       [-0.49607695,  1.09923048]])
+
+    mesh = get_vectors_mesh(1.0, 1.2, g_norm_max=1.5, angle=30.0, shear=0.1)
+    np.testing.assert_allclose(mesh, mesh4)

--- a/pyxem/utils/virtual_images_utils.py
+++ b/pyxem/utils/virtual_images_utils.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
+
 
 def normalize_virtual_images(im):
     """Normalizes image intensity by dividing by maximum value.
@@ -33,3 +35,50 @@ def normalize_virtual_images(im):
     """
     imn = im / im.max()
     return imn
+
+
+def get_vectors_mesh(g_norm, g_norm_max, angle=0.0, shear=0.0):
+    """
+    Calculate vectors coordinates of a mesh defined by a norm, a rotation and
+    a shear component.
+
+    Parameters
+    ----------
+    g_norm : float
+        The norm of one of the two vectors of the mesh.
+    g_norm_max : float
+        The maximum value for the norm of each vector.
+    angle : float, optional
+        The rotation of the mesh in degree.
+    shear : float, optional
+        The shear of the mesh. It must be in the interval [0, 1].
+        The default is 0.0.
+
+    Returns
+    -------
+    np.ndarray
+        x and y coordinates of the vectors of the mesh
+
+    """
+    def rotation_matrix(angle):
+        return np.array([[np.cos(angle), -np.sin(angle)],
+                         [np.sin(angle), np.cos(angle)]])
+
+    def shear_matrix(shear):
+        return np.array([[1.0, shear],
+                         [0.0, 1.0]])
+
+    if shear < 0 or shear > 1:
+        raise ValueError("The `shear` value must be in the interval [0, 1].")
+
+    order = int(np.ceil(g_norm_max/g_norm))
+    x = y = np.arange(-g_norm*order, g_norm*(order+1), g_norm)
+    xx, yy = np.meshgrid(x, y)
+    vectors = np.stack(np.meshgrid(x, y)).reshape((2, (2*order+1)**2))
+
+    transformation = rotation_matrix(np.radians(angle)) @ shear_matrix(shear)
+
+    vectors = transformation @ vectors
+    norm = np.linalg.norm(vectors, axis=0)
+
+    return vectors[:, norm<g_norm_max].T

--- a/pyxem/utils/virtual_images_utils.py
+++ b/pyxem/utils/virtual_images_utils.py
@@ -37,15 +37,15 @@ def normalize_virtual_images(im):
     return imn
 
 
-def get_vectors_mesh(g_norm, g_norm_max, angle=0.0, shear=0.0):
+def get_vectors_mesh(g1_norm, g2_norm, g_norm_max, angle=0.0, shear=0.0):
     """
     Calculate vectors coordinates of a mesh defined by a norm, a rotation and
     a shear component.
 
     Parameters
     ----------
-    g_norm : float
-        The norm of one of the two vectors of the mesh.
+    g1_norm, g2_norm : float
+        The norm of the two vectors of the mesh.
     g_norm_max : float
         The maximum value for the norm of each vector.
     angle : float, optional
@@ -71,8 +71,13 @@ def get_vectors_mesh(g_norm, g_norm_max, angle=0.0, shear=0.0):
     if shear < 0 or shear > 1:
         raise ValueError("The `shear` value must be in the interval [0, 1].")
 
-    order = int(np.ceil(g_norm_max/g_norm))
-    x = y = np.arange(-g_norm*order, g_norm*(order+1), g_norm)
+    order1 = int(np.ceil(g_norm_max/g1_norm))
+    order2 = int(np.ceil(g_norm_max/g2_norm))
+    order = max(order1, order2)
+
+    x = np.arange(-g1_norm*order, g1_norm*(order+1), g1_norm)
+    y = np.arange(-g2_norm*order, g2_norm*(order+1), g2_norm)
+
     xx, yy = np.meshgrid(x, y)
     vectors = np.stack(np.meshgrid(x, y)).reshape((2, (2*order+1)**2))
 
@@ -81,4 +86,4 @@ def get_vectors_mesh(g_norm, g_norm_max, angle=0.0, shear=0.0):
     vectors = transformation @ vectors
     norm = np.linalg.norm(vectors, axis=0)
 
-    return vectors[:, norm<g_norm_max].T
+    return vectors[:, norm<=g_norm_max].T


### PR DESCRIPTION
**Checklist**
- [x] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

Add convenience method to create a mesh of ROI and generate virtual images from these ROIs.

```python
import numpy as np
from pyxem.signals.diffraction2d import Diffraction2D
from pyxem.generators.virtual_image_generator import VirtualImageGenerator

shape = [2, 3, 32, 32]
s = Diffraction2D(np.arange(np.prod(shape)).reshape(shape))
vi_generator = VirtualImageGenerator(s)

for axis in s.axes_manager.signal_axes:
    axis.scale = 0.1
    axis.offset = -1.6
    axis.units = '1/nm'

vi_generator.set_ROI_mesh(0.5, 0.6, 1.4)
vi = vi_generator.get_virtual_images_from_mesh()
```
