### PR TITLE
Simplify pyxem's namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .apply_affine_transform now uses a default order of 1 (changed from 3)
 - find_peaks is now provided by hyperspy, method 'xc' now called 'template_matching'
 - virtual_annular_dark_field and virtual_bright_field renamed; now have a "lazy_" prefixing (#698)
+- Standardise how to import pyxem objects (#704)
 
 ### Removed
 - The local_gaussian_method for subpixel refinement

--- a/pyxem/__init__.py
+++ b/pyxem/__init__.py
@@ -17,42 +17,16 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import glob
 import logging
-import os
-import warnings
 
-from hyperspy.io import load
-from hyperspy.api import roi
+_logger = logging.getLogger(__name__)
 
-import numpy as np
 
-from natsort import natsorted
-
-from diffsims.generators.diffraction_generator import DiffractionGenerator
-from diffsims.generators.library_generator import DiffractionLibraryGenerator
-from diffsims.generators.library_generator import VectorLibraryGenerator
-from diffsims.sims.diffraction_simulation import DiffractionSimulation
-
-from .signals.diffraction1d import Diffraction1D
-from .signals.diffraction2d import Diffraction2D
-from .signals.diffraction1d import LazyDiffraction1D
-from .signals.diffraction2d import LazyDiffraction2D
-from .signals.electron_diffraction1d import ElectronDiffraction1D
-from .signals.electron_diffraction2d import ElectronDiffraction2D
-from .signals.electron_diffraction1d import LazyElectronDiffraction1D
-from .signals.electron_diffraction2d import LazyElectronDiffraction2D
-from .signals.polar_diffraction2d import PolarDiffraction2D
-from .signals.polar_diffraction2d import LazyPolarDiffraction2D
-
-from .signals.diffraction_variance1d import DiffractionVariance1D
-from .signals.diffraction_variance2d import DiffractionVariance2D
-from .signals.differential_phase_contrast import DPCBaseSignal, DPCSignal1D, DPCSignal2D
-from .signals.diffraction_vectors import DiffractionVectors, DiffractionVectors2D
-from .signals.indexation_results import TemplateMatchingResults
-from .signals.virtual_dark_field_image import VirtualDarkFieldImage
-from .signals.pair_distribution_function1d import PairDistributionFunction1D
-from .signals.reduced_intensity1d import ReducedIntensity1D
+from pyxem import components
+from pyxem import detectors
+from pyxem import dummy_data
+from pyxem import generators
+from pyxem import signals
 
 from pyxem.utils.io_utils import load_mib
 
@@ -67,4 +41,3 @@ __maintainer__ = release_info.maintainer
 __email__ = release_info.email
 __status__ = release_info.status
 
-_logger = logging.getLogger(__name__)

--- a/pyxem/__init__.py
+++ b/pyxem/__init__.py
@@ -32,6 +32,15 @@ from pyxem.utils.io_utils import load_mib
 
 from . import release_info
 
+__all__ = [
+    "components",
+    "detectors",
+    "dummy_data",
+    "generators",
+    "signals",
+    "load_mib",
+    ]
+
 __version__ = release_info.version
 __author__ = release_info.author
 __copyright__ = release_info.copyright
@@ -40,4 +49,3 @@ __license__ = release_info.license
 __maintainer__ = release_info.maintainer
 __email__ = release_info.email
 __status__ = release_info.status
-

--- a/pyxem/__init__.py
+++ b/pyxem/__init__.py
@@ -34,8 +34,6 @@ from diffsims.generators.library_generator import DiffractionLibraryGenerator
 from diffsims.generators.library_generator import VectorLibraryGenerator
 from diffsims.sims.diffraction_simulation import DiffractionSimulation
 
-from .generators.calibration_generator import CalibrationGenerator
-
 from .signals.diffraction1d import Diffraction1D
 from .signals.diffraction2d import Diffraction2D
 from .signals.diffraction1d import LazyDiffraction1D
@@ -46,10 +44,6 @@ from .signals.electron_diffraction1d import LazyElectronDiffraction1D
 from .signals.electron_diffraction2d import LazyElectronDiffraction2D
 from .signals.polar_diffraction2d import PolarDiffraction2D
 from .signals.polar_diffraction2d import LazyPolarDiffraction2D
-
-from .generators.red_intensity_generator1d import ReducedIntensityGenerator1D
-from .generators.pdf_generator1d import PDFGenerator1D
-from .generators.variance_generator import VarianceGenerator
 
 from .signals.diffraction_variance1d import DiffractionVariance1D
 from .signals.diffraction_variance2d import DiffractionVariance2D

--- a/pyxem/components/__init__.py
+++ b/pyxem/components/__init__.py
@@ -19,3 +19,10 @@
 from .reduced_intensity_correction_component import ReducedIntensityCorrectionComponent
 from .scattering_fit_component_lobato import ScatteringFitComponentLobato
 from .scattering_fit_component_xtables import ScatteringFitComponentXTables
+
+
+__all__ = [
+    "ReducedIntensityCorrectionComponent",
+    "ScatteringFitComponentLobato",
+    "ScatteringFitComponentXTables"
+]

--- a/pyxem/components/__init__.py
+++ b/pyxem/components/__init__.py
@@ -15,3 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from .reduced_intensity_correction_component import ReducedIntensityCorrectionComponent
+from .scattering_fit_component_lobato import ScatteringFitComponentLobato
+from .scattering_fit_component_xtables import ScatteringFitComponentXTables

--- a/pyxem/detectors/__init__.py
+++ b/pyxem/detectors/__init__.py
@@ -20,3 +20,10 @@
 from .generic_flat_detector import GenericFlatDetector
 from .medipix_256x256 import Medipix256x256Detector
 from .medipix_515x515 import Medipix515x515Detector
+
+
+__all__ = [
+    "GenericFlatDetector",
+    "Medipix256x256Detector",
+    "Medipix515x515Detector",
+]

--- a/pyxem/dummy_data/__init__.py
+++ b/pyxem/dummy_data/__init__.py
@@ -15,3 +15,61 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from .dummy_data import (
+    get_disk_shift_simple_test_signal,
+    get_holz_simple_test_signal,
+    get_holz_heterostructure_test_signal,
+    get_single_ring_diffraction_signal,
+    get_dead_pixel_signal,
+    get_hot_pixel_signal,
+    get_simple_dpc_signal,
+    get_stripe_pattern_dpc_signal,
+    get_square_dpc_signal,
+    get_fem_signal,
+    get_simple_fem_signal,
+    get_generic_fem_signal,
+    get_cbed_signal,
+    get_simple_ellipse_signal_peak_array,
+    get_nanobeam_electron_diffraction_signal,
+)
+from .make_diffraction_test_data import (
+    EllipseRing,
+    EllipseDisk,
+    Circle,
+    Disk,
+    Ring,
+    MakeTestData,
+    generate_4d_data,
+    DiffractionTestImage,
+    DiffractionTestDataset,
+)
+
+
+__all__ = [
+    "get_disk_shift_simple_test_signal",
+    "get_holz_simple_test_signal",
+    "get_holz_heterostructure_test_signal",
+    "get_single_ring_diffraction_signal",
+    "get_dead_pixel_signal",
+    "get_hot_pixel_signal",
+    "get_simple_dpc_signal",
+    "get_stripe_pattern_dpc_signal",
+    "get_square_dpc_signal",
+    "get_fem_signal",
+    "get_simple_fem_signal",
+    "get_generic_fem_signal",
+    "get_cbed_signal",
+    "get_simple_ellipse_signal_peak_array",
+    "get_nanobeam_electron_diffraction_signal",
+    "EllipseRing",
+    "EllipseDisk",
+    "Circle",
+    "Disk",
+    "Ring",
+    "MakeTestData",
+    "generate_4d_data",
+    "DiffractionTestImage",
+    "DiffractionTestDataset",
+]

--- a/pyxem/dummy_data/dummy_data.py
+++ b/pyxem/dummy_data/dummy_data.py
@@ -26,8 +26,7 @@ from skimage.draw import polygon
 from hyperspy.components1d import Gaussian
 
 from pyxem.dummy_data import make_diffraction_test_data as mdtd
-from pyxem.signals.differential_phase_contrast import DPCSignal2D
-from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
+from pyxem.signals import DPCSignal2D, Diffraction2D, LazyDiffraction2D
 
 
 def get_disk_shift_simple_test_signal(lazy=False):

--- a/pyxem/dummy_data/dummy_data.py
+++ b/pyxem/dummy_data/dummy_data.py
@@ -25,7 +25,7 @@ from skimage.draw import polygon
 
 from hyperspy.components1d import Gaussian
 
-import pyxem.dummy_data.make_diffraction_test_data as mdtd
+from pyxem.dummy_data import make_diffraction_test_data as mdtd
 from pyxem.signals.differential_phase_contrast import DPCSignal2D
 from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
 
@@ -46,12 +46,12 @@ def get_disk_shift_simple_test_signal(lazy=False):
 
     Examples
     --------
-    >>> s = ps.dummy_data.get_disk_shift_simple_test_signal()
+    >>> s = pxm.dummy_data.get_disk_shift_simple_test_signal()
     >>> s.plot()
 
     Load as lazy
 
-    >>> s = ps.dummy_data.get_disk_shift_simple_test_signal(lazy=True)
+    >>> s = pxm.dummy_data.get_disk_shift_simple_test_signal(lazy=True)
 
     """
     disk_x, disk_y = np.mgrid[22:28:20j, 22:28:20j]
@@ -87,12 +87,12 @@ def get_holz_simple_test_signal(lazy=False):
 
     Examples
     --------
-    >>> s = ps.dummy_data.get_holz_simple_test_signal()
+    >>> s = pxm.dummy_data.get_holz_simple_test_signal()
     >>> s.plot()
 
     Load as lazy
 
-    >>> s = ps.dummy_data.get_holz_simple_test_signal(lazy=True)
+    >>> s = pxm.dummy_data.get_holz_simple_test_signal(lazy=True)
 
     """
     ring_x, ring_y = np.mgrid[24:26:20j, 24:26:20j]
@@ -131,12 +131,12 @@ def get_holz_heterostructure_test_signal(lazy=False):
 
     Example
     -------
-    >>> s = ps.dummy_data.get_holz_heterostructure_test_signal()
+    >>> s = pxm.dummy_data.get_holz_heterostructure_test_signal()
     >>> s.plot()
 
     Load as lazy
 
-    >>> s = ps.dummy_data.get_holz_heterostructure_test_signal(lazy=True)
+    >>> s = pxm.dummy_data.get_holz_heterostructure_test_signal(lazy=True)
 
     """
     probe_size_x, probe_size_y = 40, 40
@@ -187,11 +187,11 @@ def get_dead_pixel_signal(lazy=False):
 
     Example
     -------
-    >>> s = ps.dummy_data.get_dead_pixel_signal()
+    >>> s = pxm.dummy_data.get_dead_pixel_signal()
 
     Lazy signal
 
-    >>> s_lazy = ps.dummy_data.get_dead_pixel_signal(lazy=True)
+    >>> s_lazy = pxm.dummy_data.get_dead_pixel_signal(lazy=True)
 
     """
     data = mdtd.MakeTestData(size_x=128, size_y=128, default=False, blur=True)
@@ -218,11 +218,11 @@ def get_hot_pixel_signal(lazy=False):
 
     Example
     -------
-    >>> s = ps.dummy_data.get_hot_pixel_signal()
+    >>> s = pxm.dummy_data.get_hot_pixel_signal()
 
     Lazy signal
 
-    >>> s_lazy = ps.dummy_data.get_hot_pixel_signal(lazy=True)
+    >>> s_lazy = pxm.dummy_data.get_hot_pixel_signal(lazy=True)
 
     """
     data = mdtd.MakeTestData(size_x=128, size_y=128, default=False, blur=True)
@@ -247,7 +247,7 @@ def get_simple_dpc_signal():
 
     Example
     -------
-    >>> s = ps.dummy_data.get_simple_dpc_signal()
+    >>> s = pxm.dummy_data.get_simple_dpc_signal()
 
     """
     data = np.mgrid[-5:5:100j, -5:5:100j]
@@ -268,7 +268,7 @@ def get_stripe_pattern_dpc_signal():
 
     Example
     -------
-    >>> s = ps.dummy_data.get_stripe_pattern_dpc_signal()
+    >>> s = pxm.dummy_data.get_stripe_pattern_dpc_signal()
 
     """
     data = np.zeros((2, 100, 50))
@@ -294,12 +294,12 @@ def get_square_dpc_signal(add_ramp=False):
 
     Examples
     --------
-    >>> s = ps.dummy_data.get_square_dpc_signal()
+    >>> s = pxm.dummy_data.get_square_dpc_signal()
     >>> s.plot()
 
     Adding a ramp
 
-    >>> s = ps.dummy_data.get_square_dpc_signal(add_ramp=True)
+    >>> s = pxm.dummy_data.get_square_dpc_signal(add_ramp=True)
     >>> s.plot()
 
     """
@@ -342,7 +342,7 @@ def get_fem_signal(lazy=False):
 
     Examples
     --------
-    >>> s = ps.dummy_data.get_fem_signal()
+    >>> s = pxm.dummy_data.get_fem_signal()
     >>> s.plot()
 
     """
@@ -434,7 +434,7 @@ def get_simple_fem_signal(lazy=False):
 
     Examples
     --------
-    >>> s = ps.dummy_data.get_simple_fem_signal()
+    >>> s = pxm.dummy_data.get_simple_fem_signal()
     >>> s.plot()
 
     """
@@ -536,7 +536,7 @@ def get_generic_fem_signal(probe_x=2, probe_y=2, image_x=50, image_y=50, lazy=Fa
 
     Examples
     --------
-    >>> s = ps.dummy_data.get_generic_fem_signal(probe_x=5, probe_y=10,
+    >>> s = pxm.dummy_data.get_generic_fem_signal(probe_x=5, probe_y=10,
     ...     image_x=25, image_y=30, lazy=False)
     >>> s.plot()
 
@@ -626,7 +626,7 @@ def get_cbed_signal():
 
     Example
     -------
-    >>> s = ps.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> s.plot()
 
     """
@@ -673,7 +673,7 @@ def get_simple_ellipse_signal_peak_array():
 
     Examples
     --------
-    >>> s, peak_array = ps.dummy_data.get_simple_ellipse_signal_peak_array()
+    >>> s, peak_array = pxm.dummy_data.get_simple_ellipse_signal_peak_array()
     >>> s.add_peak_array_as_markers(peak_array, color='blue', size=30)
 
     """
@@ -696,7 +696,7 @@ def get_nanobeam_electron_diffraction_signal():
 
     Example
     -------
-    >>> s = ps.dummy_data.get_nanobeam_electron_diffraction_signal()
+    >>> s = pxm.dummy_data.get_nanobeam_electron_diffraction_signal()
     >>> s.plot()
 
     """

--- a/pyxem/dummy_data/make_diffraction_test_data.py
+++ b/pyxem/dummy_data/make_diffraction_test_data.py
@@ -48,7 +48,7 @@ def _get_elliptical_disk(xx, yy, x, y, semi_len0, semi_len1, rotation):
     Examples
     --------
     >>> from hyperspy.signals import Signal2D
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> s = Signal2D(np.zeros((110, 130)))
     >>> s.axes_manager[0].offset, s.axes_manager[1].offset = -50, -80
     >>> xx, yy = np.meshgrid(
@@ -90,7 +90,7 @@ def _get_elliptical_ring(xx, yy, x, y, semi_len0, semi_len1, rotation, lw_r=1):
     Examples
     --------
     >>> from hyperspy.signals import Signal2D
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> from pyxem.dummy_data importmake_diffraction_test_data as mdtd
     >>> s = Signal2D(np.zeros((110, 130)))
     >>> s.axes_manager[0].offset, s.axes_manager[1].offset = -50, -80
     >>> xx, yy = np.meshgrid(
@@ -113,7 +113,7 @@ def _get_elliptical_ring(xx, yy, x, y, semi_len0, semi_len1, rotation, lw_r=1):
     return ellipse
 
 
-class EllipseRing(object):
+class EllipseRing:
     """Generate an elliptical ring.
 
     Parameters
@@ -134,7 +134,7 @@ class EllipseRing(object):
 
     Examples
     --------
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> ellipse = mdtd.EllipseRing(
     ...     xx=20, yy=30, x0=10, y0=15, semi_len0=4, semi_len1=6,
     ...     rotation=1.57, intensity=10, lw_r=2)
@@ -183,7 +183,7 @@ class EllipseRing(object):
         return self.ellipse
 
 
-class EllipseDisk(object):
+class EllipseDisk:
     """Generate an elliptical disk.
 
     Parameters
@@ -204,7 +204,7 @@ class EllipseDisk(object):
 
     Examples
     --------
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> ellipse_disk = mdtd.EllipseDisk(
     ...     xx=20, yy=30, x0=10, y0=15, semi_len0=4, semi_len1=6,
     ...     rotation=1.57, intensity=10)
@@ -244,7 +244,7 @@ class EllipseDisk(object):
         return self.ellipse
 
 
-class Circle(object):
+class Circle:
     def __init__(self, xx, yy, x0, y0, r, intensity, scale, lw=None):
         self.x0 = x0
         self.y0 = y0
@@ -304,7 +304,7 @@ class Circle(object):
         self.circle[circle_ring_indices] = self.intensity
 
 
-class Disk(object):
+class Disk:
     """Disk object, with outer edge of the ring at r."""
 
     def __init__(self, xx, yy, scale, x0, y0, r, intensity):
@@ -334,7 +334,7 @@ class Disk(object):
         return self.z.circle
 
 
-class Ring(object):
+class Ring:
     """Ring object, with outer edge of the ring at r+lr, and inner r-lr.
 
     The radius of the ring is defined as in the middle of the line making
@@ -368,7 +368,7 @@ class Ring(object):
         return self.z.circle
 
 
-class MakeTestData(object):
+class MakeTestData:
     """MakeTestData is an object containing a generated test signal.
 
     The default signal consists of a Disk and concentric Ring, with the
@@ -698,7 +698,7 @@ def generate_4d_data(
 
     Examples
     --------
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> s = mdtd.generate_4d_data(show_progressbar=False)
     >>> s.plot()
 
@@ -871,7 +871,7 @@ def _make_4d_peak_array_test_data(xf, yf, semi0, semi1, rot, nt=20):
     Examples
     --------
     >>> import pyxem as pxm
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> xf = np.random.randint(65, 70, size=(4, 5))
     >>> yf = np.random.randint(115, 120, size=(4, 5))
     >>> semi0 = np.random.randint(35, 40, size=(4, 5))
@@ -892,7 +892,7 @@ def _make_4d_peak_array_test_data(xf, yf, semi0, semi1, rot, nt=20):
     return peak_array
 
 
-class DiffractionTestImage(object):
+class DiffractionTestImage:
     def __init__(
         self,
         disk_r=7,
@@ -940,7 +940,7 @@ class DiffractionTestImage(object):
 
         Examples
         --------
-        >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+        >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
         >>> di = mdtd.DiffractionTestImage()
         >>> di.add_disk(x=128, y=128, intensity=10.)
         >>> di.add_cubic_disks(vx=20, vy=20, intensity=2., n=5)
@@ -1083,7 +1083,7 @@ class DiffractionTestImage(object):
         s.plot()
 
 
-class DiffractionTestDataset(object):
+class DiffractionTestDataset:
     def __init__(
         self,
         probe_x=10,
@@ -1107,7 +1107,7 @@ class DiffractionTestDataset(object):
 
         Examples
         --------
-        >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+        >>> from pyxem.dummy_data import make_diffraction_test_data as mdtd
         >>> di = mdtd.DiffractionTestImage(intensity_noise=False)
         >>> di.add_disk(x=128, y=128, intensity=10.)
         >>> di.add_cubic_disks(vx=20, vy=20, intensity=2., n=5)

--- a/pyxem/dummy_data/make_diffraction_test_data.py
+++ b/pyxem/dummy_data/make_diffraction_test_data.py
@@ -26,7 +26,7 @@ import dask.array as da
 
 from hyperspy.misc.utils import isiterable
 
-from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
+from pyxem.signals import Diffraction2D, LazyDiffraction2D
 import pyxem.utils.ransac_ellipse_tools as ret
 
 
@@ -879,7 +879,7 @@ def _make_4d_peak_array_test_data(xf, yf, semi0, semi1, rot, nt=20):
     >>> rot = np.random.random(size=(4, 5)) * 0.2
     >>> peak_array = mdtd._make_4d_peak_array_test_data(
     ...        xf, yf, semi0, semi1, rot)
-    >>> s = pxm.Diffraction2D(np.zeros(shape=(4, 5, 200, 210)))
+    >>> s = pxm.signals.Diffraction2D(np.zeros(shape=(4, 5, 200, 210)))
     >>> import pyxem.utils.marker_tools as mt
     >>> mt.add_peak_array_to_signal_as_markers(s, peak_array)
 

--- a/pyxem/generators/__init__.py
+++ b/pyxem/generators/__init__.py
@@ -27,6 +27,7 @@ from .indexation_generator import (
     TemplateIndexationGenerator,
     ProfileIndexationGenerator
     )
+from .integration_generator import IntegrationGenerator
 from .pdf_generator1d import PDFGenerator1D
 from .red_intensity_generator1d import ReducedIntensityGenerator1D
 from .subpixelrefinement_generator import SubpixelrefinementGenerator
@@ -45,6 +46,7 @@ __all__ = [
     "VectorIndexationGenerator",
     "TemplateIndexationGenerator",
     "ProfileIndexationGenerator",
+    "IntegrationGenerator",
     "PDFGenerator1D",
     "ReducedIntensityGenerator1D",
     "SubpixelrefinementGenerator",

--- a/pyxem/generators/__init__.py
+++ b/pyxem/generators/__init__.py
@@ -15,3 +15,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from .calibration_generator import CalibrationGenerator
+from .displacement_gradient_tensor_generator import (
+    get_DisplacementGradientMap,
+    get_single_DisplacementGradientTensor
+    )
+from .indexation_generator import (
+    IndexationGenerator,
+    VectorIndexationGenerator,
+    TemplateIndexationGenerator,
+    ProfileIndexationGenerator
+    )
+from .pdf_generator1d import PDFGenerator1D
+from .red_intensity_generator1d import ReducedIntensityGenerator1D
+from .subpixelrefinement_generator import SubpixelrefinementGenerator
+from .variance_generator import VarianceGenerator
+from .virtual_image_generator import (
+    VirtualImageGenerator,
+    VirtualDarkFieldGenerator
+    )

--- a/pyxem/generators/__init__.py
+++ b/pyxem/generators/__init__.py
@@ -35,3 +35,20 @@ from .virtual_image_generator import (
     VirtualImageGenerator,
     VirtualDarkFieldGenerator
     )
+
+
+__all__ = [
+    "CalibrationGenerator",
+    "get_DisplacementGradientMap",
+    "get_single_DisplacementGradientTensor",
+    "IndexationGenerator",
+    "VectorIndexationGenerator",
+    "TemplateIndexationGenerator",
+    "ProfileIndexationGenerator",
+    "PDFGenerator1D",
+    "ReducedIntensityGenerator1D",
+    "SubpixelrefinementGenerator",
+    "VarianceGenerator",
+    "VirtualImageGenerator",
+    "VirtualDarkFieldGenerator"
+]

--- a/pyxem/generators/calibration_generator.py
+++ b/pyxem/generators/calibration_generator.py
@@ -31,7 +31,7 @@ from diffsims.utils.ring_pattern_utils import (
     generate_ring_pattern,
 )
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from pyxem.signals import ElectronDiffraction2D
 from pyxem.utils.pyfai_utils import get_azimuthal_integrator, _get_setup
 
 

--- a/pyxem/generators/calibration_generator.py
+++ b/pyxem/generators/calibration_generator.py
@@ -21,16 +21,17 @@
 import numpy as np
 from scipy.optimize import curve_fit
 from math import sin, cos
-from hyperspy.roi import CircleROI, Line2DROI
-from hyperspy.misc.utils import stack as stack_method
 import matplotlib.pyplot as plt
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from hyperspy.roi import CircleROI, Line2DROI
+from hyperspy.misc.utils import stack as stack_method
 from diffsims.utils.ring_pattern_utils import (
     call_ring_pattern,
     calc_radius_with_distortion,
     generate_ring_pattern,
 )
+
+from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from pyxem.utils.pyfai_utils import get_azimuthal_integrator, _get_setup
 
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -19,27 +19,25 @@
 """Indexation generator and associated tools."""
 
 import numpy as np
+import lmfit
+from transforms3d.euler import mat2euler, euler2mat
 
-from pyxem.signals.indexation_results import TemplateMatchingResults
-from pyxem.signals.indexation_results import VectorMatchingResults
+from diffsims.utils.sim_utils import get_electron_wavelength
 
-from pyxem.signals import transfer_navigation_axes
-from pyxem.signals import select_method_from_method_dict
-
+from pyxem.signals import TemplateMatchingResults, VectorMatchingResults
 from pyxem.utils.indexation_utils import (
     zero_mean_normalized_correlation,
     fast_correlation,
     index_magnitudes,
     match_vectors,
     OrientationResult,
-    get_nth_best_solution)
-
-
-from transforms3d.euler import mat2euler, euler2mat
+    get_nth_best_solution
+)
 from pyxem.utils.vector_utils import detector_to_fourier
-from diffsims.utils.sim_utils import get_electron_wavelength
-
-import lmfit
+from pyxem.utils.signal import (
+    select_method_from_method_dict,
+    transfer_navigation_axes,
+)
 
 
 class IndexationGenerator:

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -213,9 +213,7 @@ class TemplateIndexationGenerator:
             mask = 1
 
         # tests if selected method is valid and can print help for selected method.
-        chosen_function = select_method_from_method_dict(
-            method, method_dict, print_help
-        )
+        _ = select_method_from_method_dict(method, method_dict, print_help)
 
         # adds a normalisation to library #TODO: Port to diffsims
         for phase in library.keys():
@@ -652,8 +650,6 @@ class VectorIndexationGenerator:
             Navigation axes of the diffraction vectors signal containing vector
             indexation results for each probe position.
         """
-        vectors = self.vectors
-        library = self.library
 
         return self.refine_n_best_orientations(
             orientations,

--- a/pyxem/generators/integration_generator.py
+++ b/pyxem/generators/integration_generator.py
@@ -19,14 +19,15 @@
 """Generating subpixel resolution on diffraction vectors."""
 
 import numpy as np
-from hyperspy.signals import BaseSignal
 from skimage import morphology
 from skimage.measure import label
 from scipy import ndimage as ndi
 from scipy.ndimage.measurements import center_of_mass
 
-from pyxem.signals.diffraction_vectors import DiffractionVectors
+from hyperspy.signals import BaseSignal
+
 from pyxem.generators.subpixelrefinement_generator import _get_pixel_vectors
+from pyxem.signals import DiffractionVectors
 
 
 def _get_intensities(z, vectors, radius=1):

--- a/pyxem/generators/pdf_generator1d.py
+++ b/pyxem/generators/pdf_generator1d.py
@@ -19,8 +19,9 @@
 """PDF generator and associated tools."""
 
 import numpy as np
-from pyxem.signals.pair_distribution_function1d import PairDistributionFunction1D
-from pyxem.signals import transfer_navigation_axes
+
+from pyxem.signals import PairDistributionFunction1D
+from pyxem.utils.signal import transfer_navigation_axes
 
 
 class PDFGenerator1D:

--- a/pyxem/generators/red_intensity_generator1d.py
+++ b/pyxem/generators/red_intensity_generator1d.py
@@ -19,11 +19,9 @@
 """Reduced intensity generator and associated tools."""
 import numpy as np
 
-from pyxem.components.scattering_fit_component_xtables import (
+from pyxem.components import (
     ScatteringFitComponentXTables,
-)
-from pyxem.components.scattering_fit_component_lobato import (
-    ScatteringFitComponentLobato,
+    ScatteringFitComponentLobato
 )
 from pyxem.utils.ri_utils import subtract_pattern, mask_from_pattern
 

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -19,11 +19,10 @@
 """Generating subpixel resolution on diffraction vectors."""
 
 import numpy as np
-
 from skimage.registration import phase_cross_correlation
 from skimage import draw
 
-from pyxem.signals.diffraction_vectors import DiffractionVectors
+from pyxem.signals import DiffractionVectors
 
 
 def get_experimental_square(z, vector, square_size):

--- a/pyxem/generators/variance_generator.py
+++ b/pyxem/generators/variance_generator.py
@@ -22,10 +22,11 @@ import numpy as np
 from hyperspy.signals import Signal2D
 from hyperspy.api import stack
 
-from pyxem.signals.diffraction_variance2d import DiffractionVariance2D
-from pyxem.signals.diffraction_variance2d import ImageVariance
-from pyxem.signals import transfer_signal_axes
-from pyxem.signals import transfer_navigation_axes_to_signal_axes
+from pyxem.signals import DiffractionVariance2D, ImageVariance
+from pyxem.utils.signal import (
+    transfer_navigation_axes_to_signal_axes,
+    transfer_signal_axes,
+)
 
 
 class VarianceGenerator:

--- a/pyxem/libraries/__init__.py
+++ b/pyxem/libraries/__init__.py
@@ -15,3 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+from .calibration_library import CalibrationDataLibrary
+
+__all__ = [
+    "CalibrationDataLibrary"
+]

--- a/pyxem/signals/__init__.py
+++ b/pyxem/signals/__init__.py
@@ -16,132 +16,71 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-
-def select_method_from_method_dict(method, method_dict, print_help=True, **kwargs):
-    """Streamlines the selection of utils to be mapped in class methods.
-
-    Parameters
-    ----------
-    method : str
-        The key to method_dict for the chosen method
-    method_dict : dict
-        dictionary with strings as keys and functions as values
-    kwargs : dict
-        Parameters for the method, if empty help is return
-    print_help : bool
-        If True: Prints information about the chosen method.
-
-    Returns
-    -------
-    method_function :
-        The utility function that corresponds the given method string, unless
-        kwargs is empty, in which case the help for the utility function is
-        returned.
-    """
-
-    if method not in method_dict:
-        raise NotImplementedError(
-            "The method `{}` is not implemented. "
-            "See documentation for available "
-            "implementations.".format(method)
-        )
-    elif print_help and not kwargs:
-        help(method_dict[method])
-
-    return method_dict[method]
+from .common_diffraction import CommonDiffraction
+from .correlation2d import Correlation2D, LazyCorrelation2D
+from .differential_phase_contrast import (
+    DPCBaseSignal,
+    DPCSignal1D,
+    DPCSignal2D,
+    LazyDPCBaseSignal,
+    LazyDPCSignal1D,
+    LazyDPCSignal2D,
+)
+from .diffraction_variance1d import DiffractionVariance1D
+from .diffraction_variance2d import DiffractionVariance2D, ImageVariance
+from .diffraction_vectors import DiffractionVectors, DiffractionVectors2D
+from .diffraction1d import Diffraction1D, LazyDiffraction1D
+from .diffraction2d import Diffraction2D, LazyDiffraction2D
+from .electron_diffraction1d import ElectronDiffraction1D, LazyElectronDiffraction1D
+from .electron_diffraction2d import ElectronDiffraction2D, LazyElectronDiffraction2D
+from .indexation_results import (
+    TemplateMatchingResults,
+    VectorMatchingResults
+)
+from .pair_distribution_function1d import PairDistributionFunction1D
+from .polar_diffraction2d import PolarDiffraction2D, LazyPolarDiffraction2D
+from .power2d import Power2D, LazyPower2D
+from .reduced_intensity1d import ReducedIntensity1D
+from .segments import LearningSegment, VDFSegment
+from .strain_map import StrainMap
+from .tensor_field import DisplacementGradientMap
+from .virtual_dark_field_image import VirtualDarkFieldImage
 
 
-def transfer_signal_axes(new_signal, old_signal):
-    """Transfers signal axis calibrations from an old signal to a new
-    signal produced from it by a method or a generator.
-
-    Parameters
-    ----------
-    new_signal : Signal
-        The product signal with undefined signal axes.
-    old_signal : Signal
-        The parent signal with calibrated signal axes.
-
-    Returns
-    -------
-    new_signal : Signal
-        The new signal with calibrated signal axes.
-    """
-
-    for i in range(old_signal.axes_manager.signal_dimension):
-        ax_new = new_signal.axes_manager.signal_axes[i]
-        ax_old = old_signal.axes_manager.signal_axes[i]
-        ax_new.name = ax_old.name
-        ax_new.scale = ax_old.scale
-        ax_new.units = ax_old.units
-
-    return new_signal
-
-
-def transfer_navigation_axes(new_signal, old_signal):
-    """Transfers navigation axis calibrations from an old signal to a new
-    signal produced from it by a method or a generator.
-
-    Parameters
-    ----------
-    new_signal : Signal
-        The product signal with undefined navigation axes.
-    old_signal : Signal
-        The parent signal with calibrated navigation axes.
-
-    Returns
-    -------
-    new_signal : Signal
-        The new signal with calibrated navigation axes.
-    """
-    new_signal.axes_manager.set_signal_dimension(
-        len(new_signal.data.shape) - old_signal.axes_manager.navigation_dimension
-    )
-
-    for i in range(
-        min(
-            new_signal.axes_manager.navigation_dimension,
-            old_signal.axes_manager.navigation_dimension,
-        )
-    ):
-        ax_new = new_signal.axes_manager.navigation_axes[i]
-        ax_old = old_signal.axes_manager.navigation_axes[i]
-        ax_new.name = ax_old.name
-        ax_new.scale = ax_old.scale
-        ax_new.units = ax_old.units
-
-    return new_signal
-
-
-def transfer_navigation_axes_to_signal_axes(new_signal, old_signal):
-    """Transfers navigation axis calibrations from an old signal to the signal
-    axes of a new signal produced from it by a method or a generator.
-
-    Used from methods that generate a signal with a single value at each
-    navigation position.
-
-    Parameters
-    ----------
-    new_signal : Signal
-        The product signal with undefined navigation axes.
-    old_signal : Signal
-        The parent signal with calibrated navigation axes.
-
-    Returns
-    -------
-    new_signal : Signal
-        The new signal with calibrated signal axes.
-    """
-    for i in range(
-        min(
-            new_signal.axes_manager.signal_dimension,
-            old_signal.axes_manager.navigation_dimension,
-        )
-    ):
-        ax_new = new_signal.axes_manager.signal_axes[i]
-        ax_old = old_signal.axes_manager.navigation_axes[i]
-        ax_new.name = ax_old.name
-        ax_new.scale = ax_old.scale
-        ax_new.units = ax_old.units
-
-    return new_signal
+__all__ = [
+    "CommonDiffraction",
+    "Correlation2D",
+    "LazyCorrelation2D",
+    "DPCBaseSignal",
+    "DPCSignal1D",
+    "DPCSignal2D",
+    "LazyDPCBaseSignal",
+    "LazyDPCSignal1D",
+    "LazyDPCSignal2D",
+    "DiffractionVariance1D",
+    "DiffractionVariance2D",
+    "ImageVariance",
+    "DiffractionVectors",
+    "DiffractionVectors2D",
+    "Diffraction1D",
+    "LazyDiffraction1D",
+    "Diffraction2D",
+    "LazyDiffraction2D",
+    "ElectronDiffraction1D",
+    "LazyElectronDiffraction1D",
+    "ElectronDiffraction2D",
+    "LazyElectronDiffraction2D",
+    "TemplateMatchingResults",
+    "VectorMatchingResults",
+    "PairDistributionFunction1D",
+    "PolarDiffraction2D",
+    "LazyPolarDiffraction2D",
+    "Power2D",
+    "LazyPower2D",
+    "ReducedIntensity1D",
+    "LearningSegment",
+    "VDFSegment",
+    "StrainMap",
+    "DisplacementGradientMap",
+    "VirtualDarkFieldImage",
+]

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -17,16 +17,16 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-import numpy as np
 
-import pyxem.utils.pixelated_stem_tools as pst
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
+from scipy.ndimage import rotate, gaussian_filter
 
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 from hyperspy._signals.lazy import LazySignal
 
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
-from scipy.ndimage import rotate, gaussian_filter
+import pyxem.utils.pixelated_stem_tools as pst
 
 
 def make_bivariate_histogram(

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -203,7 +203,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_square_dpc_signal(add_ramp=True)
+        >>> s = pxm.dummy_data.get_square_dpc_signal(add_ramp=True)
         >>> s_corr = s.correct_ramp()
         >>> s_corr.plot()
 
@@ -247,7 +247,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_simple_dpc_signal()
+        >>> s = pxm.dummy_data.get_simple_dpc_signal()
         >>> s_magnitude = s.get_magnitude_signal()
         >>> s_magnitude.plot()
 
@@ -316,8 +316,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> from pyxem.dummy_data import dummy_data
-        >>> s = dummy_data.get_square_dpc_signal()
+        >>> s = pxm.dummy_data.get_square_dpc_signal()
         >>> s_phase = s.phase_retrieval()
         >>> s_phase.plot()
         """
@@ -426,7 +425,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_simple_dpc_signal()
+        >>> s = pxm.dummy_data.get_simple_dpc_signal()
         >>> s_color = s.get_phase_signal(rotation=20)
         >>> s_color.plot()
 
@@ -472,7 +471,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_simple_dpc_signal()
+        >>> s = pxm.dummy_data.get_simple_dpc_signal()
         >>> s_color = s.get_color_signal()
         >>> s_color.plot()
 
@@ -547,7 +546,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_simple_dpc_signal()
+        >>> s = pxm.dummy_data.get_simple_dpc_signal()
         >>> fig = s.get_color_image_with_indicator()
         >>> fig.savefig("simple_dpc_test_signal.png")
 
@@ -626,7 +625,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_stripe_pattern_dpc_signal()
+        >>> s = pxm.dummy_data.get_stripe_pattern_dpc_signal()
         >>> s_hist = s.get_bivariate_histogram()
         >>> s_hist.plot()
 
@@ -660,7 +659,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_stripe_pattern_dpc_signal()
+        >>> s = pxm.dummy_data.get_stripe_pattern_dpc_signal()
         >>> s
         <DPCSignal2D, title: , dimensions: (2|50, 100)>
         >>> s_rot = s.flip_axis_90_degrees()
@@ -704,7 +703,7 @@ class DPCSignal2D(Signal2D):
 
         Rotate data by 10 degrees clockwise
 
-        >>> s = ps.dummy_data.get_simple_dpc_signal()
+        >>> s = pxm.dummy_data.get_simple_dpc_signal()
         >>> s_rot = s.rotate_data(10)
         >>> s_rot.plot()
 
@@ -731,7 +730,7 @@ class DPCSignal2D(Signal2D):
 
         Rotate beam shifts by 10 degrees clockwise
 
-        >>> s = ps.dummy_data.get_simple_dpc_signal()
+        >>> s = pxm.dummy_data.get_simple_dpc_signal()
         >>> s_new = s.rotate_beam_shifts(10)
         >>> s_new.plot()
 
@@ -759,7 +758,7 @@ class DPCSignal2D(Signal2D):
 
         Examples
         --------
-        >>> s = ps.dummy_data.get_square_dpc_signal(add_ramp=False)
+        >>> s = pxm.dummy_data.get_square_dpc_signal(add_ramp=False)
         >>> s_blur = s.gaussian_blur()
 
         Different sigma

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -862,8 +862,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Examples
         --------
-        >>> import pyxem.dummy_data.dummy_data as dd
-        >>> s = dd.get_disk_shift_simple_test_signal()
+        >>> s = pxm.dummy_data.get_disk_shift_simple_test_signal()
         >>> mask = (25, 25, 10)
         >>> s_out = s.threshold_and_mask(
         ...     mask=mask, threshold=2, show_progressbar=False)
@@ -931,8 +930,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         --------
         With mask centered at x=105, y=120 and 30 pixel radius
 
-        >>> import pyxem.dummy_data.dummy_data as dd
-        >>> s = dd.get_disk_shift_simple_test_signal()
+        >>> s = pxm.dummy_data.get_disk_shift_simple_test_signal()
         >>> mask = (25, 25, 10)
         >>> s_com = s.center_of_mass(mask=mask, show_progressbar=False)
         >>> s_color = s_com.get_color_signal()
@@ -1623,8 +1621,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Examples
         --------
-        >>> import pyxem.dummy_data.dummy_data as dd
-        >>> s = dd.get_holz_simple_test_signal()
+        >>> s = pxm.dummy_data.get_holz_simple_test_signal()
         >>> s.axes_manager.signal_axes[0].offset = -25
         >>> s.axes_manager.signal_axes[1].offset = -25
         >>> mask_array = s.angular_mask(0.5*np.pi, np.pi)
@@ -1778,8 +1775,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Examples
         --------
-        >>> import pyxem.dummy_data.dummy_data as dd
-        >>> s = dd.get_holz_simple_test_signal()
+        >>> s = pxm.dummy_data.get_holz_simple_test_signal()
         >>> s_r = s.radial_average(centre_x=25, centre_y=25,
         ...     show_progressbar=False)
         >>> s_r.plot()
@@ -1899,8 +1895,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Examples
         --------
-        >>> import pyxem.dummy_data.dummy_data as dd
-        >>> s = dd.get_holz_simple_test_signal()
+        >>> s = pxm.dummy_data.get_holz_simple_test_signal()
         >>> s_com = s.center_of_mass(show_progressbar=False)
         >>> s_ar = s.angular_slice_radial_average(
         ...     angleN=10, centre_x=s_com.inav[0].data,

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -19,6 +19,13 @@
 """Signal class for two-dimensional diffraction data in Cartesian coordinates."""
 
 import numpy as np
+from skimage import filters
+from skimage.morphology import square
+from scipy.ndimage import rotate
+from skimage import morphology
+import dask.array as da
+from dask.diagnostics import ProgressBar
+from tqdm import tqdm
 
 import hyperspy.api as hs
 from hyperspy.signals import Signal2D
@@ -29,24 +36,20 @@ from hyperspy.misc.utils import isiterable
 
 from pyFAI.units import to_unit
 
-from pyxem.signals.differential_phase_contrast import (
+from pyxem.signals import (
+    CommonDiffraction,
     DPCBaseSignal,
     DPCSignal1D,
     DPCSignal2D,
-)
-from pyxem.signals.differential_phase_contrast import (
     LazyDPCBaseSignal,
     LazyDPCSignal1D,
     LazyDPCSignal2D,
 )
-from pyxem.signals import transfer_navigation_axes, select_method_from_method_dict
-from pyxem.signals.common_diffraction import CommonDiffraction
 from pyxem.utils.pyfai_utils import (
     get_azimuthal_integrator,
     _get_radial_extent,
     _get_setup,
 )
-
 from pyxem.utils.expt_utils import (
     azimuthal_integrate1d,
     azimuthal_integrate2d,
@@ -63,26 +66,20 @@ from pyxem.utils.expt_utils import (
     medfilt_1d,
     sigma_clip,
 )
-
 from pyxem.utils.dask_tools import (
     _process_dask_array,
     _get_dask_array,
     get_signal_dimension_host_chunk_slice,
     align_single_frame,
 )
-
+from pyxem.utils.signal import (
+    select_method_from_method_dict,
+    transfer_navigation_axes,
+)
 import pyxem.utils.pixelated_stem_tools as pst
 import pyxem.utils.dask_tools as dt
 import pyxem.utils.marker_tools as mt
 import pyxem.utils.ransac_ellipse_tools as ret
-
-from skimage import filters
-from skimage.morphology import square
-from scipy.ndimage import rotate
-from skimage import morphology
-import dask.array as da
-from dask.diagnostics import ProgressBar
-from tqdm import tqdm
 
 
 class Diffraction2D(Signal2D, CommonDiffraction):

--- a/pyxem/signals/diffraction_variance2d.py
+++ b/pyxem/signals/diffraction_variance2d.py
@@ -17,8 +17,9 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 """Signal class for two-dimensional diffraction variance."""
 
-from pyxem.signals.diffraction2d import Diffraction2D
 from hyperspy.signals import Signal2D
+
+from pyxem.signals.diffraction2d import Diffraction2D
 
 
 class DiffractionVariance2D(Diffraction2D):

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -16,27 +16,30 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 import itertools
+from warnings import warn
 
-from hyperspy.signals import BaseSignal, Signal1D
-from hyperspy.api import markers
-
+import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.cm import get_cmap
 from scipy.spatial import distance_matrix
 from sklearn.cluster import DBSCAN
 
-from warnings import warn
+from hyperspy.signals import BaseSignal, Signal1D
+from hyperspy.api import markers
 
-from pyxem.signals import (
+from pyxem.utils.signal import (
     transfer_navigation_axes,
     transfer_navigation_axes_to_signal_axes,
 )
-from pyxem.utils.vector_utils import detector_to_fourier
-from pyxem.utils.vector_utils import calculate_norms, calculate_norms_ragged
-from pyxem.utils.vector_utils import get_npeaks, filter_vectors_ragged
-from pyxem.utils.vector_utils import filter_vectors_edge_ragged
+from pyxem.utils.vector_utils import (
+    detector_to_fourier,
+    calculate_norms,
+    calculate_norms_ragged,
+    get_npeaks,
+    filter_vectors_ragged,
+    filter_vectors_edge_ragged
+)
 from pyxem.utils.expt_utils import peaks_as_gvectors
 
 

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -16,21 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import hyperspy.api as hs
-from hyperspy.signal import BaseSignal
-from hyperspy.signals import Signal2D
 from warnings import warn
 import numpy as np
-from operator import attrgetter
+from transforms3d.euler import mat2euler
 
-from pyxem.signals import transfer_navigation_axes
-from pyxem.signals.diffraction_vectors import generate_marker_inputs_from_peaks
-from pyxem.utils.indexation_utils import get_nth_best_solution
-
+import hyperspy.api as hs
+from hyperspy.signal import BaseSignal
 from orix.quaternion import Rotation
 from orix.crystal_map import CrystalMap
 
-from transforms3d.euler import mat2euler
+from pyxem.signals.diffraction_vectors import generate_marker_inputs_from_peaks
+from pyxem.utils.signal import transfer_navigation_axes
+from pyxem.utils.indexation_utils import get_nth_best_solution
+
+
 
 def crystal_from_vector_matching(z_matches):
     """Takes vector matching results for a single navigation position and

--- a/pyxem/signals/reduced_intensity1d.py
+++ b/pyxem/signals/reduced_intensity1d.py
@@ -19,9 +19,7 @@
 
 from hyperspy.signals import Signal1D
 
-from pyxem.components.reduced_intensity_correction_component import (
-    ReducedIntensityCorrectionComponent,
-)
+from pyxem.components import ReducedIntensityCorrectionComponent
 from pyxem.utils.ri_utils import (
     damp_ri_exponential,
     damp_ri_lorch,

--- a/pyxem/signals/segments.py
+++ b/pyxem/signals/segments.py
@@ -26,14 +26,13 @@ from tqdm import tqdm
 
 from hyperspy.signals import Signal2D
 
+from pyxem.signals import DiffractionVectors, ElectronDiffraction2D
+from pyxem.utils.signal import transfer_signal_axes
 from pyxem.utils.segment_utils import (
     norm_cross_corr,
     separate_watershed,
     get_gaussian2d,
 )
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals import transfer_signal_axes
 
 
 class LearningSegment:

--- a/pyxem/signals/strain_map.py
+++ b/pyxem/signals/strain_map.py
@@ -16,9 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.signals import Signal2D
 import numpy as np
-from pyxem.signals import transfer_signal_axes
+
+from hyperspy.signals import Signal2D
+
+from pyxem.utils.signal import transfer_signal_axes
 
 
 def _get_rotation_matrix(x_new):

--- a/pyxem/signals/tensor_field.py
+++ b/pyxem/signals/tensor_field.py
@@ -16,12 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.signals import Signal2D
 import numpy as np
 from scipy.linalg import polar
-from hyperspy.utils import stack
 import math
-from pyxem.signals.strain_map import StrainMap
+
+from hyperspy.signals import Signal2D
+from hyperspy.utils import stack
+
+from pyxem.signals import StrainMap
 
 """Signal class for Tensor Fields."""
 

--- a/pyxem/signals/virtual_dark_field_image.py
+++ b/pyxem/signals/virtual_dark_field_image.py
@@ -20,10 +20,9 @@ import numpy as np
 
 from hyperspy.signals import Signal2D
 
+from pyxem.signals import DiffractionVectors, VDFSegment
+from pyxem.utils.signal import transfer_signal_axes
 from pyxem.utils.segment_utils import separate_watershed
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals import transfer_signal_axes
-from pyxem.signals.segments import VDFSegment
 
 
 class VirtualDarkFieldImage(Signal2D):

--- a/pyxem/tests/components/test_scattering_fit_component_lobato.py
+++ b/pyxem/tests/components/test_scattering_fit_component_lobato.py
@@ -18,7 +18,8 @@
 
 import pytest
 import numpy as np
-from pyxem.signals.reduced_intensity1d import ReducedIntensity1D
+
+from pyxem.signals import ReducedIntensity1D
 from pyxem.components import ScatteringFitComponentLobato
 
 

--- a/pyxem/tests/components/test_scattering_fit_component_lobato.py
+++ b/pyxem/tests/components/test_scattering_fit_component_lobato.py
@@ -19,9 +19,7 @@
 import pytest
 import numpy as np
 from pyxem.signals.reduced_intensity1d import ReducedIntensity1D
-from pyxem.components.scattering_fit_component_lobato import (
-    ScatteringFitComponentLobato,
-)
+from pyxem.components import ScatteringFitComponentLobato
 
 
 def test_scattering_component_init_lobato():

--- a/pyxem/tests/components/test_scattering_fit_component_xtables.py
+++ b/pyxem/tests/components/test_scattering_fit_component_xtables.py
@@ -18,10 +18,9 @@
 
 import pytest
 import numpy as np
-from pyxem.signals.reduced_intensity1d import ReducedIntensity1D
-from pyxem.components.scattering_fit_component_xtables import (
-    ScatteringFitComponentXTables,
-)
+
+from pyxem.signals import ReducedIntensity1D
+from pyxem.components import ScatteringFitComponentXTables
 
 
 def test_scattering_component_init_xtables():

--- a/pyxem/tests/conftest.py
+++ b/pyxem/tests/conftest.py
@@ -25,9 +25,9 @@ import pytest
 import diffpy.structure
 import numpy as np
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals.electron_diffraction1d import ElectronDiffraction1D
 from diffsims.libraries.vector_library import DiffractionVectorLibrary
+
+from pyxem.signals import ElectronDiffraction1D, ElectronDiffraction2D
 
 # a straight lift from
 # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option--

--- a/pyxem/tests/dummy_data/test_dummy_data.py
+++ b/pyxem/tests/dummy_data/test_dummy_data.py
@@ -17,7 +17,7 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-import pyxem.dummy_data.dummy_data as dd
+import pyxem.dummy_data as dd
 
 
 @pytest.mark.slow
@@ -61,7 +61,7 @@ class TestDummyDataModule:
     def test_get_square_dpc_signal(self):
         s = dd.get_square_dpc_signal()
         assert hasattr(s, "plot")
-        s_ramp = dd.get_square_dpc_signal(add_ramp=True)
+        _ = dd.get_square_dpc_signal(add_ramp=True)
         assert hasattr(s, "plot")
 
     def test_get_dead_pixel_signal(self):

--- a/pyxem/tests/dummy_data/test_make_diffraction_test_data.py
+++ b/pyxem/tests/dummy_data/test_make_diffraction_test_data.py
@@ -21,7 +21,7 @@ import pytest
 from pytest import approx
 import numpy as np
 from hyperspy.signals import Signal2D
-import pyxem.dummy_data.make_diffraction_test_data as mdtd
+from pyxem.dummy_data import make_diffraction_test_data as mdtd
 
 
 class TestMakeTestData:

--- a/pyxem/tests/generators/test_calibration_generator.py
+++ b/pyxem/tests/generators/test_calibration_generator.py
@@ -24,7 +24,7 @@ from hyperspy.roi import Line2DROI
 import hyperspy.api as hs
 
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.generators.calibration_generator import CalibrationGenerator
+from pyxem.generators import CalibrationGenerator
 from diffsims.utils.ring_pattern_utils import generate_ring_pattern
 from pyxem.libraries.calibration_library import CalibrationDataLibrary
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D

--- a/pyxem/tests/generators/test_calibration_generator.py
+++ b/pyxem/tests/generators/test_calibration_generator.py
@@ -19,17 +19,14 @@
 import pytest
 import numpy as np
 
+from pyFAI.azimuthalIntegrator import AzimuthalIntegrator
 from hyperspy.signals import Signal2D
 from hyperspy.roi import Line2DROI
-import hyperspy.api as hs
+from diffsims.utils.ring_pattern_utils import generate_ring_pattern
 
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from pyxem.generators import CalibrationGenerator
-from diffsims.utils.ring_pattern_utils import generate_ring_pattern
-from pyxem.libraries.calibration_library import CalibrationDataLibrary
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-import matplotlib.pyplot as plt
-from pyFAI.azimuthalIntegrator import AzimuthalIntegrator
+from pyxem.libraries import CalibrationDataLibrary
 
 @pytest.fixture
 def input_parameters():

--- a/pyxem/tests/generators/test_calibration_generator.py
+++ b/pyxem/tests/generators/test_calibration_generator.py
@@ -24,7 +24,7 @@ from hyperspy.signals import Signal2D
 from hyperspy.roi import Line2DROI
 from diffsims.utils.ring_pattern_utils import generate_ring_pattern
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from pyxem.signals import ElectronDiffraction2D
 from pyxem.generators import CalibrationGenerator
 from pyxem.libraries import CalibrationDataLibrary
 

--- a/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
@@ -16,10 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyxem.generators.displacement_gradient_tensor_generator import (
-    get_DisplacementGradientMap,
-    get_single_DisplacementGradientTensor,
-)
+from pyxem.generators import get_DisplacementGradientMap
 import hyperspy.api as hs
 import pytest
 import numpy as np

--- a/pyxem/tests/generators/test_indexation_generator.py
+++ b/pyxem/tests/generators/test_indexation_generator.py
@@ -23,21 +23,19 @@ from hyperspy._signals.signal2d import Signal2D
 
 from pyxem import ElectronDiffraction2D
 from pyxem.signals.indexation_results import TemplateMatchingResults
-from pyxem.generators.indexation_generator import (
+from pyxem.generators import (
     TemplateIndexationGenerator,
     ProfileIndexationGenerator,
     VectorIndexationGenerator)
 
 
 from diffsims.libraries.vector_library import DiffractionVectorLibrary
-from diffsims.libraries.diffraction_library import DiffractionLibrary
 from diffsims.sims.diffraction_simulation import ProfileSimulation
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 
 
 from diffsims.generators.diffraction_generator import DiffractionGenerator
 from diffsims.generators.library_generator import DiffractionLibraryGenerator
-from diffsims.libraries.diffraction_library import DiffractionLibrary
 from diffsims.libraries.structure_library import StructureLibrary
 
 from pyxem.utils.indexation_utils import OrientationResult

--- a/pyxem/tests/generators/test_indexation_generator.py
+++ b/pyxem/tests/generators/test_indexation_generator.py
@@ -20,24 +20,20 @@ import pytest
 import numpy as np
 
 from hyperspy._signals.signal2d import Signal2D
-
-from pyxem import ElectronDiffraction2D
-from pyxem.signals.indexation_results import TemplateMatchingResults
-from pyxem.generators import (
-    TemplateIndexationGenerator,
-    ProfileIndexationGenerator,
-    VectorIndexationGenerator)
-
-
 from diffsims.libraries.vector_library import DiffractionVectorLibrary
 from diffsims.sims.diffraction_simulation import ProfileSimulation
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-
-
 from diffsims.generators.diffraction_generator import DiffractionGenerator
 from diffsims.generators.library_generator import DiffractionLibraryGenerator
 from diffsims.libraries.structure_library import StructureLibrary
 
+from pyxem.generators import (
+    TemplateIndexationGenerator,
+    ProfileIndexationGenerator,
+    VectorIndexationGenerator
+)
+from pyxem.signals import (
+    ElectronDiffraction2D, TemplateMatchingResults, DiffractionVectors
+)
 from pyxem.utils.indexation_utils import OrientationResult
 
 @pytest.mark.parametrize("method",['fast_correlation',

--- a/pyxem/tests/generators/test_integration_generator.py
+++ b/pyxem/tests/generators/test_integration_generator.py
@@ -19,11 +19,12 @@
 import pytest
 import numpy as np
 
-from pyxem.generators.integration_generator import IntegrationGenerator
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from hyperspy.signals import BaseSignal
 from scipy.ndimage import gaussian_filter
+
+from hyperspy.signals import BaseSignal
+
+from pyxem.generators import IntegrationGenerator
+from pyxem.signals import DiffractionVectors, ElectronDiffraction2D
 
 
 @pytest.mark.parametrize("radius, offset", [[1, 0], [2, 1], [3, 2]])

--- a/pyxem/tests/generators/test_pdf_generator.py
+++ b/pyxem/tests/generators/test_pdf_generator.py
@@ -18,7 +18,7 @@
 
 import pytest
 import numpy as np
-from pyxem.generators.pdf_generator1d import PDFGenerator1D
+from pyxem.generators import PDFGenerator1D
 from pyxem.signals.reduced_intensity1d import ReducedIntensity1D
 from pyxem.signals.pair_distribution_function1d import PairDistributionFunction1D
 

--- a/pyxem/tests/generators/test_red_intensity_generator.py
+++ b/pyxem/tests/generators/test_red_intensity_generator.py
@@ -19,9 +19,8 @@
 import pytest
 import numpy as np
 
-from pyxem.signals.electron_diffraction1d import ElectronDiffraction1D
-from pyxem.signals.reduced_intensity1d import ReducedIntensity1D
-from pyxem.generators.red_intensity_generator1d import ReducedIntensityGenerator1D
+from pyxem.signals import ElectronDiffraction1D, ReducedIntensity1D
+from pyxem.generators import ReducedIntensityGenerator1D
 
 
 @pytest.fixture

--- a/pyxem/tests/generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/generators/test_subpixelrefinement_generator.py
@@ -19,11 +19,10 @@
 import pytest
 import numpy as np
 
+from pyxem.generators import SubpixelrefinementGenerator
 from pyxem.generators.subpixelrefinement_generator import (
-    SubpixelrefinementGenerator,
     get_simulated_disc,
     get_experimental_square,
-    get_simulated_disc,
 )
 from pyxem.signals.diffraction_vectors import DiffractionVectors
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
@@ -51,12 +50,12 @@ def test_experimental_square_size(exp_disc):
 
 def test_failure_for_non_even_entry_to_get_simulated_disc():
     with pytest.raises(ValueError, match="'square_size' must be an even number"):
-        disc = get_simulated_disc(61, 5)
+        _ = get_simulated_disc(61, 5)
 
 
 def test_failure_for_non_even_errors_get_experimental_square(exp_disc):
     with pytest.raises(ValueError, match="'square_size' must be an even number"):
-        square = get_experimental_square(exp_disc, [17, 19], 7)
+        _ = get_experimental_square(exp_disc, [17, 19], 7)
 
 
 class Test_init_xfails:
@@ -70,7 +69,7 @@ class Test_init_xfails:
             ValueError,
             match="Some of your vectors do not lie within your diffraction pattern",
         ):
-            sprg = SubpixelrefinementGenerator(dp, vector)
+            _ = SubpixelrefinementGenerator(dp, vector)
 
     def test_out_of_range_vectors_DiffractionVectors(self):
         """Test that putting vectors that lie outside of the
@@ -82,7 +81,7 @@ class Test_init_xfails:
             ValueError,
             match="Some of your vectors do not lie within your diffraction pattern",
         ):
-            sprg = SubpixelrefinementGenerator(dp, vectors)
+            _ = SubpixelrefinementGenerator(dp, vectors)
 
     def test_wrong_navigation_dimensions(self):
         """Tests that navigation dimensions must be appropriate too."""
@@ -96,7 +95,7 @@ class Test_init_xfails:
             ValueError,
             match=r"Vectors with shape .* must have the same navigation shape as .*",
         ):
-            sprg = SubpixelrefinementGenerator(dp, vectors)
+            _ = SubpixelrefinementGenerator(dp, vectors)
 
 
 class set_up_for_subpixelpeakfinders:

--- a/pyxem/tests/generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/generators/test_subpixelrefinement_generator.py
@@ -19,14 +19,13 @@
 import pytest
 import numpy as np
 
+from skimage import draw
+
 from pyxem.generators import SubpixelrefinementGenerator
 from pyxem.generators.subpixelrefinement_generator import (
-    get_simulated_disc,
-    get_experimental_square,
+    get_simulated_disc, get_experimental_square
 )
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from skimage import draw
+from pyxem.signals import DiffractionVectors, ElectronDiffraction2D
 
 
 @pytest.fixture()

--- a/pyxem/tests/generators/test_variance_generator.py
+++ b/pyxem/tests/generators/test_variance_generator.py
@@ -20,10 +20,9 @@ import pytest
 import numpy as np
 
 from pyxem.generators import VarianceGenerator
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-
-from pyxem.signals.diffraction_variance2d import DiffractionVariance2D
-from pyxem.signals.diffraction_variance2d import ImageVariance
+from pyxem.signals import (
+    ElectronDiffraction2D, DiffractionVariance2D, ImageVariance
+)
 
 
 @pytest.fixture

--- a/pyxem/tests/generators/test_variance_generator.py
+++ b/pyxem/tests/generators/test_variance_generator.py
@@ -19,7 +19,7 @@
 import pytest
 import numpy as np
 
-from pyxem.generators.variance_generator import VarianceGenerator
+from pyxem.generators import VarianceGenerator
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 
 from pyxem.signals.diffraction_variance2d import DiffractionVariance2D

--- a/pyxem/tests/generators/test_virtual_image_generator.py
+++ b/pyxem/tests/generators/test_virtual_image_generator.py
@@ -20,13 +20,13 @@ import pytest
 import numpy as np
 import hyperspy.api as hs
 
-from pyxem.generators.virtual_image_generator import (VirtualImageGenerator,
-                                                      VirtualDarkFieldGenerator)
-
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals.diffraction2d import Diffraction2D
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals.virtual_dark_field_image import VirtualDarkFieldImage
+from pyxem.generators import VirtualImageGenerator, VirtualDarkFieldGenerator
+from pyxem.signals import (
+    Diffraction2D,
+    ElectronDiffraction2D,
+    DiffractionVectors,
+    VirtualDarkFieldImage
+)
 
 
 @pytest.fixture(params=[np.array([[1, 1], [2, 2]])])

--- a/pyxem/tests/library/test_calibration_library.py
+++ b/pyxem/tests/library/test_calibration_library.py
@@ -23,7 +23,7 @@ from hyperspy.signals import Signal2D
 from hyperspy.roi import Line2DROI
 
 from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.libraries.calibration_library import CalibrationDataLibrary
+from pyxem.libraries import CalibrationDataLibrary
 
 
 @pytest.fixture

--- a/pyxem/tests/library/test_calibration_library.py
+++ b/pyxem/tests/library/test_calibration_library.py
@@ -22,7 +22,7 @@ import numpy as np
 from hyperspy.signals import Signal2D
 from hyperspy.roi import Line2DROI
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from pyxem.signals import ElectronDiffraction2D
 from pyxem.libraries import CalibrationDataLibrary
 
 

--- a/pyxem/tests/signals/test_correlation2d.py
+++ b/pyxem/tests/signals/test_correlation2d.py
@@ -20,10 +20,7 @@ import pytest
 import numpy as np
 import dask.array as da
 
-from hyperspy.signals import Signal2D
-
-from pyxem.signals.correlation2d import Correlation2D, LazyCorrelation2D
-from pyxem.signals.power2d import Power2D
+from pyxem.signals import Correlation2D, LazyCorrelation2D, Power2D
 
 
 class TestComputeAndAsLazy2D:

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -17,15 +17,18 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from tempfile import TemporaryDirectory
+
 import pytest
 from pytest import approx
-from tempfile import TemporaryDirectory
-import numpy as np
 import dask.array as da
+import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 from matplotlib.pyplot import subplots
-from pyxem.signals.differential_phase_contrast import (
-    make_bivariate_histogram,
+
+import hyperspy.api as hs
+
+from pyxem.signals import (
     DPCBaseSignal,
     DPCSignal1D,
     DPCSignal2D,
@@ -33,6 +36,7 @@ from pyxem.signals.differential_phase_contrast import (
     LazyDPCSignal1D,
     LazyDPCSignal2D,
 )
+from pyxem.signals.differential_phase_contrast import make_bivariate_histogram
 import pyxem.dummy_data as dd
 import pyxem as pxm
 
@@ -244,7 +248,7 @@ class TestBivariateHistogram:
         s_random.get_bivariate_histogram()
 
     def test_masked_get_bivariate_histogram(self):
-        s = pxm.DPCSignal2D(np.zeros((2, 5, 5)))
+        s = pxm.signals.DPCSignal2D(np.zeros((2, 5, 5)))
         value = 3
         s.data[0, 0, 0] = value
         s_hist = s.get_bivariate_histogram(bins=10, histogram_range=(-5, 5))
@@ -453,7 +457,7 @@ class TestDpcsignalIo:
         assert s.axes_manager.navigation_dimension == 1
         filename = os.path.join(self.tmpdir.name, "dpcbasesignal.hspy")
         s.save(filename)
-        s_load = pxm.load(filename)
+        s_load = hs.load(filename)
         assert s.__class__ == s_load.__class__
         assert s_load.axes_manager.signal_dimension == 0
         assert s_load.axes_manager.navigation_dimension == 1
@@ -464,7 +468,7 @@ class TestDpcsignalIo:
         assert s.axes_manager.navigation_dimension == 1
         filename = os.path.join(self.tmpdir.name, "dpcsignal1d.hspy")
         s.save(filename)
-        s_load = pxm.load(filename)
+        s_load = hs.load(filename)
         assert s.__class__ == s_load.__class__
         assert s_load.axes_manager.signal_dimension == 1
         assert s_load.axes_manager.navigation_dimension == 1
@@ -475,7 +479,7 @@ class TestDpcsignalIo:
         assert s.axes_manager.navigation_dimension == 1
         filename = os.path.join(self.tmpdir.name, "dpcsignal2d.hspy")
         s.save(filename)
-        s_load = pxm.load(filename)
+        s_load = hs.load(filename)
         assert s.__class__ == s_load.__class__
         assert s_load.axes_manager.signal_dimension == 2
         assert s_load.axes_manager.navigation_dimension == 1
@@ -485,7 +489,7 @@ class TestDpcsignalIo:
         s.metadata.General.title = "test_data"
         filename = os.path.join(self.tmpdir.name, "test_metadata.hspy")
         s.save(filename)
-        s_load = pxm.load(filename)
+        s_load = hs.load(filename)
         assert s_load.metadata.General.title == "test_data"
 
     def test_retain_axes_manager(self):
@@ -496,7 +500,7 @@ class TestDpcsignalIo:
         s_sa0.units, s_sa1.units, s_sa0.name, s_sa1.name = "a", "b", "e", "f"
         filename = os.path.join(self.tmpdir.name, "test_axes_manager.hspy")
         s.save(filename)
-        s_load = pxm.load(filename)
+        s_load = hs.load(filename)
         assert s_load.axes_manager[1].offset == 20
         assert s_load.axes_manager[2].offset == 10
         assert s_load.axes_manager[1].scale == 0.2

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -33,8 +33,7 @@ from pyxem.signals.differential_phase_contrast import (
     LazyDPCSignal1D,
     LazyDPCSignal2D,
 )
-import pyxem.dummy_data.dummy_data as dd
-import pyxem.utils.pixelated_stem_tools as pst
+import pyxem.dummy_data as dd
 import pyxem as pxm
 
 

--- a/pyxem/tests/signals/test_diffraction1d.py
+++ b/pyxem/tests/signals/test_diffraction1d.py
@@ -18,11 +18,12 @@
 
 import numpy as np
 import dask.array as da
-import hyperspy.api as hs
 import pytest
 from matplotlib import pyplot as plt
 
-from pyxem.signals.diffraction1d import Diffraction1D, LazyDiffraction1D
+import hyperspy.api as hs
+
+from pyxem.signals import Diffraction1D, LazyDiffraction1D
 
 
 class TestComputeAndAsLazy1D:

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -23,9 +23,9 @@ import hyperspy.api as hs
 from matplotlib import pyplot as plt
 from numpy.random import default_rng
 
-from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
-from pyxem.signals.polar_diffraction2d import PolarDiffraction2D
-from pyxem.signals.diffraction1d import Diffraction1D
+from pyxem.signals import (
+    Diffraction1D, Diffraction2D, LazyDiffraction2D, PolarDiffraction2D
+)
 
 
 class TestComputeAndAsLazy2D:

--- a/pyxem/tests/signals/test_diffraction_variance1d.py
+++ b/pyxem/tests/signals/test_diffraction_variance1d.py
@@ -17,10 +17,9 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import pytest
 
 from hyperspy.signals import Signal1D
-from pyxem.signals.diffraction_variance1d import DiffractionVariance1D
+from pyxem.signals import DiffractionVariance1D
 
 
 class TestDiffractionVariance1D:

--- a/pyxem/tests/signals/test_diffraction_variance2d.py
+++ b/pyxem/tests/signals/test_diffraction_variance2d.py
@@ -16,13 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
 
-from pyxem.signals.diffraction_variance2d import DiffractionVariance2D
-from pyxem.signals.diffraction_variance2d import ImageVariance
-from pyxem.signals.diffraction_variance1d import DiffractionVariance1D
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from pyxem.signals import (
+    DiffractionVariance2D, ImageVariance, DiffractionVariance1D,
+)
+
 
 
 class TestDiffractionVariance:

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -18,9 +18,11 @@
 
 import pytest
 import numpy as np
-from pyxem.signals.diffraction_vectors import DiffractionVectors
 from sklearn.cluster import DBSCAN
+
 from hyperspy.signals import Signal2D
+
+from pyxem.signals import DiffractionVectors
 
 # DiffractionVectors correspond to a single list of vectors, a map of vectors
 # all of equal length, and the ragged case. A fixture is defined for each of

--- a/pyxem/tests/signals/test_electron_diffraction1d.py
+++ b/pyxem/tests/signals/test_electron_diffraction1d.py
@@ -20,8 +20,7 @@ import numpy as np
 import dask.array as da
 import pytest
 
-from pyxem.signals.electron_diffraction1d import ElectronDiffraction1D
-from pyxem.signals.electron_diffraction1d import LazyElectronDiffraction1D
+from pyxem.signals import ElectronDiffraction1D, LazyElectronDiffraction1D
 
 
 class TestSimpleHyperspy:

--- a/pyxem/tests/signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/signals/test_electron_diffraction2d.py
@@ -19,19 +19,20 @@
 import pytest
 import numpy as np
 import dask.array as da
-import hyperspy.api as hs
 
-from hyperspy.signals import Signal1D, Signal2D
+from hyperspy.signals import Signal2D
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals.electron_diffraction1d import ElectronDiffraction1D
-from pyxem.signals.polar_diffraction2d import PolarDiffraction2D
-from pyxem.signals.electron_diffraction2d import LazyElectronDiffraction2D
+from pyxem.signals import (
+    ElectronDiffraction1D,
+    ElectronDiffraction2D,
+    PolarDiffraction2D,
+    LazyElectronDiffraction2D
+)
 
 
 def test_init():
     z = np.zeros((2, 2, 2, 2))
-    dp = ElectronDiffraction2D(
+    _ = ElectronDiffraction2D(
         z, metadata={"Acquisition_instrument": {"SEM": "Expensive-SEM"}}
     )
 

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -18,18 +18,20 @@
 
 import numpy as np
 import pytest
-import diffsims as ds
 from matplotlib import pyplot as plt
+from transforms3d.euler import euler2mat
 
-from pyxem.signals.indexation_results import TemplateMatchingResults, VectorMatchingResults
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from diffsims.libraries.vector_library import DiffractionVectorLibrary
 from diffsims.libraries.structure_library import StructureLibrary
 from diffsims.generators.diffraction_generator import DiffractionGenerator
 from diffsims.generators.library_generator import DiffractionLibraryGenerator
+
+from pyxem.generators import TemplateIndexationGenerator
+from pyxem.signals import (
+    TemplateMatchingResults,
+    VectorMatchingResults,
+    DiffractionVectors,
+)
 from pyxem.utils.indexation_utils import OrientationResult
-from pyxem.generators.indexation_generator import TemplateIndexationGenerator
-from transforms3d.euler import euler2mat
 
 
 def test_TemplateMatchingResults_to_crystal_map():

--- a/pyxem/tests/signals/test_lazy_diffraction1d.py
+++ b/pyxem/tests/signals/test_lazy_diffraction1d.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyxem.signals.diffraction1d import Diffraction1D, LazyDiffraction1D
+from pyxem.signals import Diffraction1D, LazyDiffraction1D
 
 
 class TestDecomposition:

--- a/pyxem/tests/signals/test_lazy_diffraction2d.py
+++ b/pyxem/tests/signals/test_lazy_diffraction2d.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
+from pyxem.signals import Diffraction2D, LazyDiffraction2D
 
 
 class TestDecomposition:

--- a/pyxem/tests/signals/test_lazy_electron_diffraction1d.py
+++ b/pyxem/tests/signals/test_lazy_electron_diffraction1d.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyxem.signals.electron_diffraction1d import LazyElectronDiffraction1D
+from pyxem.signals import LazyElectronDiffraction1D
 
 
 class TestDecomposition:

--- a/pyxem/tests/signals/test_lazy_electron_diffraction2d.py
+++ b/pyxem/tests/signals/test_lazy_electron_diffraction2d.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyxem.signals.electron_diffraction2d import LazyElectronDiffraction2D
+from pyxem.signals import LazyElectronDiffraction2D
 
 
 class TestDecomposition:

--- a/pyxem/tests/signals/test_metadata.py
+++ b/pyxem/tests/signals/test_metadata.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyxem.signals.diffraction2d import Diffraction2D
 import numpy as np
+
+from pyxem.signals import Diffraction2D
 
 
 class TestAdjustMetadata:

--- a/pyxem/tests/signals/test_pixelated_stem_class.py
+++ b/pyxem/tests/signals/test_pixelated_stem_class.py
@@ -25,8 +25,8 @@ from hyperspy.signals import Signal2D
 
 from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
 import pyxem.utils.ransac_ellipse_tools as ret
-import pyxem.dummy_data.make_diffraction_test_data as mdtd
-import pyxem.dummy_data.dummy_data as dd
+from pyxem.dummy_data import make_diffraction_test_data as mdtd
+import pyxem.dummy_data as dd
 
 
 @pytest.mark.slow

--- a/pyxem/tests/signals/test_pixelated_stem_class.py
+++ b/pyxem/tests/signals/test_pixelated_stem_class.py
@@ -21,9 +21,10 @@ import numpy as np
 from numpy.random import randint
 import dask.array as da
 from skimage import morphology
+
 from hyperspy.signals import Signal2D
 
-from pyxem.signals.diffraction2d import Diffraction2D, LazyDiffraction2D
+from pyxem.signals import Diffraction2D, LazyDiffraction2D
 import pyxem.utils.ransac_ellipse_tools as ret
 from pyxem.dummy_data import make_diffraction_test_data as mdtd
 import pyxem.dummy_data as dd

--- a/pyxem/tests/signals/test_polar_diffraction2d.py
+++ b/pyxem/tests/signals/test_polar_diffraction2d.py
@@ -22,9 +22,12 @@ import dask.array as da
 
 from hyperspy.signals import Signal2D
 
-from pyxem.signals.polar_diffraction2d import PolarDiffraction2D, LazyPolarDiffraction2D
-from pyxem.signals.correlation2d import Correlation2D
-from pyxem.signals.power2d import Power2D
+from pyxem.signals import (
+    PolarDiffraction2D,
+    LazyPolarDiffraction2D,
+    Correlation2D,
+    Power2D
+)
 
 
 class TestComputeAndAsLazy2D:

--- a/pyxem/tests/signals/test_power2d.py
+++ b/pyxem/tests/signals/test_power2d.py
@@ -20,9 +20,7 @@ import pytest
 import numpy as np
 import dask.array as da
 
-from hyperspy.signals import Signal2D
-
-from pyxem.signals.power2d import Power2D, LazyPower2D
+from pyxem.signals import Power2D, LazyPower2D
 
 
 class TestComputeAndAsLazy2D:

--- a/pyxem/tests/signals/test_reduced_intensity1d.py
+++ b/pyxem/tests/signals/test_reduced_intensity1d.py
@@ -19,7 +19,7 @@
 import pytest
 import numpy as np
 
-from pyxem.signals.reduced_intensity1d import ReducedIntensity1D
+from pyxem.signals import ReducedIntensity1D
 
 
 @pytest.fixture

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -22,10 +22,10 @@ import numpy as np
 
 from hyperspy.signals import Signal2D
 
-from pyxem.generators.virtual_image_generator import VirtualDarkFieldGenerator
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals.segments import LearningSegment, VDFSegment
+from pyxem.generators import VirtualDarkFieldGenerator
+from pyxem.signals import (
+    ElectronDiffraction2D, DiffractionVectors, LearningSegment, VDFSegment
+)
 
 
 @pytest.fixture

--- a/pyxem/tests/signals/test_strain_map.py
+++ b/pyxem/tests/signals/test_strain_map.py
@@ -18,18 +18,13 @@
 
 import hyperspy.api as hs
 import pytest
-import diffpy.structure
 import numpy as np
-from diffsims.generators.diffraction_generator import DiffractionGenerator
 
 from pyxem.tests.generators.test_displacement_gradient_tensor_generator import (
     generate_test_vectors,
 )
-from pyxem.generators.displacement_gradient_tensor_generator import (
-    get_DisplacementGradientMap,
-)
-from pyxem.signals.strain_map import StrainMap, _get_rotation_matrix
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
+from pyxem.generators import get_DisplacementGradientMap
+from pyxem.signals.strain_map import _get_rotation_matrix
 
 
 @pytest.fixture()

--- a/pyxem/tests/signals/test_virtual_dark_field_image.py
+++ b/pyxem/tests/signals/test_virtual_dark_field_image.py
@@ -22,10 +22,8 @@ import pytest
 
 from hyperspy.signals import Signal2D
 
-from pyxem.generators.virtual_image_generator import VirtualDarkFieldGenerator
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals.diffraction_vectors import DiffractionVectors
-from pyxem.signals.segments import VDFSegment
+from pyxem.generators import VirtualDarkFieldGenerator
+from pyxem.signals import ElectronDiffraction2D, DiffractionVectors, VDFSegment
 
 
 @pytest.fixture(

--- a/pyxem/tests/utils/test_big_data_utils.py
+++ b/pyxem/tests/utils/test_big_data_utils.py
@@ -21,6 +21,7 @@ import tempfile
 
 import numpy as np
 import pytest
+
 import pyxem as pxm
 from pyxem.utils.big_data_utils import chunked_application_of_UDF, _get_chunk_size
 
@@ -50,7 +51,7 @@ the chunked version is compared with doing the entire operation in memory.
 @pytest.fixture()
 def big_electron_diffraction_pattern():
     z = np.arange(0, 160, step=1).reshape(4, 10, 2, 2)  # x_size=10, y_size=4 in hspy
-    dp = pxm.ElectronDiffraction2D(z)
+    dp = pxm.signals.ElectronDiffraction2D(z)
     return dp
 
 

--- a/pyxem/tests/utils/test_cluster_tools.py
+++ b/pyxem/tests/utils/test_cluster_tools.py
@@ -19,7 +19,7 @@
 import pytest
 import numpy as np
 from numpy.random import randint
-from pyxem.signals.diffraction2d import Diffraction2D
+from pyxem.signals import Diffraction2D
 import pyxem.utils.cluster_tools as ct
 
 

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -20,9 +20,10 @@ import pytest
 import numpy as np
 import dask.array as da
 import skimage.morphology as sm
+
+from pyxem.signals import Diffraction2D, LazyDiffraction2D
 import pyxem.utils.dask_tools as dt
 import pyxem.utils.pixelated_stem_tools as pst
-from pyxem import Diffraction2D, LazyDiffraction2D
 
 
 class TestSignalDimensionGetChunkSliceList:

--- a/pyxem/tests/utils/test_dpc_signal_tools.py
+++ b/pyxem/tests/utils/test_dpc_signal_tools.py
@@ -21,9 +21,11 @@ import pytest
 from pytest import approx
 import numpy as np
 from numpy.testing import assert_allclose
+
 import hyperspy.api as hs
-import pyxem.utils.pixelated_stem_tools as pst
+
 from pyxem.signals.differential_phase_contrast import make_bivariate_histogram
+import pyxem.utils.pixelated_stem_tools as pst
 
 
 class TestGetRgbPhaseMagnitudeArray:

--- a/pyxem/tests/utils/test_expt_utils.py
+++ b/pyxem/tests/utils/test_expt_utils.py
@@ -21,11 +21,8 @@ import numpy as np
 from scipy.ndimage.filters import gaussian_filter
 from matplotlib import pyplot as plt
 
-from pyFAI.azimuthalIntegrator import AzimuthalIntegrator
 from pyFAI.detectors import Detector
-from pyxem.detectors.generic_flat_detector import GenericFlatDetector
 
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
 from pyxem.utils.expt_utils import (
     _index_coords,
     _cart2polar,

--- a/pyxem/tests/utils/test_io_utils.py
+++ b/pyxem/tests/utils/test_io_utils.py
@@ -18,13 +18,17 @@
 
 import pytest
 import numpy as np
-import pyxem as pxm
 import os
 
-from pyxem.signals.electron_diffraction1d import ElectronDiffraction1D
-from pyxem.signals.electron_diffraction2d import ElectronDiffraction2D
-from pyxem.signals.diffraction_vectors import DiffractionVectors, DiffractionVectors2D
-from pyxem.signals.virtual_dark_field_image import VirtualDarkFieldImage
+import hyperspy.api as hs
+
+from pyxem.signals import(
+    ElectronDiffraction1D,
+    ElectronDiffraction2D,
+    DiffractionVectors,
+    DiffractionVectors2D,
+    VirtualDarkFieldImage
+)
 
 
 @pytest.mark.parametrize(
@@ -48,7 +52,7 @@ def test_load_function_core(class_to_test, meta_string):
     if class_to_test is DiffractionVectors2D:
         to_save.axes_manager.set_signal_dimension(2)
     to_save.save("tempfile_for_load_and_save.hspy", overwrite=True)
-    from_save = pxm.load("tempfile_for_load_and_save.hspy")
+    from_save = hs.load("tempfile_for_load_and_save.hspy")
     assert isinstance(from_save, class_to_test)
     assert from_save.metadata.Signal.tracker == meta_string
     assert np.allclose(to_save.data, from_save.data)
@@ -69,7 +73,7 @@ def test_load_ElectronDiffraction2D(diffraction_pattern, make_saved_dp):
     """
     This tests that our load function keeps .data, instance and metadata
     """
-    dp = pxm.load("dp_temp.hspy")
+    dp = hs.load("dp_temp.hspy")
     assert np.allclose(dp.data, diffraction_pattern.data)
     assert isinstance(dp, ElectronDiffraction2D)
     assert (

--- a/pyxem/tests/utils/test_marker_tools.py
+++ b/pyxem/tests/utils/test_marker_tools.py
@@ -20,7 +20,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 import dask.array as da
-from pyxem.signals.diffraction2d import Diffraction2D
+
+from pyxem.signals import Diffraction2D
 import pyxem.utils.marker_tools as mt
 
 

--- a/pyxem/tests/utils/test_pixelated_stem_tools.py
+++ b/pyxem/tests/utils/test_pixelated_stem_tools.py
@@ -19,9 +19,11 @@
 import pytest
 import numpy as np
 import dask.array as da
-from pyxem.signals.diffraction2d import Diffraction2D
-import pyxem.utils.pixelated_stem_tools as pst
+
 from hyperspy.signals import Signal2D
+
+from pyxem.signals import Diffraction2D
+import pyxem.utils.pixelated_stem_tools as pst
 
 
 class TestRadialIntegrationDaskArray:

--- a/pyxem/tests/utils/test_radial.py
+++ b/pyxem/tests/utils/test_radial.py
@@ -19,7 +19,8 @@
 import pytest
 from pytest import approx
 import numpy as np
-from pyxem.signals.diffraction2d import Diffraction2D
+
+from pyxem.signals import Diffraction2D
 import pyxem.utils.radial_utils as ra
 from pyxem.dummy_data import make_diffraction_test_data as mdtd
 

--- a/pyxem/tests/utils/test_radial.py
+++ b/pyxem/tests/utils/test_radial.py
@@ -21,7 +21,7 @@ from pytest import approx
 import numpy as np
 from pyxem.signals.diffraction2d import Diffraction2D
 import pyxem.utils.radial_utils as ra
-import pyxem.dummy_data.make_diffraction_test_data as mdtd
+from pyxem.dummy_data import make_diffraction_test_data as mdtd
 
 
 @pytest.mark.slow

--- a/pyxem/tests/utils/test_ransac_ellipse_tools.py
+++ b/pyxem/tests/utils/test_ransac_ellipse_tools.py
@@ -24,8 +24,8 @@ from scipy.signal import convolve2d
 from skimage import morphology
 
 from pyxem.dummy_data import make_diffraction_test_data as mdtd
+from pyxem.signals import Diffraction2D
 import pyxem.utils.ransac_ellipse_tools as ret
-from pyxem.signals.diffraction2d import Diffraction2D
 
 
 class TestIsEllipseGood:

--- a/pyxem/tests/utils/test_ransac_ellipse_tools.py
+++ b/pyxem/tests/utils/test_ransac_ellipse_tools.py
@@ -23,7 +23,7 @@ from numpy.testing import assert_allclose
 from scipy.signal import convolve2d
 from skimage import morphology
 
-import pyxem.dummy_data.make_diffraction_test_data as mdtd
+from pyxem.dummy_data import make_diffraction_test_data as mdtd
 import pyxem.utils.ransac_ellipse_tools as ret
 from pyxem.signals.diffraction2d import Diffraction2D
 

--- a/pyxem/utils/cluster_tools.py
+++ b/pyxem/utils/cluster_tools.py
@@ -449,7 +449,7 @@ def _add_peak_dicts_to_signal(
     >>> peak_dicts['centre'] = np.random.randint(99, size=(2, 3, 10, 2))
     >>> peak_dicts['rest'] = np.random.randint(99, size=(2, 3, 3, 2))
     >>> peak_dicts['none'] = np.random.randint(99, size=(2, 3, 2, 2))
-    >>> s = pxm.Diffraction2D(np.random.random((2, 3, 100, 100)))
+    >>> s = pxm.signals.Diffraction2D(np.random.random((2, 3, 100, 100)))
     >>> import pyxem.utils.cluster_tools as ct
     >>> ct._add_peak_dicts_to_signal(s, peak_dicts)
     >>> s.plot()
@@ -502,7 +502,7 @@ def _sorted_cluster_dict_to_marker_list(
     >>> marker_list = ct._sorted_cluster_dict_to_marker_list(
     ...     sorted_cluster_dict)
     >>> import pyxem.utils.marker_tools as mt
-    >>> s = pxm.Diffraction2D(np.random.random((3, 4, 100, 100)))
+    >>> s = pxm.signals.Diffraction2D(np.random.random((3, 4, 100, 100)))
     >>> mt._add_permanent_markers_to_signal(s, marker_list)
 
     Different colors

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -1312,9 +1312,9 @@ def _background_removal_dog(dask_array, **kwargs):
     --------
     >>> import pyxem.utils.dask_tools as dt
     >>> import dask.array as da
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> dask_array = da.from_array(s.data, chunks=(5,5,25, 25))
-    >>> s_rem = pxm.Diffraction2D(
+    >>> s_rem = pxm.signals.Diffraction2D(
     ...     dt._background_removal_dog(dask_array))
 
     """
@@ -1340,7 +1340,7 @@ def _background_removal_single_frame_median(frame, footprint=19):
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> s_rem = dt._background_removal_single_frame_median(s.data[0, 0])
 
     """
@@ -1365,7 +1365,7 @@ def _background_removal_chunk_median(data, **kwargs):
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> s_rem = dt._background_removal_chunk_median(s.data[0:10, 0:10,:,:])
 
     """
@@ -1396,9 +1396,9 @@ def _background_removal_median(dask_array, **kwargs):
     --------
     >>> import pyxem.utils.dask_tools as dt
     >>> import dask.array as da
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> dask_array = da.from_array(s.data+1e3, chunks=(5,5,25, 25))
-    >>> s_rem = pxm.Diffraction2D(
+    >>> s_rem = pxm.signals.Diffraction2D(
     ...     dt._background_removal_median(dask_array), footprint=20)
 
     """
@@ -1429,7 +1429,7 @@ def _background_removal_single_frame_radial_median(frame, centre_x=128, centre_y
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> s_rem = dt._background_removal_single_frame_radial_median(s.data[0, 0])
     """
 
@@ -1467,7 +1467,7 @@ def _background_removal_chunk_radial_median(data, **kwargs):
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> s_rem = _background_removal_chunk_radial_median(s.data[0:10, 0:10,:,:])
     """
     output_array = np.zeros_like(data, dtype=np.float32)
@@ -1500,9 +1500,9 @@ def _background_removal_radial_median(dask_array, **kwargs):
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> dask_array = da.from_array(s.data+1e3, chunks=(5,5,25, 25))
-    >>> s_r = pxm.Diffraction2D(
+    >>> s_r = pxm.signals.Diffraction2D(
     ...     dt._background_removal_radial_median(
     ...     dask_array, centre_x=128, centre_y=128))
 
@@ -1535,7 +1535,7 @@ def _peak_refinement_centre_of_mass_frame(frame, peaks, square_size):
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> peak_array = np.array(([48.,48.],[25.,48.]))
     >>> r_p_array = dt._peak_refinement_centre_of_mass_frame(
     ...     s.data[0,0,:,:], peak_array, 20)
@@ -1585,7 +1585,7 @@ def _peak_refinement_centre_of_mass_chunk(data, peak_array, square_size):
     Examples
     --------
     >>> import pyxem.utils.dask_tools as dt
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> peak_array = dt._peak_find_dog_chunk(s.data)
     >>> r_p_array = dt._peak_refinement_centre_of_mass_chunk(
     ...     s.data, peak_array, 20)

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import copy
 import numpy as np
 import dask.array as da
 from skimage.feature import match_template, blob_dog, blob_log
@@ -595,7 +594,7 @@ def _peak_find_dog_single_frame(
 
     Example
     -------
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> import pyxem.utils.dask_tools as dt
     >>> peaks = _peak_find_dog_single_frame(s.data[0, 0])
 
@@ -1630,7 +1629,7 @@ def _peak_refinement_centre_of_mass(dask_array, peak_array, square_size):
     --------
     >>> import pyxem.utils.dask_tools as dt
     >>> import dask.array as da
-    >>> s = ps.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> dask_array = da.from_array(s.data, chunks=(5, 5, 25, 25))
     >>> peak_array = dt._peak_find_dog(dask_array)
     >>> r_p_array = dt._peak_refinement_centre_of_mass(
@@ -1745,8 +1744,7 @@ def _get_experimental_square(z, vector, square_size):
 
     Examples
     --------
-    >>> import pyxem.dummy_data.dummy_data as dd
-    >>> d = dd.get_cbed_signal()
+    >>> d = pxm.dummy_data.get_cbed_signal()
     >>> import pyxem.utils.dask_tools as dt
     >>> sub_d = dt._get_experimental_square(d.data[0,0,:,:], [50,50], 30)
 

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -696,7 +696,7 @@ def investigate_dog_background_removal_interactive(
                 max_sigma=std_dev_max,
                 show_progressbar=False,
             )
-    dp_gaussian = pxm.ElectronDiffraction2D(gauss_processed)
+    dp_gaussian = pxm.signals.ElectronDiffraction2D(gauss_processed)
     dp_gaussian.metadata.General.title = "Gaussian preprocessed"
     dp_gaussian.axes_manager.navigation_axes[0].name = r"$\sigma_{\mathrm{min}}$"
     dp_gaussian.axes_manager.navigation_axes[1].name = r"$\sigma_{\mathrm{max}}$"

--- a/pyxem/utils/io_utils.py
+++ b/pyxem/utils/io_utils.py
@@ -19,15 +19,15 @@
 # a lot of stuff depends on this, so we have to create it first
 
 import os
+from struct import unpack
 
 import numpy as np
 import dask.array as da
 from math import floor
 from scipy.signal import find_peaks
 import h5py
-from struct import unpack
 
-from pyxem.signals.electron_diffraction2d import LazyElectronDiffraction2D
+from pyxem.signals import LazyElectronDiffraction2D
 
 
 def load_mib(mib_path, reshape=True, flip=True):

--- a/pyxem/utils/marker_tools.py
+++ b/pyxem/utils/marker_tools.py
@@ -51,7 +51,7 @@ def _get_4d_points_marker_list(
 
     Example
     -------
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> peak_array = s.find_peaks(lazy_result=False, show_progressbar=False)
     >>> import pyxem.utils.marker_tools as mt
     >>> marker_list = mt._get_4d_points_marker_list(
@@ -275,7 +275,7 @@ def _add_permanent_markers_to_signal(signal, marker_list):
 
     Example
     -------
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> peak_array = s.find_peaks(lazy_result=False, show_progressbar=False)
     >>> import pyxem.utils.marker_tools as mt
     >>> marker_list = mt._get_4d_points_marker_list(
@@ -312,7 +312,7 @@ def add_peak_array_to_signal_as_markers(
 
     Example
     -------
-    >>> s = pxm.dummy_data.dummy_data.get_cbed_signal()
+    >>> s = pxm.dummy_data.get_cbed_signal()
     >>> peak_array = s.find_peaks(lazy_result=False, show_progressbar=False)
     >>> import pyxem.utils.marker_tools as mt
     >>> mt.add_peak_array_to_signal_as_markers(s, peak_array)

--- a/pyxem/utils/radial_utils.py
+++ b/pyxem/utils/radial_utils.py
@@ -656,7 +656,7 @@ def fit_single_ellipse_to_signal(
     Examples
     --------
     >>> import pyxem.dummy_data import make_diffraction_test_data as mdtd
-    >>> s = pxm.Diffraction2D(np.zeros((200, 220)))
+    >>> s = pxm.signals.Diffraction2D(np.zeros((200, 220)))
     >>> s.axes_manager[0].offset, s.axes_manager[1].offset = -100, -110
     >>> xx, yy = np.meshgrid(s.axes_manager[0].axis, s.axes_manager[1].axis)
     >>> ellipse_ring = mdtd._get_elliptical_ring(xx, yy, 0, 0, 50, 70, 0.8)

--- a/pyxem/utils/radial_utils.py
+++ b/pyxem/utils/radial_utils.py
@@ -146,8 +146,7 @@ def get_optimal_centre_position(
 
     Examples
     --------
-    >>> import pyxem.dummy_data.dummy_data as dd
-    >>> s = dd.get_single_ring_diffraction_signal()
+    >>> s = pxm.dummy_data.get_single_ring_diffraction_signal()
     >>> s.axes_manager.signal_axes[0].offset = -105
     >>> s.axes_manager.signal_axes[1].offset = -67
     >>> import pyxem.utils.radial_utils as ra
@@ -205,9 +204,8 @@ def refine_signal_centre_position(
 
     Example
     -------
-    >>> import pyxem.dummy_data.dummy_data as dd
     >>> import pyxem.utils.radial_utils as ra
-    >>> s = dd.get_single_ring_diffraction_signal()
+    >>> s = pxm.dummy_data.get_single_ring_diffraction_signal()
     >>> s.axes_manager[0].offset, s.axes_manager[1].offset = -103, -69
     >>> ra.refine_signal_centre_position(s, (32., 48.), angleN=4)
     >>> x, y = s.axes_manager[0].offset, s.axes_manager[1].offset
@@ -346,8 +344,7 @@ def get_radius_vs_angle(
 
     Examples
     --------
-    >>> import pyxem.dummy_data.dummy_data as dd
-    >>> s = dd.get_single_ring_diffraction_signal()
+    >>> s = pxm.dummy_data.get_single_ring_diffraction_signal()
     >>> s.axes_manager.signal_axes[0].offset = -105
     >>> s.axes_manager.signal_axes[1].offset = -67
     >>> import pyxem.utils.radial_utils as ra
@@ -396,7 +393,7 @@ def get_angle_image_comparison(s0, s1, angleN=12, mask_radius=None):
 
     Examples
     --------
-    >>> from pyxem.dummy_data.make_diffraction_test_data import MakeTestData
+    >>> from pyxem.dummy_data import MakeTestData
     >>> test_data0 = MakeTestData(300, 300)
     >>> test_data0.add_ring(150, 150, 40)
     >>> test_data1 = MakeTestData(300, 300)
@@ -658,7 +655,7 @@ def fit_single_ellipse_to_signal(
 
     Examples
     --------
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> import pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> s = pxm.Diffraction2D(np.zeros((200, 220)))
     >>> s.axes_manager[0].offset, s.axes_manager[1].offset = -100, -110
     >>> xx, yy = np.meshgrid(s.axes_manager[0].axis, s.axes_manager[1].axis)
@@ -718,7 +715,7 @@ def fit_ellipses_to_signal(
 
     Examples
     --------
-    >>> import pyxem.dummy_data.make_diffraction_test_data as mdtd
+    >>> import pyxem.dummy_data import make_diffraction_test_data as mdtd
     >>> s = ps.PixelatedSTEM(np.zeros((200, 220)))
     >>> s.axes_manager[0].offset, s.axes_manager[1].offset = -100, -110
     >>> xx, yy = np.meshgrid(s.axes_manager[0].axis, s.axes_manager[1].axis)

--- a/pyxem/utils/signal.py
+++ b/pyxem/utils/signal.py
@@ -1,0 +1,129 @@
+
+def select_method_from_method_dict(method, method_dict, print_help=True, **kwargs):
+    """Streamlines the selection of utils to be mapped in class methods.
+
+    Parameters
+    ----------
+    method : str
+        The key to method_dict for the chosen method
+    method_dict : dict
+        dictionary with strings as keys and functions as values
+    kwargs : dict
+        Parameters for the method, if empty help is return
+    print_help : bool
+        If True: Prints information about the chosen method.
+
+    Returns
+    -------
+    method_function :
+        The utility function that corresponds the given method string, unless
+        kwargs is empty, in which case the help for the utility function is
+        returned.
+    """
+
+    if method not in method_dict:
+        raise NotImplementedError(
+            "The method `{}` is not implemented. "
+            "See documentation for available "
+            "implementations.".format(method)
+        )
+    elif print_help and not kwargs:
+        help(method_dict[method])
+
+    return method_dict[method]
+
+
+def transfer_signal_axes(new_signal, old_signal):
+    """Transfers signal axis calibrations from an old signal to a new
+    signal produced from it by a method or a generator.
+
+    Parameters
+    ----------
+    new_signal : Signal
+        The product signal with undefined signal axes.
+    old_signal : Signal
+        The parent signal with calibrated signal axes.
+
+    Returns
+    -------
+    new_signal : Signal
+        The new signal with calibrated signal axes.
+    """
+
+    for i in range(old_signal.axes_manager.signal_dimension):
+        ax_new = new_signal.axes_manager.signal_axes[i]
+        ax_old = old_signal.axes_manager.signal_axes[i]
+        ax_new.name = ax_old.name
+        ax_new.scale = ax_old.scale
+        ax_new.units = ax_old.units
+
+    return new_signal
+
+
+def transfer_navigation_axes(new_signal, old_signal):
+    """Transfers navigation axis calibrations from an old signal to a new
+    signal produced from it by a method or a generator.
+
+    Parameters
+    ----------
+    new_signal : Signal
+        The product signal with undefined navigation axes.
+    old_signal : Signal
+        The parent signal with calibrated navigation axes.
+
+    Returns
+    -------
+    new_signal : Signal
+        The new signal with calibrated navigation axes.
+    """
+    new_signal.axes_manager.set_signal_dimension(
+        len(new_signal.data.shape) - old_signal.axes_manager.navigation_dimension
+    )
+
+    for i in range(
+        min(
+            new_signal.axes_manager.navigation_dimension,
+            old_signal.axes_manager.navigation_dimension,
+        )
+    ):
+        ax_new = new_signal.axes_manager.navigation_axes[i]
+        ax_old = old_signal.axes_manager.navigation_axes[i]
+        ax_new.name = ax_old.name
+        ax_new.scale = ax_old.scale
+        ax_new.units = ax_old.units
+
+    return new_signal
+
+
+def transfer_navigation_axes_to_signal_axes(new_signal, old_signal):
+    """Transfers navigation axis calibrations from an old signal to the signal
+    axes of a new signal produced from it by a method or a generator.
+
+    Used from methods that generate a signal with a single value at each
+    navigation position.
+
+    Parameters
+    ----------
+    new_signal : Signal
+        The product signal with undefined navigation axes.
+    old_signal : Signal
+        The parent signal with calibrated navigation axes.
+
+    Returns
+    -------
+    new_signal : Signal
+        The new signal with calibrated signal axes.
+    """
+    for i in range(
+        min(
+            new_signal.axes_manager.signal_dimension,
+            old_signal.axes_manager.navigation_dimension,
+        )
+    ):
+        ax_new = new_signal.axes_manager.signal_axes[i]
+        ax_old = old_signal.axes_manager.navigation_axes[i]
+        ax_new.name = ax_old.name
+        ax_new.scale = ax_old.scale
+        ax_new.units = ax_old.units
+
+    return new_signal


### PR DESCRIPTION
---
name: Pull request 
about: A pull request that fixes a bug or adds a feature

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

This PR is opened to discuss pyxem's namespace. I find it confusing and I think that it could be more clear and more convenient to use. Some of the generators are in the pyxem's namespace while other are not - see the diff of this PR to notice the difference.
For example to use the `VirtualImageGenerator`:
```python
from pyxem.generators.virtual_image_generator import VirtualImageGenerator
```
And I would prefer to use:
```python
from pyxem import VirtualImageGenerator
```
or 
```python
from pyxem.generators import VirtualImageGenerator
```

Even if I am not experienced enough with pyxem to have a precise idea of pyxem overall design, I think that I can still start the discussion with this PR! Since I find the folder structure fairly clear, I would suggest to mainly mirror it: 
- import components from `pyxem.components`
- import detectors from `pyxem.detectors` (already the case)
- import generators from `pyxem.generators` (the first commit of this PR)
- import utils function relevant to users from `pyxem.utils`
- import utils function used very often from `pyxem`

Looking at some of the demo notebook, this structure should improve the readability of the import statements!

## Outcome of this PR
Example of import of the different pyxem objects:
```python
from pyxem.components import ReducedIntensityCorrectionComponent
from pyxem.detetors import Medipix256x256Detector
from pyxem.dummy_data import get_cbed_signal
from pyxem.generatos import IndexationGenerator
from pyxem.librairies import CalibrationDataLibrary
from pyxem.signals import Diffraction1D
```
or
```python
import pyxem as pxm

s = pxm.load_mid("filename")
s2 = pxm.dummy_data.get_cbed_signal()
```