### PR TITLE
Change default chunk size in dask_tools._get_dask_array

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -405,7 +405,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             bg_subtracted.data = bg_subtracted.data / np.max(bg_subtracted.data)
             return bg_subtracted
 
-        dask_array = _get_dask_array(self,size_of_chunk=8)
+        dask_array = _get_dask_array(self)
 
         if method == "difference of gaussians":
             output_array = dt._background_removal_dog(dask_array, **kwargs)
@@ -482,7 +482,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         correct_bad_pixels
 
         """
-        dask_array = _get_dask_array(self,size_of_chunk=8)
+        dask_array = _get_dask_array(self)
 
         dead_pixels = dt._find_dead_pixels(
             dask_array, dead_pixel_value=dead_pixel_value, mask_array=mask_array
@@ -546,7 +546,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         correct_bad_pixels
 
         """
-        dask_array = _get_dask_array(self,size_of_chunk=8)
+        dask_array = _get_dask_array(self)
 
         hot_pixels = dt._find_hot_pixels(
             dask_array, threshold_multiplier=threshold_multiplier, mask_array=mask_array
@@ -1112,7 +1112,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         template_match_ring
 
         """
-        dask_array = _get_dask_array(self,size_of_chunk=8)
+        dask_array = _get_dask_array(self)
 
         output_array = dt._template_match_with_binary_image(dask_array, binary_image)
         if not lazy_result:
@@ -1248,7 +1248,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             raise ValueError(
                 "square_size must be even number, not {0}".format(square_size)
             )
-        dask_array = _get_dask_array(self,size_of_chunk=8)
+        dask_array = _get_dask_array(self)
 
         chunks_peak = dask_array.chunks[:-2]
         if hasattr(peak_array, "chunks"):
@@ -1303,7 +1303,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         >>> intensity_array_computed = intensity_array.compute()
 
         """
-        dask_array = _get_dask_array(self,size_of_chunk=8)
+        dask_array = _get_dask_array(self)
 
         chunks_peak = dask_array.chunks[:-2]
         if hasattr(peak_array, "chunks"):

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -544,15 +544,15 @@ class TestGetDaskArray:
         array_out = dt._get_dask_array(s)
         assert hasattr(array_out, "compute")
 
-    def test_size_of_chunk(self):
+    def test_chunk_shape(self):
         s = Diffraction2D(np.zeros((10, 10, 8, 8)))
-        array_out = dt._get_dask_array(s, size_of_chunk=5)
+        array_out = dt._get_dask_array(s, chunk_shape=5)
         assert array_out.chunksize[:2] == (5, 5)
 
-    def test_chunk_limit(self):
+    def test_chunk_bytes(self):
         s = Diffraction2D(np.zeros((10, 10, 8, 8)))
         array_out0 = dt._get_dask_array(s)
-        array_out1 = dt._get_dask_array(s, chunk_limit="25KiB")
+        array_out1 = dt._get_dask_array(s, chunk_bytes="25KiB")
         assert array_out0.chunksize[:2] != array_out1.chunksize[:2]
 
     def test_lazy_input(self):
@@ -568,14 +568,14 @@ class TestGetChunking:
         chunks = dt._get_chunking(s)
         assert len(chunks) == 4
 
-    def test_size_of_chunk(self):
+    def test_chunk_shape(self):
         s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
-        chunks = dt._get_chunking(s, size_of_chunk=16)
+        chunks = dt._get_chunking(s, chunk_shape=16)
         assert chunks == ((16, 16), (16, 16), (256,), (256,))
 
-    def test_chunk_limit(self):
+    def test_chunk_bytes(self):
         s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
-        chunks = dt._get_chunking(s, chunk_limit="15MiB")
+        chunks = dt._get_chunking(s, chunk_bytes="15MiB")
         assert chunks == ((8, 8, 8, 8), (8, 8, 8, 8), (256,), (256,))
 
 

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -549,11 +549,34 @@ class TestGetDaskArray:
         array_out = dt._get_dask_array(s, size_of_chunk=5)
         assert array_out.chunksize[:2] == (5, 5)
 
+    def test_chunk_limit(self):
+        s = Diffraction2D(np.zeros((10, 10, 8, 8)))
+        array_out0 = dt._get_dask_array(s)
+        array_out1 = dt._get_dask_array(s, chunk_limit="25KiB")
+        assert array_out0.chunksize[:2] != array_out1.chunksize[:2]
+
     def test_lazy_input(self):
         s = LazyDiffraction2D(da.zeros((20, 20, 30, 30), chunks=(10, 10, 10, 10)))
         array_out = dt._get_dask_array(s)
         assert s.data.chunks == array_out.chunks
         assert s.data.shape == array_out.shape
+
+
+class TestGetChunking:
+    def test_simple(self):
+        s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
+        chunks = dt._get_chunking(s)
+        assert len(chunks) == 4
+
+    def test_size_of_chunk(self):
+        s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
+        chunks = dt._get_chunking(s, size_of_chunk=16)
+        assert chunks == ((16, 16), (16, 16), (256,), (256,))
+
+    def test_chunk_limit(self):
+        s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
+        chunks = dt._get_chunking(s, chunk_limit="15MiB")
+        assert chunks == ((8, 8, 8, 8), (8, 8, 8, 8), (256,), (256,))
 
 
 class TestAlignSingleFrame:

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -82,7 +82,7 @@ def _expand_iter_dimensions(iter_dask_array, dask_array_dims):
     return iter_dask_array
 
 
-def _get_dask_array(signal, size_of_chunk=32):
+def _get_dask_array(signal, size_of_chunk=8):
     if signal._lazy:
         dask_array = signal.data
     else:


### PR DESCRIPTION
This pull request changes the default navigation dimension chunk size when creating a dask array from a numpy array using `dask_tools._get_dask_array`. This only affects non-lazy signals, as the navigation dimension chunk size is kept for lazy signals.

Based on the results from https://github.com/pyxem/pyxem/issues/684#issuecomment-748479615, I think the current default chunk size of 32 for the navigation dimensions is sub-optimal. This is due to the processing for smaller datasets effectively becoming non-parallel, leading to much slower processing.

This should maybe be set in a smarter way, for example as a function of the dataset size. For example, if the detector dimension is 1024 x 1024, the chunking should probably be set differently than if the detector is 256 x 256. However, since the next release is scheduled in two days, I suggest going with this easier solution.

------------------------

- [x]  Implement using automatic chunking
- [x]  Ready for review