### PR TITLE
fixed mirror template oversight

### DIFF
--- a/pyxem/tests/utils/test_rotation_tempate_match.py
+++ b/pyxem/tests/utils/test_rotation_tempate_match.py
@@ -87,21 +87,21 @@ def test_get_in_plane_rotation_correlation(simulations,itf, norim, nortemp):
 
 def test_match_polar_to_polar_library():
     image = np.ones((123, 50))
-    r = np.linspace(2, 40, 30, dtype=np.uint64)
+    r = np.linspace(2, 40, 30, dtype=np.int64)
     r = np.repeat(r[np.newaxis, ...], 4, axis=0)
-    theta = np.linspace(10, 110, 30, dtype=np.uint64)
+    theta = np.linspace(10, 110, 30, dtype=np.int64)
     theta = np.repeat(theta[np.newaxis, ...], 4, axis=0)
     intensities = np.ones(30, dtype=np.float64)
     intensities = np.repeat(intensities[np.newaxis, ...], 4, axis=0)
     image_norm = 1.0
     template_norms = np.ones(4, dtype=np.float64)
-    cor, angles = iutls._match_polar_to_polar_library(
+    cor, angles, cor_m, angles_m = iutls._match_polar_to_polar_library(
         image, r, theta, intensities, image_norm, template_norms
     )
     assert cor.shape[0] == 4
     assert angles.shape[0] == 4
-    assert cor.dtype == np.float64
-    assert angles.dtype == np.float64
+    assert cor_m.shape[0] == 4
+    assert angles_m.shape[0] == 4
 
 
 @pytest.mark.parametrize(
@@ -113,7 +113,7 @@ def test_match_polar_to_polar_library():
 )
 def test_correlate_library_to_pattern(simulations,norim, nortemp):
     image = np.ones((123, 50))
-    ang, cor = iutls.correlate_library_to_pattern(
+    ang, cor, ang_m, cor_m = iutls.correlate_library_to_pattern(
         image,
         simulations,
         delta_r=2.6,
@@ -123,8 +123,8 @@ def test_correlate_library_to_pattern(simulations,norim, nortemp):
     )
     assert ang.shape[0] == 3
     assert cor.shape[0] == 3
-    assert cor.dtype == np.float64
-    assert ang.dtype == np.float64
+    assert ang_m.shape[0] == 3
+    assert cor_m.shape[0] == 3
 
 
 def test_correlation_at_angle():
@@ -143,7 +143,6 @@ def test_correlation_at_angle():
         image, r, theta, intensities, angles, image_norm, template_norms
     )
     assert cor.shape[0] == 4
-    assert cor.dtype == np.float64
 
 
 def test_get_integrated_templates():
@@ -188,7 +187,6 @@ def test_correlate_library_to_pattern_fast(simulations,norim, nortemp):
         normalize_templates=nortemp,
     )
     assert cor.shape[0] == 3
-    assert cor.dtype == np.float64
 
 
 @pytest.mark.parametrize("intensity_transform_function", [np.sqrt, None])
@@ -217,9 +215,9 @@ def test_mixed_matching_lib_to_polar(nbest):
     polar_sum_norm = 2.3
     integrated_templates = np.ones((5, 51), dtype=np.float64)
     integrated_template_norms = np.sum(integrated_templates, axis=1)
-    r = np.linspace(2, 40, 30, dtype=np.uint64)
+    r = np.linspace(2, 40, 30, dtype=np.int64)
     r = np.repeat(r[np.newaxis, ...], 5, axis=0)
-    theta = np.linspace(10, 110, 30, dtype=np.uint64)
+    theta = np.linspace(10, 110, 30, dtype=np.int64)
     theta = np.repeat(theta[np.newaxis, ...], 5, axis=0)
     intensities = np.ones(30, dtype=np.float64)
     intensities = np.repeat(intensities[np.newaxis, ...], 5, axis=0)
@@ -240,7 +238,7 @@ def test_mixed_matching_lib_to_polar(nbest):
         nbest,
     )
     assert answer.shape[0] == nbest
-    assert answer.shape[1] == 3
+    assert answer.shape[1] == 4
 
 
 @pytest.mark.parametrize(
@@ -252,7 +250,7 @@ def test_mixed_matching_lib_to_polar(nbest):
 )
 def test_correlate_library_to_pattern_partial(simulations,frk, norim, nortemp):
     image = np.ones((123, 50))
-    indx, angs, cor = iutls.correlate_library_to_pattern_partial(
+    indx, angs, cor, angs_m, cors_m = iutls.correlate_library_to_pattern_partial(
         image,
         simulations,
         frac_keep=frk,
@@ -261,8 +259,7 @@ def test_correlate_library_to_pattern_partial(simulations,frk, norim, nortemp):
         normalize_image=norim,
         normalize_templates=nortemp,
     )
-    assert cor.dtype == np.float64
-    assert cor.shape[0] == indx.shape[0] == angs.shape[0]
+    assert cor.shape[0] == indx.shape[0] == angs.shape[0] == angs_m.shape[0] == cors_m.shape[0]
 
 
 @pytest.mark.parametrize(
@@ -274,7 +271,7 @@ def test_correlate_library_to_pattern_partial(simulations,frk, norim, nortemp):
 )
 def test_get_n_best_matches(simulations,nbest, frk, norim, nortemp):
     image = np.ones((123, 50))
-    indx, angs, cor = iutls.get_n_best_matches(
+    indx, angs, cor, signs = iutls.get_n_best_matches(
         image,
         simulations,
         n_best=nbest,
@@ -284,7 +281,6 @@ def test_get_n_best_matches(simulations,nbest, frk, norim, nortemp):
         normalize_image=norim,
         normalize_templates=nortemp,
     )
-    assert cor.dtype == np.float64
     assert cor.shape[0] == indx.shape[0] == angs.shape[0] == nbest
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -552,7 +552,7 @@ def _match_polar_to_polar_template(
     for i in range(n):
         column = polar_image[:, r_template[i]].copy()  # extract column at r for each spot
         match_matrix[:, i] = np.roll(column, -theta_template[i])  # shift column over by theta and put in array
-    correlation = np.dot(match_matrix, intensities)/(image_norm * template_norm)  # all in-plane angles are encoded in the matrix
+    correlation = np.dot(match_matrix, intensities.astype(np.float64)) / (image_norm * template_norm)  # all in-plane angles are encoded in the matrix
     return correlation
 
 

--- a/pyxem/utils/polar_transform_utils.py
+++ b/pyxem/utils/polar_transform_utils.py
@@ -56,9 +56,7 @@ def get_template_polar_coordinates(
         r = r[condition]
         theta = theta[condition]
         intensities = intensities[condition]
-    return ((r / delta_r).astype(np.int32),
-            (theta / delta_theta).astype(np.int32),
-            (intensities).astype(np.float32))
+    return r / delta_r, theta / delta_theta, intensities
 
 
 def get_template_cartesian_coordinates(

--- a/pyxem/utils/polar_transform_utils.py
+++ b/pyxem/utils/polar_transform_utils.py
@@ -56,7 +56,9 @@ def get_template_polar_coordinates(
         r = r[condition]
         theta = theta[condition]
         intensities = intensities[condition]
-    return r / delta_r, theta / delta_theta, intensities
+    return ((r / delta_r).astype(np.int32),
+            (theta / delta_theta).astype(np.int32),
+            (intensities).astype(np.float32))
 
 
 def get_template_cartesian_coordinates(


### PR DESCRIPTION
---
name: Fixed mirror template oversight
about: See issues https://github.com/pyxem/diffsims/issues/157 and https://github.com/pyxem/pyxem/issues/739

---

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
This PR should fix a bug whereby only half of the possible diffraction pattern templates are checked against experimental patterns. Instead of doubling the input template list, I decided I would try to keep the workflow the same as much as possible. The doubling of the templates happens under the hood. The polar templates can be easily "mirrored" by changing the theta coordinate to 359 - theta. Some functions have slightly changed API's however.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] Since return values of some functions may be different, tests may fail as I haven't updated them yet.
- [ ] Faster indexation using cuda kernels will be the topic of another PR
