### PR TITLE
Support CUDA GPU accelerated template matching

### DIFF
--- a/pyxem/tests/utils/test_cuda_utils.py
+++ b/pyxem/tests/utils/test_cuda_utils.py
@@ -1,0 +1,27 @@
+from pyxem.utils import cuda_utils as cutls
+import dask.array as da
+import numpy as np
+import pytest
+from unittest.mock import Mock
+
+
+try:
+    import cupy as cp
+
+    CUPY_INSTALLED = True
+except ImportError:
+    CUPY_INSTALLED = False
+    cp = np
+
+
+skip_cupy = pytest.mark.skipif(not CUPY_INSTALLED, reason="cupy is required")
+
+
+@skip_cupy
+def test_dask_array_to_gpu():
+    cutls.dask_array_to_gpu(da.array([1, 2, 3, 4]))
+
+
+@skip_cupy
+def test_dask_array_from_gpu():
+    cutls.dask_array_from_gpu(da.array(cp.array([1, 2, 3, 4])))

--- a/pyxem/tests/utils/test_polar_transform_utils.py
+++ b/pyxem/tests/utils/test_polar_transform_utils.py
@@ -59,7 +59,7 @@ def test_template_to_polar(mock_simulation, max_r, expected_r):
 )
 def test_template_to_polar_gpu(mock_simulation_gpu, max_r, expected_r):
     r, theta, _ = ptu.get_template_polar_coordinates(mock_simulation_gpu, max_r=max_r)
-    np.testing.assert_allclose(r, expected_r)
+    cp.testing.assert_allclose(r, expected_r)
 
 
 @pytest.mark.parametrize(

--- a/pyxem/tests/utils/test_polar_transform_utils.py
+++ b/pyxem/tests/utils/test_polar_transform_utils.py
@@ -76,18 +76,18 @@ def test_image_to_polar(delta_r, delta_theta, max_r, fdb, db, expected_shape):
 
 
 @pytest.mark.parametrize(
-    "beam_positions, parallelize, expected_shape",
+    "beam_positions, expected_shape",
     [
-        (None, False, (3, 2, 360, 7)),
-        (None, True, (3, 2, 360, 7)),
-        ((2, 3), True, (3, 2, 360, 7)),
-        (np.ones((3, 2, 2)), True, (3, 2, 360, 7)),
+        (None, (3, 2, 360, 7)),
+        (None, (3, 2, 360, 7)),
+        ((2, 3), (3, 2, 360, 7)),
+        (np.ones((3, 2, 2)), (3, 2, 360, 7)),
     ],
 )
-def test_chunk_polar(beam_positions, parallelize, expected_shape):
+def test_chunk_polar(beam_positions, expected_shape):
     chunk = np.ones((3, 2, 10, 7))
     polar_chunk = ptu.chunk_to_polar(
-        chunk, direct_beam_positions=beam_positions, parallelize=parallelize
+        chunk, direct_beam_positions=beam_positions,
     )
     np.testing.assert_array_almost_equal(polar_chunk.shape, expected_shape)
 

--- a/pyxem/tests/utils/test_polar_transform_utils.py
+++ b/pyxem/tests/utils/test_polar_transform_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 try:
     import cupy as cp
+
     CUPY_INSTALLED = True
 except ImportError:
     CUPY_INSTALLED = False
@@ -69,7 +70,9 @@ def test_template_to_polar_gpu(mock_simulation_gpu, max_r, expected_r):
         (90, (7, 7), np.array([]), np.array([])),
     ],
 )
-def test_get_template_cartesian_coordinates(mock_simulation,angle, window, expected_x, expected_y):
+def test_get_template_cartesian_coordinates(
+    mock_simulation, angle, window, expected_x, expected_y
+):
     x, y, _ = ptu.get_template_cartesian_coordinates(
         mock_simulation, in_plane_angle=angle, window_size=window
     )
@@ -86,7 +89,9 @@ def test_get_template_cartesian_coordinates(mock_simulation,angle, window, expec
         (90, (7, 7), cp.array([]), cp.array([])),
     ],
 )
-def test_get_template_cartesian_coordinates_gpu(mock_simulation_gpu,angle, window, expected_x, expected_y):
+def test_get_template_cartesian_coordinates_gpu(
+    mock_simulation_gpu, angle, window, expected_x, expected_y
+):
     x, y, _ = ptu.get_template_cartesian_coordinates(
         mock_simulation_gpu, in_plane_angle=angle, window_size=window
     )
@@ -158,9 +163,7 @@ def test_image_to_polar_gpu(delta_r, delta_theta, max_r, fdb, db, expected_shape
 )
 def test_chunk_polar(center, radius, output_shape, expected_shape):
     chunk = np.ones((3, 2, 10, 7))
-    polar_chunk = ptu._chunk_to_polar(
-        chunk, center, radius, output_shape
-    )
+    polar_chunk = ptu._chunk_to_polar(chunk, center, radius, output_shape)
     np.testing.assert_array_almost_equal(polar_chunk.shape, expected_shape)
 
 
@@ -174,7 +177,5 @@ def test_chunk_polar(center, radius, output_shape, expected_shape):
 )
 def test_chunk_polar_gpu(center, radius, output_shape, expected_shape):
     chunk = cp.ones((3, 2, 10, 7))
-    polar_chunk = ptu._chunk_to_polar(
-        chunk, center, radius, output_shape
-    )
+    polar_chunk = ptu._chunk_to_polar(chunk, center, radius, output_shape)
     cp.testing.assert_array_almost_equal(polar_chunk.shape, expected_shape)

--- a/pyxem/tests/utils/test_rotation_tempate_match.py
+++ b/pyxem/tests/utils/test_rotation_tempate_match.py
@@ -402,3 +402,58 @@ def test_index_dataset_with_template_rotation_gpu(library,sigdim, n_best, frac_k
         chunks=chu,
         target="gpu",
     )
+
+
+def run_index_chunk(di, n_best, fraction):
+    max_r = 4
+    max_theta = 5
+    di.random.seed(1001)
+    data = di.random.random((2, 3, max_theta, max_r))
+    lib_n = 4
+    lib_spots = 5
+    r = di.random.randint(0, max_r, size=(lib_n, lib_spots))
+    theta = di.random.randint(0, max_theta, size=(lib_n, lib_spots))
+    intensities = di.random.random((lib_n, lib_spots))
+    integrated_templates = di.random.random((lib_n, max_r))
+    integrated_template_norms = di.random.random((lib_n))
+    template_norms = di.random.random((lib_n))
+    answer = iutls._index_chunk(
+            data,
+            integrated_templates,
+            integrated_template_norms,
+            r,
+            theta,
+            intensities,
+            template_norms,
+            fraction,
+            n_best,
+            True,
+            )
+    assert answer.shape == (2, 3, n_best, 4)
+
+
+
+@pytest.mark.parametrize(
+    "n_best, fraction",
+    [
+        (1, 1),
+        (2, 0),
+        (3, 0.5),
+    ],
+)
+def test_index_chunk(n_best, fraction):
+    run_index_chunk(np, n_best, fraction)
+
+
+@pytest.mark.parametrize(
+    "n_best, fraction",
+    [
+        (1, 1),
+        (2, 0),
+        (3, 0.5),
+    ],
+)
+@skip_cupy
+def test_index_chunk_gpu(n_best, fraction):
+    import cupy as cp
+    run_index_chunk(cp, n_best, fraction)

--- a/pyxem/tests/utils/test_rotation_tempate_match.py
+++ b/pyxem/tests/utils/test_rotation_tempate_match.py
@@ -368,7 +368,7 @@ def test_prep_image_and_templates(simulations, intensity_transform_function):
         True,
     )
     assert pim.shape[0] == 112
-    assert pim.shape[1] == 15
+    assert pim.shape[1] == 16
     assert r.max() <= 15
     assert t.min() >= 0
     assert t.max() < 112
@@ -393,7 +393,7 @@ def test_prep_image_and_templates_gpu(simulations, intensity_transform_function)
         True,
     )
     assert pim.shape[0] == 112
-    assert pim.shape[1] == 15
+    assert pim.shape[1] == 16
     assert r.max() <= 15
     assert t.min() >= 0
     assert t.max() < 112

--- a/pyxem/tests/utils/test_rotation_tempate_match.py
+++ b/pyxem/tests/utils/test_rotation_tempate_match.py
@@ -564,27 +564,27 @@ def test_fail_index_dataset_with_template_rot(library):
 
 
 @pytest.mark.parametrize(
-    "sigdim, n_best, frac_keep, norim, nort, chu",
+    "sigdim, maxr, n_best, frac_keep, norim, nort, chu",
     [
-        ((2, 3, 4, 5), 1, 1, False, False, {0: "auto", 1: "auto", 2: None, 3: None}),
-        ((2, 3, 4, 5), 2, 1, False, False, {0: "auto", 1: "auto", 2: None, 3: None}),
-        ((2, 3, 4, 5), 3, 0.5, False, False, {0: "auto", 1: "auto", 2: None, 3: None}),
+        ((2, 3, 4, 5), None, 1, 1, False, False, {0: "auto", 1: "auto", 2: None, 3: None}),
+        ((2, 3, 4, 5), 3, 2, 1, False, False, {0: "auto", 1: "auto", 2: None, 3: None}),
+        ((2, 3, 4, 5), 9, 3, 0.5, False, False, {0: "auto", 1: "auto", 2: None, 3: None}),
     ],
 )
 @pytest.mark.slow
 @skip_cupy
 def test_index_dataset_with_template_rotation_gpu(
-    library, sigdim, n_best, frac_keep, norim, nort, chu
+    library, sigdim, maxr, n_best, frac_keep, norim, nort, chu
 ):
     signal = create_dataset(sigdim)
-    result = iutls.index_dataset_with_template_rotation(
+    result, dicto = iutls.index_dataset_with_template_rotation(
         signal,
         library,
         n_best=n_best,
         frac_keep=frac_keep,
         delta_r=0.5,
         delta_theta=36,
-        max_r=None,
+        max_r=maxr,
         intensity_transform_function=np.sqrt,
         normalize_images=norim,
         normalize_templates=nort,
@@ -597,15 +597,22 @@ def run_index_chunk(di, n_best, frac_keep):
     max_r = 4
     max_theta = 5
     di.random.seed(1001)
-    data = di.random.random((2, 3, max_theta, max_r))
+    data = di.random.random((2, 3, 10, 12))
     lib_n = 4
     lib_spots = 5
     r = di.random.randint(0, max_r, size=(lib_n, lib_spots))
     theta = di.random.randint(0, max_theta, size=(lib_n, lib_spots))
     intensities = di.random.random((lib_n, lib_spots))
     integrated_templates = di.random.random((lib_n, max_r))
+    center=(7, 4)
+    max_radius=max_r
+    precision=np.float32
     answer = iutls._index_chunk(
         data,
+        center,
+        max_radius,
+        (5, 4),
+        precision,
         integrated_templates,
         r,
         theta,

--- a/pyxem/tests/utils/test_rotation_tempate_match.py
+++ b/pyxem/tests/utils/test_rotation_tempate_match.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import Mock
 import dask.array as da
 import sys
+from pyxem.utils.cuda_utils import is_cupy_array
 
 
 try:
@@ -117,7 +118,7 @@ def test_match_image_to_template_gpu(mock_sim, rot, dr, dt, nim, nt):
         normalize_image=nim,
         normalize_template=nt,
     )
-    assert abs(a[np.argmax(c)] - rot) % 180 < 2.0
+    assert abs(a[cp.argmax(c)] - rot) % 180 < 2.0
 
 
 @pytest.mark.parametrize(
@@ -378,7 +379,7 @@ def test_prep_image_and_templates(simulations, intensity_transform_function):
 @skip_cupy
 @pytest.mark.parametrize("intensity_transform_function", [cp.sqrt, None])
 def test_prep_image_and_templates_gpu(simulations, intensity_transform_function):
-    image = rp.ones((123, 51))
+    image = cp.ones((123, 51))
     pim, r, t, i = iutls._prepare_image_and_templates(
         image,
         simulations,

--- a/pyxem/utils/cuda_utils.py
+++ b/pyxem/utils/cuda_utils.py
@@ -126,6 +126,8 @@ def _correlate_polar_image_to_library_gpu(
             tmp = 0.0
             # add up all contributions to the correlation from spots
             for spot in range(sim_r.shape[1]):
+                if sim_r[template, spot] == 0:
+                    break
                 tmp += (
                     polar_image[
                         (sim_t[template, spot] + shift) % polar_image.shape[0],

--- a/pyxem/utils/cuda_utils.py
+++ b/pyxem/utils/cuda_utils.py
@@ -1,0 +1,203 @@
+from numba import cuda
+import numpy as np
+import cupy as cp
+import cupyx.scipy.ndimage as ndigpu
+
+
+def warp_polar_gpu(image, center=None, radius=None, output_shape=None, **kwargs):
+    """
+    Function to emulate warp_polar in skimage.transform on the GPU. Not all
+    parameters are supported
+    
+    Parameters
+    ----------
+    image: cupy.ndarray
+        Input image. Only 2-D arrays are accepted.         
+    center: tuple (row, col), optional
+        Point in image that represents the center of the transformation
+        (i.e., the origin in cartesian space). Values can be of type float.
+        If no value is given, the center is assumed to be the center point of the image.
+    radius: float, optional
+        Radius of the circle that bounds the area to be transformed.
+    output_shape: tuple (row, col), optional
+
+    Returns
+    -------
+    polar: cupy.ndarray
+        polar image
+
+    Notes
+    -----
+    Speed gains on the GPU will depend on the size of your problem.
+    On a Tesla V100 a 10x speed up was achieved with a 256x256 image:
+    from 5 ms to 400 microseconds. For a 4000x4000 image a 1000x speed up
+    was achieved: from 180 ms to 400 microseconds. However, this does not
+    count the time to transfer data from the CPU to the GPU and back.
+    """
+    if radius is None:
+        radius = int(np.ceil(np.sqrt((image.shape[0] / 2)**2 + (image.shape[1] / 2)**2)))
+    cx, cy = image.shape[1] // 2, image.shape[0] // 2
+    if center is not None:
+        cx, cy = center
+    if output_shape is None:
+        output_shape = (360, radius)
+    delta_theta = 360 / output_shape[0]
+    delta_r = radius / output_shape[1]
+    t = cp.arange(output_shape[0])
+    r = cp.arange(output_shape[1])
+    R, T = cp.meshgrid(r, t)
+    X = R * delta_r * cp.cos(cp.deg2rad(T * delta_theta)) + cx
+    Y = R * delta_r * cp.sin(cp.deg2rad(T * delta_theta)) + cy
+    coordinates = cp.stack([Y, X])
+    polar = ndigpu.map_coordinates(image, coordinates, order=1)
+    return polar
+
+
+@cuda.jit
+def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, image_norm, template_norms, correlation):
+    """
+    Custom cuda kernel for calculating the correlation for each template
+    in a library at all in-plane angles with a polar image
+
+    Parameters
+    ----------
+    polar_image: 2D numpy.ndarray or cupy.ndarray
+        The image in polar coordinates of shape (theta, R)
+    sim_r: 2D numpy.ndarray or cupy.ndarray
+        The r coordinates of all spots in all templates in the library.
+        Spot number is the column, template is the row
+    sim_t: 2D numpy.ndarray or cupy.ndarray
+        The theta coordinates of all spots in all templates in the library.
+        Spot number is the column, template is the row
+    sim_i: 2D numpy.ndarray or cupy.ndarray
+        The intensity of all spots in all templates in the library.
+        Spot number is the column, template is the row
+    image_norm: float
+        The norm of the image (square root of the sum of all pixel intensities
+        squared)
+    template_norms: 1D numpy.ndarray or cupy.ndarray
+        The norm of each template, same length as number of rows in sim arrays
+    correlation: 2D numpy.ndarray or cupy.ndarray
+        The output correlation matrix of shape (template number, theta), giving
+        the correlation of each template at each in-plane angle
+    """
+    # grid and stride for the output so that each cuda thread deals with more than one element at a time
+    start_template, start_shift = cuda.grid(2)
+    stride_template, stride_shift = cuda.gridsize(2)
+    # don't calculate for grid positions outside
+    if start_template >= sim_r.shape[0] or start_shift >= polar_image.shape[0]:
+        return
+    # loop over all templates
+    for template in range(start_template, sim_r.shape[0], stride_template):
+        # loop over all in-plane angles
+        for shift in range(start_shift, polar_image.shape[0], stride_shift):
+            tmp = 0
+            # add up all contributions to the correlation from spots
+            for spot in range(sim_r.shape[1]):
+                tmp += (polar_image[(sim_t[template, spot] + shift) % polar_image.shape[0],
+                                    sim_r[template, spot]] * sim_i[template, spot])
+            correlation[template, shift] = tmp / (image_norm * template_norms[template])
+
+
+def _index_block_gpu(
+    polar_images,
+    r_templates,
+    theta_templates,
+    intensities_templates,
+    template_norms,
+    n_best,
+    norm_images,
+    threadsperblock=(16, 16),
+):
+    """
+    Helper function to perform indexation on the GPU
+
+    Parameters
+    ----------
+    polar_images: cupy.ndarray (y, x, theta, r)
+        images in a chunk in polar coordinates on the gpu
+    r_templates: cupy.ndarray (T, S)
+        r coordinates of all S spots in all T patterns
+    theta_templates: cupy.ndarray (T, S)
+        theta coordinates of all S spots in all T patterns
+    intensities_templates: cupy.ndarray (T, S)
+        intensities of all S spots in all T templates
+    n_best: int
+        number of best results in the templates to return in the result
+    norm_images: bool
+        whether to normalize the images in the correlation calculation
+    threadsperblock: 2-tuple of ints
+        number of threads in each block (setting for evaluating cuda kernel)
+
+    Returns
+    -------
+    result: numpy.ndarray (y, x, n_best, 4)
+        n_best results for each pattern of the form:
+        (template_index, correlation, theta_shift, sign)
+
+    Notes
+    -----
+    sign in the result is 1 if the positive template is best matched, -1 if
+    the mirrored template is best matched. theta_shift is expressed in pixels
+    of the polar_template, it should still be multiplied by delta_theta to
+    express it in units of degrees.
+    """
+    indexation_result_chunk = cp.empty(
+        (polar_images.shape[0], polar_images.shape[1], n_best, 4), dtype=cp.float32
+    )
+    blockspergrid_x = int(np.ceil(polar_images.shape[2] / threadsperblock[0]))
+    blockspergrid_y = int(np.ceil(polar_images.shape[3] / threadsperblock[1]))
+    blockspergrid = (blockspergrid_x, blockspergrid_y)    
+    pattern_norms = cp.ones(polar_images.shape[:2])
+    if norm_images:
+        pattern_norms = cp.linalg.norm(polar_images, axis = (2, 3))
+    for index in np.ndindex(polar_images.shape[:2]):
+        pattern = polar_images[index]
+        polar_norm = float(pattern_norms[index])
+        correlation = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
+        _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
+            pattern,
+            r_templates,
+            theta_templates,
+            intensities_templates,
+            polar_norm,
+            template_norms,
+            correlation,
+        )
+        correlation_m = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
+        _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
+            pattern,
+            r_templates,
+            (polar_images.shape[0] - theta_templates)%pattern.shape[0],
+            intensities_templates,
+            polar_norm,
+            template_norms,
+            correlation_m,
+        )
+        best_in_plane_corr = cp.amax(correlation, axis=1)
+        best_in_plane_corr_m = cp.amax(correlation_m, axis=1)
+        best_in_plane_shift = cp.argmax(correlation, axis=1)
+        best_in_plane_shift_m = cp.argmax(correlation_m, axis=1)
+        # compare positive and negative templates and combine
+        positive_is_best = best_in_plane_corr > best_in_plane_corr_m
+        best_sign = positive_is_best*1 + np.invert(positive_is_best)*(-1)
+        best_cors = positive_is_best*best_in_plane_corr + np.invert(positive_is_best)*best_in_plane_corr_m
+        best_angles = positive_is_best*best_in_plane_shift + np.invert(positive_is_best)*best_in_plane_shift_m
+        answer = cp.empty((n_best, 4), dtype=cp.float32)
+        if n_best == 1:
+            best_index = cp.argmax(best_cors)
+            answer[0,0] = best_index
+            answer[0,1] = best_cors[best_index]
+            answer[0,2] = best_angles[best_index]
+            answer[0,3] = best_sign[best_index]
+        else:
+            indices_sorted = cp.argsort(-best_cors)
+            n_best_indices = indices_sorted[:n_best]
+            for i in range(n_best):
+                j = n_best_indices[i]
+                answer[i, 0] = j
+                answer[i, 1] = best_cors[j]
+                answer[i, 2] = best_angles[j]
+                answer[i, 3] = best_sign[j]
+        indexation_result_chunk[index] = answer
+    return cp.asnumpy(indexation_result_chunk)

--- a/pyxem/utils/cuda_utils.py
+++ b/pyxem/utils/cuda_utils.py
@@ -3,9 +3,10 @@ import numpy as np
 
 try:
     import cupy as cp
-    CUPY_INSTALLED=True
+
+    CUPY_INSTALLED = True
 except ImportError:
-    CUPY_INSTALLED=False
+    CUPY_INSTALLED = False
 
 
 def dask_array_to_gpu(dask_array):
@@ -39,6 +40,7 @@ def to_numpy(array):
     """
     if is_cupy_array(array):
         import cupy as cp
+
         array = cp.asnumpy(array)
     return array
 
@@ -57,6 +59,7 @@ def get_array_module(array):
     module = np
     try:
         import cupy as cp
+
         if isinstance(array, cp.ndarray):
             module = cp
     except ImportError:
@@ -79,13 +82,16 @@ def is_cupy_array(array):
     """
     try:
         import cupy as cp
+
         return isinstance(array, cp.ndarray)
     except ImportError:
         return False
 
 
 @cuda.jit
-def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, correlation):
+def _correlate_polar_image_to_library_gpu(
+    polar_image, sim_r, sim_t, sim_i, correlation
+):
     """
     Custom cuda kernel for calculating the correlation for each template
     in a library at all in-plane angles with a polar image
@@ -117,9 +123,14 @@ def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, corr
     for template in range(start_template, sim_r.shape[0], stride_template):
         # loop over all in-plane angles
         for shift in range(start_shift, polar_image.shape[0], stride_shift):
-            tmp = 0.
+            tmp = 0.0
             # add up all contributions to the correlation from spots
             for spot in range(sim_r.shape[1]):
-                tmp += (polar_image[(sim_t[template, spot] + shift) % polar_image.shape[0],
-                                    sim_r[template, spot]] * sim_i[template, spot])
+                tmp += (
+                    polar_image[
+                        (sim_t[template, spot] + shift) % polar_image.shape[0],
+                        sim_r[template, spot],
+                    ]
+                    * sim_i[template, spot]
+                )
             correlation[template, shift] = tmp

--- a/pyxem/utils/cuda_utils.py
+++ b/pyxem/utils/cuda_utils.py
@@ -85,7 +85,7 @@ def is_cupy_array(array):
 
 
 @cuda.jit
-def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, image_norm, template_norms, correlation):
+def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, correlation):
     """
     Custom cuda kernel for calculating the correlation for each template
     in a library at all in-plane angles with a polar image
@@ -103,11 +103,6 @@ def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, imag
     sim_i: 2D numpy.ndarray or cupy.ndarray
         The intensity of all spots in all templates in the library.
         Spot number is the column, template is the row
-    image_norm: float
-        The norm of the image (square root of the sum of all pixel intensities
-        squared)
-    template_norms: 1D numpy.ndarray or cupy.ndarray
-        The norm of each template, same length as number of rows in sim arrays
     correlation: 2D numpy.ndarray or cupy.ndarray
         The output correlation matrix of shape (template number, theta), giving
         the correlation of each template at each in-plane angle
@@ -122,146 +117,9 @@ def _correlate_polar_image_to_library_gpu(polar_image, sim_r, sim_t, sim_i, imag
     for template in range(start_template, sim_r.shape[0], stride_template):
         # loop over all in-plane angles
         for shift in range(start_shift, polar_image.shape[0], stride_shift):
-            tmp = 0
+            tmp = 0.
             # add up all contributions to the correlation from spots
             for spot in range(sim_r.shape[1]):
                 tmp += (polar_image[(sim_t[template, spot] + shift) % polar_image.shape[0],
                                     sim_r[template, spot]] * sim_i[template, spot])
-            correlation[template, shift] = tmp / (image_norm * template_norms[template])
-
-
-def _match_polar_to_polar_library_gpu(
-    pattern,
-    r_templates,
-    theta_templates,
-    intensities_templates,
-    polar_norm,
-    template_norms,
-    blockspergrid,
-    threadsperblock,
-):
-    correlation = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
-    _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
-        pattern,
-        r_templates,
-        theta_templates,
-        intensities_templates,
-        polar_norm,
-        template_norms,
-        correlation,
-    )
-    correlation_m = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
-    _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
-        pattern,
-        r_templates,
-        (pattern.shape[0] - theta_templates) % pattern.shape[0],
-        intensities_templates,
-        polar_norm,
-        template_norms,
-        correlation_m,
-    )
-    return correlation, correlation_m
-
-
-def _index_block_gpu(
-    polar_images,
-    r_templates,
-    theta_templates,
-    intensities_templates,
-    template_norms,
-    n_best,
-    norm_images,
-    threadsperblock=(16, 16),
-):
-    """
-    Helper function to perform indexation on the GPU
-
-    Parameters
-    ----------
-    polar_images: cupy.ndarray (y, x, theta, r)
-        images in a chunk in polar coordinates on the gpu
-    r_templates: cupy.ndarray (T, S)
-        r coordinates of all S spots in all T patterns
-    theta_templates: cupy.ndarray (T, S)
-        theta coordinates of all S spots in all T patterns
-    intensities_templates: cupy.ndarray (T, S)
-        intensities of all S spots in all T templates
-    n_best: int
-        number of best results in the templates to return in the result
-    norm_images: bool
-        whether to normalize the images in the correlation calculation
-    threadsperblock: 2-tuple of ints
-        number of threads in each block (setting for evaluating cuda kernel)
-
-    Returns
-    -------
-    result: numpy.ndarray (y, x, n_best, 4)
-        n_best results for each pattern of the form:
-        (template_index, correlation, theta_shift, sign)
-
-    Notes
-    -----
-    sign in the result is 1 if the positive template is best matched, -1 if
-    the mirrored template is best matched. theta_shift is expressed in pixels
-    of the polar_template, it should still be multiplied by delta_theta to
-    express it in units of degrees.
-    """
-    indexation_result_chunk = cp.empty(
-        (polar_images.shape[0], polar_images.shape[1], n_best, 4), dtype=cp.float32
-    )
-    blockspergrid_x = int(np.ceil(polar_images.shape[2] / threadsperblock[0]))
-    blockspergrid_y = int(np.ceil(polar_images.shape[3] / threadsperblock[1]))
-    blockspergrid = (blockspergrid_x, blockspergrid_y)    
-    pattern_norms = cp.ones(polar_images.shape[:2])
-    if norm_images:
-        pattern_norms = cp.linalg.norm(polar_images, axis = (2, 3))
-    for index in np.ndindex(polar_images.shape[:2]):
-        pattern = polar_images[index]
-        polar_norm = float(pattern_norms[index])
-        correlation = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
-        _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
-            pattern,
-            r_templates,
-            theta_templates,
-            intensities_templates,
-            polar_norm,
-            template_norms,
-            correlation,
-        )
-        correlation_m = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
-        _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
-            pattern,
-            r_templates,
-            (polar_images.shape[0] - theta_templates)%pattern.shape[0],
-            intensities_templates,
-            polar_norm,
-            template_norms,
-            correlation_m,
-        )
-        best_in_plane_corr = cp.amax(correlation, axis=1)
-        best_in_plane_corr_m = cp.amax(correlation_m, axis=1)
-        best_in_plane_shift = cp.argmax(correlation, axis=1)
-        best_in_plane_shift_m = cp.argmax(correlation_m, axis=1)
-        # compare positive and negative templates and combine
-        positive_is_best = best_in_plane_corr > best_in_plane_corr_m
-        best_sign = positive_is_best*1 + np.invert(positive_is_best)*(-1)
-        best_cors = positive_is_best*best_in_plane_corr + np.invert(positive_is_best)*best_in_plane_corr_m
-        best_angles = positive_is_best*best_in_plane_shift + np.invert(positive_is_best)*best_in_plane_shift_m
-        answer = cp.empty((n_best, 4), dtype=cp.float32)
-        if n_best == 1:
-            best_index = cp.argmax(best_cors)
-            answer[0,0] = best_index
-            answer[0,1] = best_cors[best_index]
-            answer[0,2] = best_angles[best_index]
-            answer[0,3] = best_sign[best_index]
-        else:
-            indices_sorted = cp.argsort(-best_cors)
-            n_best_indices = indices_sorted[:n_best]
-            for i in range(n_best):
-                j = n_best_indices[i]
-                answer[i, 0] = j
-                answer[i, 1] = best_cors[j]
-                answer[i, 2] = best_angles[j]
-                answer[i, 3] = best_sign[j]
-        indexation_result_chunk[index] = answer
-    return cp.asnumpy(indexation_result_chunk)
+            correlation[template, shift] = tmp

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -596,7 +596,7 @@ def find_beam_center_blur(z, sigma):
         dispatcher = np
     blurred = gaus(z, sigma, mode="wrap")
     center = dispatcher.unravel_index(blurred.argmax(), blurred.shape)[::-1]
-    return np.array(center)
+    return dispatcher.array(center)
 
 
 def find_beam_offset_cross_correlation(z, radius_start, radius_finish):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1072,13 +1072,6 @@ def get_in_plane_rotation_correlation(
         delta_theta=delta_theta,
         max_r=polar_image.shape[1],
     )
-    if intensity_transform_function is not None:
-        intensity = intensity_transform_function(intensity)
-        polar_image = intensity_transform_function(polar_image)
-    if normalize_image:
-        polar_image = polar_image / np.linalg.norm(polar_image)
-    if normalize_template:
-        intensity = intensity / np.linalg.norm(intensity)
     if is_cupy_array(polar_image):
         dispatcher = cp
         r = cp.asarray(r)
@@ -1086,6 +1079,13 @@ def get_in_plane_rotation_correlation(
         intensity = cp.asarray(intensity)
     else:
         dispatcher = np
+    if intensity_transform_function is not None:
+        intensity = intensity_transform_function(intensity)
+        polar_image = intensity_transform_function(polar_image)
+    if normalize_image:
+        polar_image = polar_image / dispatcher.linalg.norm(polar_image)
+    if normalize_template:
+        intensity = intensity / dispatcher.linalg.norm(intensity)
     correlation_array = _match_polar_to_polar_template(
         polar_image,
         r,

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1647,7 +1647,7 @@ def index_dataset_with_template_rotation(
     parallel_workers="auto",
     target="cpu",
     threadsperblock=(16,16),
-    scheduler="processes",
+    scheduler="threads",
 ):
     """
     Index a dataset with template_matching while simultaneously optimizing in-plane rotation angle of the templates

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -945,7 +945,7 @@ def _mixed_matching_lib_to_polar(
         positive_is_best * best_in_plane_corr + negative_is_best * best_in_plane_corr_m
     )
     best_angles = (
-        positive_is_best * best_in_plane_shift + negative_is_best * best_in_plane_shift
+        positive_is_best * best_in_plane_shift + negative_is_best * best_in_plane_shift_m
     )
     if n_best >= best_cors.shape[0]:
         n_best = best_cors.shape[0]
@@ -1727,12 +1727,12 @@ def index_dataset_with_template_rotation(
     # calculate number of workers
     if parallel_workers == "auto":
         parallel_workers = os.cpu_count()
+
+    indexation = indexation.map_blocks(to_numpy)
     with ProgressBar():
         res_index = indexation.compute(
             scheduler=scheduler, num_workers=parallel_workers, optimize_graph=True
         )
-    # in case the data is on the GPU, retrieve it
-    res_index = to_numpy(res_index)
     # wrangle data to (template_index), (orientation), (correlation)
     result = {}
     result["phase_index"] = phase_index[res_index[:, :, :, 0].astype(np.int32)]

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -693,7 +693,7 @@ def _get_best_correlations_and_angles(correlations, correlations_m):
     best_in_plane_shift_m = dispatcher.argmax(correlations_m, axis=1)
     rows = dispatcher.arange(best_in_plane_shift.shape[0])
     best_in_plane_corr = correlations[rows, best_in_plane_shift]
-    best_in_plane_corr_m = correlations[rows, best_in_plane_shift_m]
+    best_in_plane_corr_m = correlations_m[rows, best_in_plane_shift_m]
     return best_in_plane_shift, best_in_plane_shift_m, best_in_plane_corr, best_in_plane_corr_m
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1104,6 +1104,8 @@ def _get_fast_correlation_index(
     normalize_templates,
 ):
     integrated_polar = polar_image.sum(axis=0)
+    rrr = np.arange(integrated_polar.shape[0]) / integrated_polar.shape[0]
+    integrated_polar = integrated_polar * rrr
     integrated_templates = _get_integrated_polar_templates(
         integrated_polar.shape[0],
         r,
@@ -1215,6 +1217,8 @@ def _prefilter_templates(
     template_indexes = dispatcher.arange(r.shape[0], dtype=np.int32)
     if max_keep != r.shape[0]:
         polar_sum = polar_image.sum(axis=0)
+        rrr = np.arange(polar_sum.shape[0]) / polar_sum.shape[0]
+        polar_sum = polar_sum * rrr
         correlations_fast = _match_library_to_polar_fast(
             polar_sum,
             integrated_templates,

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -513,7 +513,7 @@ def _match_polar_to_polar_template(
     dispatcher = get_array_module(polar_image)
     sli = polar_image[:, r_template]
     rows, column_indices = dispatcher.ogrid[: sli.shape[0], : sli.shape[1]]
-    rows = (rows + theta_template[np.newaxis, :]) % polar_image.shape[0]
+    rows = (rows + theta_template[None, :]) % polar_image.shape[0]
     extr = sli[rows, column_indices].astype(intensities.dtype)
     correlation = dispatcher.dot(extr, intensities)
     return correlation

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1689,7 +1689,7 @@ def index_dataset_with_template_rotation(
             template_norms = np.ones(N, dtype=np.float32)
         if target == "gpu":
             import cupy as cp
-            from pyxem.utils.cuda_utils import _index_chunk_gpu
+            from pyxem.utils.cuda_utils import _index_block_gpu
 
             r = cp.asarray(r)
             theta = cp.asarray(theta)
@@ -1697,7 +1697,7 @@ def index_dataset_with_template_rotation(
             template_norms = cp.asarray(template_norms)
 
             indexation = polar_data.map_blocks(
-                _index_chunk_gpu,
+                _index_block_gpu,
                 r,
                 theta,
                 intensities,

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1253,8 +1253,9 @@ def _get_full_correlations(
 ):
     # get a full match on the filtered data - we must branch for CPU/GPU
     if is_cupy_array(polar_image):
-        blockspergrid_x = int(np.ceil(polar_image.shape[0] / threadsperblock[0]))
-        blockspergrid_y = int(np.ceil(polar_image.shape[1] / threadsperblock[1]))
+        # we assume one thread per element
+        blockspergrid_x = int(np.ceil(r.shape[0] / threadsperblock[0]))
+        blockspergrid_y = int(np.ceil(polar_image.shape[0] / threadsperblock[1]))
         blockspergrid = (blockspergrid_x, blockspergrid_y)
         (
             best_in_plane_shift,

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1644,7 +1644,6 @@ def index_dataset_with_template_rotation(
     direct_beam_positions=None,
     normalize_images=True,
     normalize_templates=True,
-    parallelize_polar_conversion=False,
     chunks="auto",
     parallel_workers="auto",
     target="cpu",

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -685,7 +685,7 @@ def _get_best_correlations_and_angles(correlations, correlations_m):
     best_in_plane_shift_m = dispatcher.argmax(correlations_m, axis=1).astype(np.int32)
     rows = dispatcher.arange(correlations.shape[0], dtype=np.int32)
     best_in_plane_corr = correlations[rows, best_in_plane_shift]
-    best_in_plane_corr_m = correlations[rows, best_in_plane_shift_m]
+    best_in_plane_corr_m = correlations_m[rows, best_in_plane_shift_m]
     return (
         best_in_plane_shift,
         best_in_plane_shift_m,

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1023,7 +1023,8 @@ def _mixed_matching_lib_to_polar(
         of the best fitting template, where factor is 1 if the direct template is
         matched and -1 if the mirror template is matched
     """
-    template_indexes = np.arange(theta_templates.shape[0])
+    dispatcher = get_array_module(polar_image)
+    template_indexes = dispatcher.arange(theta_templates.shape[0])
 
     # filter based on azimuthal matches if necessary
     if fraction<1:
@@ -1031,7 +1032,7 @@ def _mixed_matching_lib_to_polar(
         coors = _match_library_to_polar_fast(
             polar_sum, integrated_templates, polar_sum_norm, integrated_template_norms
         )
-        lowest = np.percentile(coors, fraction * 100)
+        lowest = dispatcher.percentile(coors, fraction * 100)
         condition = coors >= lowest
         r_templates_filter = r_templates[condition]
         theta_templates_filter = theta_templates[condition]
@@ -1060,7 +1061,6 @@ def _mixed_matching_lib_to_polar(
                                                 blockspergrid,
                                                 threadsperblock
                                                 )
-        dispatcher = cp
     else:
         correlation, correlation_m = _match_polar_to_polar_library_cpu(
                                                 polar_image,
@@ -1070,7 +1070,6 @@ def _mixed_matching_lib_to_polar(
                                                 polar_norm,
                                                 template_norms_filter,
                                                 )
-        dispatcher = np
 
     # find the best in-plane angles and correlations
     best_in_plane_shift, best_in_plane_shift_m, best_in_plane_corr, best_in_plane_corr_m = _get_best_correlations_and_angles(correlation, correlation_m)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -21,6 +21,7 @@ from itertools import combinations
 from operator import attrgetter
 
 import numpy as np
+import scipy
 
 from pyxem.utils.expt_utils import _cart2polar
 from pyxem.utils.vector_utils import get_rotation_matrix_between_vectors
@@ -29,7 +30,7 @@ from pyxem.utils.cuda_utils import (
     is_cupy_array,
     to_numpy,
     get_array_module,
-    _match_polar_to_polar_library_gpu,
+    _correlate_polar_image_to_library_gpu,
 )
 
 from transforms3d.euler import mat2euler
@@ -39,20 +40,20 @@ from collections import namedtuple
 from pyxem.utils.dask_tools import _get_dask_array
 import os
 from dask.diagnostics import ProgressBar
-from numba import njit, objmode, prange, guvectorize
-from skimage.filters import gaussian
-from skimage.transform import warp_polar
+from numba import njit, float64, float32, int32, prange
 
 from pyxem.utils.polar_transform_utils import (
+    _cartesian_positions_to_polar,
     get_polar_pattern_shape,
     image_to_polar,
     get_template_polar_coordinates,
-    chunk_to_polar,
+    _chunk_to_polar,
 )
 
 try:
     import cupy as cp
     CUPY_INSTALLED=True
+    import cupyx.scipy as spgpu
 except ImportError:
     CUPY_INSTALLED=False
 
@@ -480,56 +481,22 @@ def _simulations_to_arrays(simulations, max_radius=None):
     return positions, intensities
 
 
-def _cartesian_positions_to_polar(x, y, delta_r=1, delta_theta=1):
-    """
-    Convert 2D cartesian image coordinates to polar image coordinates
-
-    Parameters
-    ----------
-    x : 1D numpy.ndarray
-        x coordinates
-    y : 1D numpy.ndarray
-        y coordinates
-    delta_r : float
-        sampling interval in the r direction
-    delta_theta : float
-        sampling interval in the theta direction
-
-    Returns
-    -------
-    r : 1D numpy.ndarray
-        r coordinate or x coordinate in the polar image
-    theta : 1D numpy.ndarray
-        theta coordinate or y coordinate in the polar image
-    """
-    imag = (x) + 1j * (y)
-    r = (np.abs(imag) / delta_r).astype(np.int32)
-    angle = np.rad2deg(np.angle(imag))
-    theta = (np.mod(angle, 360) / delta_theta).astype(np.int32)
-    return r, theta
-
-
+# @njit([float32[:](float32[:,:], int32[:], int32[:]),
+#        float64[:](float64[:,:], int32[:], int32[:])
+#        ])
 @njit
 def _extract_pixel_intensities(image, x, y):
-    experimental = np.zeros(x.shape, dtype=np.float64)
-    for j in prange(x.shape[-1]):
+    experimental = np.zeros(x.shape, dtype=image.dtype)
+    for j in range(x.shape[0]):
         experimental[j] = image[y[j], x[j]]
     return experimental
 
 
-@njit
-def _simple_correlation(
-    image_intensities, template_intensities, image_norm, template_norm
-):
-    """Simple correlation coefficient - sum of products divided by the norms"""
-    return np.sum(np.multiply(image_intensities, template_intensities)) / (
-        image_norm * template_norm
-    )
-
-
-@njit
+# @njit([float32[:](float32[:,:], int32[:], int32[:], float32[:]),
+#        float64[:](float64[:,:], int32[:], int32[:], float64[:])
+#        ])
 def _match_polar_to_polar_template(
-    polar_image, r_template, theta_template, intensities, image_norm, template_norm
+    polar_image, r_template, theta_template, intensities,
 ):
     """
     Correlate a single polar template to a single polar image
@@ -547,37 +514,37 @@ def _match_polar_to_polar_template(
         theta coordinates of diffraction spots in template
     intensities : 1D numpy.ndarray
         intensities of diffraction spots in template
-    image_norm : float
-        norm of the polar image
-    template_norm : float
-        norm of the template
 
     Returns
     -------
     correlation : 1D numpy.ndarray
         correlation index at each in-plane angle position
     """
-    n = intensities.shape[0]  # number of reflections (maximum)
-    match_matrix = np.empty((polar_image.shape[0], n), dtype=np.float64)
-    theta_template = theta_template.astype(np.int64)
-    for i in range(n):
-        column = polar_image[:, r_template[i]].copy()  # extract column at r for each spot
-        match_matrix[:, i] = np.roll(column, -theta_template[i])  # shift column over by theta and put in array
-    correlation = np.dot(match_matrix, intensities.astype(np.float64)) / (image_norm * template_norm)  # all in-plane angles are encoded in the matrix
+    dispatcher = get_array_module(polar_image)
+    sli = polar_image[:,r_template]
+    rows, column_indices = dispatcher.ogrid[:sli.shape[0], :sli.shape[1]]
+    rows = (rows + theta_template[np.newaxis, :]) % polar_image.shape[0]
+    extr = sli[rows, column_indices].astype(intensities.dtype)
+    correlation = dispatcher.dot(extr, intensities)
     return correlation
 
 
+# @njit([
+#     float32[:,:](float32[:,:], int32[:,:], int32[:,:], float32[:,:]),
+#     float64[:,:](float64[:,:], int32[:,:], int32[:,:], float64[:,:])],
+#     parallel=True, nogil=True)
 @njit(parallel=True, nogil=True)
-def _correlate_polar_to_library_cpu(
+def _correlate_polar_to_library_cpu_comparison(
     polar_image,
     r_templates,
     theta_templates,
     intensities_templates,
-    polar_image_norm,
-    template_norms,
     ):
     """
     Correlates a polar pattern to all polar templates at all in_plane angles
+
+    This is a direct copy of the cuda kernel serving for comparison. In the
+    actual CPU calculation, the optimal correlations are directly calculated.
 
     Parameters
     ----------
@@ -589,10 +556,6 @@ def _correlate_polar_to_library_cpu(
         theta-coordinates of diffraction spots in templates.
     intensities_templates : (N, D) 2D numpy.ndarray
         intensities of the spots in each template
-    polar_image_norm : float
-        norm of the polar image
-    template_norms : (N), 1D numpy.ndarray
-        norms of each template
 
     Returns
     -------
@@ -606,39 +569,92 @@ def _correlate_polar_to_library_cpu(
             for spot in range(r_templates.shape[1]):
                 tmp += (polar_image[(theta_templates[template, spot]+shift)%polar_image.shape[0],
                                     r_templates[template, spot]] * intensities_templates[template, spot])
-            correlation[template, shift] = tmp / (polar_image_norm * template_norms[template])
+            correlation[template, shift] = tmp
     return correlation
 
 
-@njit
-def np_apply_along_axis(func1d, axis, arr):
-    """
-    Boilerplate from https://github.com/numba/numba/issues/1269 to gain
-    access to the "axis" kwarg on numpy functions. Only works on 2D arrays
-    """
-    assert arr.ndim == 2
-    assert axis in [0, 1]
-    if axis == 0:
-        result = np.empty(arr.shape[1], dtype=arr.dtype)
-        for i in range(len(result)):
-            result[i] = func1d(arr[:, i])
-    else:
-        result = np.empty(arr.shape[0], dtype=arr.dtype)
-        for i in range(len(result)):
-            result[i] = func1d(arr[i, :])
-    return result
-
-
-def _match_polar_to_polar_library_cpu(
+# @njit([
+#     float32[:,:](float32[:,:], int32[:,:], int32[:,:], float32[:,:]),
+#     float64[:,:](float64[:,:], int32[:,:], int32[:,:], float64[:,:])],
+#     parallel=True, nogil=True)
+@njit(parallel=True, nogil=True)
+def _match_polar_to_library_cpu(
     polar_image,
     r_templates,
     theta_templates,
     intensities_templates,
-    polar_image_norm,
-    template_norms,
+    ):
+    """
+    Correlates a polar pattern to all polar templates and return best angles
+    and correlation values for each template and its mirror image
+
+    Parameters
+    ----------
+    polar_image : (T, R) 2D numpy.ndarray
+        The image converted to polar coordinates
+    r_templates : (N, D) 2D numpy.ndarray
+        r-coordinates of diffraction spots in templates.
+    theta_templates : (N, D) 2D numpy ndarray
+        theta-coordinates of diffraction spots in templates.
+    intensities_templates : (N, D) 2D numpy.ndarray
+        intensities of the spots in each template
+
+    Returns
+    -------
+    best_in_plane_shift : (N) 1D numpy.ndarray
+        Shift for all templates that yields best correlation
+    best_in_plane_shift_m : (N) 1D numpy.ndarray
+        Shift for all mirrored templates that yields best correlation
+    best_in_plane_corr : (N) 1D numpy.ndarray
+        Correlation at best match for each template
+    best_in_plane_corr_m : (N) 1D numpy.ndarray
+        Correlation at best match for each mirrored template
+    """
+    best_in_plane_shift = np.zeros(r_templates.shape[0], dtype=r_templates.dtype)
+    best_in_plane_shift_m = np.zeros(r_templates.shape[0], dtype=r_templates.dtype)
+    best_in_plane_corr = np.zeros(r_templates.shape[0], dtype=polar_image.dtype)
+    best_in_plane_corr_m = np.zeros(r_templates.shape[0], dtype=polar_image.dtype)
+    for template in prange(r_templates.shape[0]):
+        best_shift = 0
+        best_shift_m = 0
+        best_cor = 0.
+        best_cor_m = 0.
+        t = theta_templates[template]
+        r = r_templates[template]
+        i = intensities_templates[template]
+        # can not make prange here, otherwise we get race conditions
+        for shift in range(polar_image.shape[0]):
+            t_r = np.mod(t + shift, polar_image.shape[0])
+            t_m = np.mod(polar_image.shape[0] + shift - t, polar_image.shape[0])
+            cor = np.sum(_extract_pixel_intensities(polar_image, r, t_r) * i)
+            cor_m = np.sum(_extract_pixel_intensities(polar_image, r, t_m) * i)
+            if cor > best_cor:
+                best_shift = shift
+                best_cor = cor
+            if cor_m > best_cor_m:
+                best_shift_m = shift
+                best_cor_m = cor_m
+        best_in_plane_shift[template] = best_shift
+        best_in_plane_corr[template] = best_cor
+        best_in_plane_shift_m[template] = best_shift_m
+        best_in_plane_corr_m[template] = best_cor_m
+    return (best_in_plane_shift,
+            best_in_plane_shift_m,
+            best_in_plane_corr,
+            best_in_plane_corr_m)
+
+
+def _match_polar_to_polar_library_cpu_comparison(
+    polar_image,
+    r_templates,
+    theta_templates,
+    intensities_templates,
 ):
     """
     Correlates a polar pattern to all polar templates on CPU
+
+    Algorithm matches the GPU implementation for comparison. The actual
+    CPU implementation used in _index_chunk directly calculates best angles
 
     Parameters
     ----------
@@ -650,19 +666,17 @@ def _match_polar_to_polar_library_cpu(
         theta-coordinates of diffraction spots in templates.
     intensities_templates : 2D numpy.ndarray
         intensities of the spots in each template
-    polar_image_norm : float
-        norm of the polar image
-    template_norms : 1D numpy.ndarray
-        norms of each template
 
     Returns
     -------
-    correlations : 2D numpy.ndarray
-        The correlation of the image with all the templates (rows) at all in-plane angles
-        (columns)
-    correlations_mirrored : 2D numpy.ndarray
-        The correlation of the image with all the mirrored templates (rows) at all in-plane angles
-        (columns)
+    best_in_plane_shift : (N) 1D numpy.ndarray
+        Shift for all templates that yields best correlation
+    best_in_plane_shift_m : (N) 1D numpy.ndarray
+        Shift for all mirrored templates that yields best correlation
+    best_in_plane_corr : (N) 1D numpy.ndarray
+        Correlation at best match for each template
+    best_in_plane_corr_m : (N) 1D numpy.ndarray
+        Correlation at best match for each mirrored template
 
     Notes
     -----
@@ -670,15 +684,71 @@ def _match_polar_to_polar_library_cpu(
     N is the number of templates and R the number of spots in the template
     with the maximum number of spots
     """
-    correlations = _correlate_polar_to_library_cpu(
-            polar_image, r_templates, theta_templates, intensities_templates,
-            polar_image_norm, template_norms)
-    correlations_mirror = _correlate_polar_to_library_cpu(
+    correlations = _correlate_polar_to_library_cpu_comparison(
+            polar_image, r_templates, theta_templates, intensities_templates)
+    correlations_mirror = _correlate_polar_to_library_cpu_comparison(
             polar_image, r_templates,
             (polar_image.shape[0]-theta_templates)%polar_image.shape[0],
-            intensities_templates,
-            polar_image_norm, template_norms)
-    return correlations, correlations_mirror
+            intensities_templates)
+    return _get_best_correlations_and_angles(correlations, correlations_mirror)
+
+
+def _match_polar_to_polar_library_gpu(
+    pattern,
+    r_templates,
+    theta_templates,
+    intensities_templates,
+    blockspergrid,
+    threadsperblock,
+):
+    """
+    Correlates a polar pattern to all polar templates on GPU
+
+    Parameters
+    ----------
+    polar_image : 2D cupy.ndarray
+        The image converted to polar coordinates
+    r_templates : 2D cupy.ndarray
+        r-coordinates of diffraction spots in templates.
+    theta_templates : 2D cupy ndarray
+        theta-coordinates of diffraction spots in templates.
+    intensities_templates : 2D cupy.ndarray
+        intensities of the spots in each template
+
+    Returns
+    -------
+    best_in_plane_shift : (N) 1D cupy.ndarray
+        Shift for all templates that yields best correlation
+    best_in_plane_shift_m : (N) 1D cupy.ndarray
+        Shift for all mirrored templates that yields best correlation
+    best_in_plane_corr : (N) 1D cupy.ndarray
+        Correlation at best match for each template
+    best_in_plane_corr_m : (N) 1D cupy.ndarray
+        Correlation at best match for each mirrored template
+
+    Notes
+    -----
+    The dimensions of r_templates and theta_templates should be (N, R) where
+    N is the number of templates and R the number of spots in the template
+    with the maximum number of spots
+    """
+    correlation = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
+    _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
+        pattern,
+        r_templates,
+        theta_templates,
+        intensities_templates,
+        correlation,
+    )
+    correlation_m = cp.empty((r_templates.shape[0], pattern.shape[0]), dtype=cp.float32)
+    _correlate_polar_image_to_library_gpu[blockspergrid, threadsperblock](
+        pattern,
+        r_templates,
+        (pattern.shape[0] - theta_templates) % pattern.shape[0],
+        intensities_templates,
+        correlation_m,
+    )
+    return _get_best_correlations_and_angles(correlation, correlation_m)
 
 
 def _get_best_correlations_and_angles(correlations, correlations_m):
@@ -691,179 +761,63 @@ def _get_best_correlations_and_angles(correlations, correlations_m):
     # find the best in-plane angles and correlations
     best_in_plane_shift = dispatcher.argmax(correlations, axis=1)
     best_in_plane_shift_m = dispatcher.argmax(correlations_m, axis=1)
-    rows = dispatcher.arange(best_in_plane_shift.shape[0])
-    best_in_plane_corr = correlations[rows, best_in_plane_shift]
-    best_in_plane_corr_m = correlations_m[rows, best_in_plane_shift_m]
+    best_in_plane_corr = dispatcher.choose(best_in_plane_shift, correlations)
+    best_in_plane_corr_m = dispatcher.choose(best_in_plane_shift_m, correlations_m)
     return best_in_plane_shift, best_in_plane_shift_m, best_in_plane_corr, best_in_plane_corr_m
 
 
-def _match_polar_to_polar_library(
-    polar_image,
-    r_templates,
-    theta_templates,
-    intensities_templates,
-    polar_image_norm,
-    template_norms,
-):
-    """
-    Correlates a polar pattern to all polar templates
-
-    Parameters
-    ----------
-    polar_image : 2D numpy.ndarray
-        The image converted to polar coordinates
-    r_templates : 2D numpy.ndarray
-        r-coordinates of diffraction spots in templates.
-    theta_templates : 2D numpy ndarray
-        theta-coordinates of diffraction spots in templates.
-    intensities_templates : 2D numpy.ndarray
-        intensities of the spots in each template
-    polar_image_norm : float
-        norm of the polar image
-    template_norms : 1D numpy.ndarray
-        norms of each template
-
-    Returns
-    -------
-    correlations : 1D numpy.ndarray
-        the maximum correlation index for each template with the image
-    angles : 1D numpy.ndarray
-        the best fit in-plane angle for each template in degrees
-    correlations_mirrored : 1D numpy.ndarray
-        the maximum correlation index for the mirrored templates
-    angles_mirrored : 1D numpy.ndarray
-        the best fit in-plane angle for each mirrored template
-
-    Notes
-    -----
-    The dimensions of r_templates and theta_templates should be (N, R) where
-    N is the number of templates and R the number of spots in the template
-    with the maximum number of spots
-    """
-    correlations, correlations_mirror = _match_polar_to_polar_library_cpu(
-                                                polar_image,
-                                                r_templates,
-                                                theta_templates,
-                                                intensities_templates,
-                                                polar_image_norm,
-                                                template_norms,
-                                                )
-    best_in_plane_shift, best_in_plane_shift_m, best_in_plane_corr, best_in_plane_corr_m = _get_best_correlations_and_angles(correlations, correlations_mirror)
-    return (best_in_plane_corr,
-            best_in_plane_shift,
-            best_in_plane_corr_m,
-            best_in_plane_shift_m)
-
-
-@njit
-def _get_correlation_at_angle(
-    polar_image,
-    r_templates,
-    theta_templates,
-    intensities,
-    angle_shifts,
-    image_norm,
-    template_norms,
-):
-    """
-    Get the correlation between a polar image and the polar templates at specific in-plane angles
-
-    Parameters
-    ----------
-    polar_image : 2D numpy.ndarray
-        The image converted to polar coordinates
-    r_templates : 2D numpy.ndarray
-        r-coordinates of diffraction spots in templates.
-    theta_templates : 2D numpy ndarray
-        theta-coordinates of diffraction spots in templates.
-    intensities : 2D numpy.ndarray
-        intensities of the spots in each template
-    angle_shifts : 1D numpy.ndarray
-        first euler angle for each template
-    polar_image_norm : float
-        norm of the polar image
-    template_norms : 1D numpy.ndarray
-        norms of each template
-
-    Returns
-    -------
-    correlations : 1D numpy.ndarray
-        the maximum correlation index for each template with the image at the
-        specified angle
-
-    Notes
-    -----
-    The dimensions of r_templates, theta_templates, and intensities should be (N, R) where
-    N is the number of templates and R the number of spots in the template
-    with the maximum number of spots. All coordinates and angle_shifts should
-    be in the same units as the axes of the polar image.
-    """
-    correlations = np.zeros(r_templates.shape[0], dtype=np.float64)
-    for i in range(r_templates.shape[0]):
-        angle = angle_shifts[i]
-        r = r_templates[i]
-        theta = np.mod(theta_templates[i] + angle, polar_image.shape[0])
-        r = r.astype(np.int64)
-        theta = theta.astype(np.int64)
-        intensity = intensities[i]
-        template_norm = template_norms[i]
-        image_intensities = _extract_pixel_intensities(polar_image, r, theta)
-        correlations[i] = _simple_correlation(
-            image_intensities, intensities, image_norm, template_norm
-        )
-    return correlations
-
-
-@njit
 def _get_row_norms(array):
     """Get the norm of all rows in a 2D array"""
-    norms = np.sqrt(np.sum(array ** 2, axis=1))
+    norms = ((array ** 2).sum(axis=1))**0.5
     return norms
 
 
-@njit
 def _norm_rows(array):
     """Normalize all the rows in a 2D array"""
     norms = _get_row_norms(array)
-    array = (array.T / norms).T
-    return array
+    return array / norms[:, None]
 
 
-@njit
-def _get_integrated_polar_templates(r_max, r_templates, intensities_templates):
+def _get_integrated_polar_templates(r_max, r_templates, intensities_templates,
+                                    normalize_templates):
     """
     Get an azimuthally integrated representation of the templates.
 
     Parameters
     ----------
     r_max : float
-        maximum radial distance to consider in pixel units. typically the
+        maximum radial distance to consider in pixel units. Typically the
         radial width of the polar images.
-    r_templates : 2D numpy array
+    r_templates : 2D numpy or cupy ndarray
         r-coordinate of all spots in the templates. Of shape (N, R) where
         N is the number of templates and R is the number of spots in the
         template with the maximum number of spots
-    intensities_templates : 2D numpy array
+    intensities_templates : 2D numpy or cupy ndarray
         intensities in all spots of the templates. Of shape (N, R)
+    normalize_templates : bool
+        Whether to normalize the integrated templates
 
     Returns
     -------
-    integrated_templates : 2D numpy array
+    integrated_templates : 2D numpy or cupy ndarray
         Templates integrated over the azimuthal axis of shape (N, r_max)
     """
-    integrated_templates = np.zeros((r_templates.shape[0], r_max), dtype=np.float32)
-    for i in range(intensities_templates.shape[0]):
-        intensity = intensities_templates[i]
-        r_template = r_templates[i]
-        for j in range(intensity.shape[0]):
-            inten = intensity[j]
-            r_p = r_template[j]
-            integrated_templates[i, r_p] = integrated_templates[i, r_p] + inten
+    dispatcher = get_array_module(intensities_templates)
+    data = intensities_templates.ravel()
+    columns = r_templates.ravel()
+    rows = dispatcher.arange(r_templates.shape[0]).repeat(r_templates.shape[1])
+    out_shape = (r_templates.shape[0], r_max)
+    if is_cupy_array(intensities_templates):
+        integrated_templates = spgpu.sparse.coo_matrix((data, (rows, columns)), shape=out_shape).toarray()
+    else:
+        integrated_templates = scipy.sparse.coo_matrix((data, (rows, columns)), shape=out_shape).toarray()
+    if normalize_templates:
+        integrated_templates = _norm_rows(integrated_templates)
     return integrated_templates
 
 
 def _match_library_to_polar_fast(
-    polar_sum, integrated_templates, polar_norm, template_norms
+    polar_sum, integrated_templates
 ):
     """
     Compare a polar image to azimuthally integrated templates
@@ -876,10 +830,6 @@ def _match_library_to_polar_fast(
     integrated_templates : 2D numpy array or cupy array
         azimuthally integrated templates of shape (N, r_max) with N
         the number of templates and r_max the width of the polar image
-    polar_norm : float
-        norm of the integrated polar template
-    template_norms : 1D numpy array or cupy array
-        norms of all the integrated templates (shape = (N,))
 
     Returns
     -------
@@ -887,8 +837,7 @@ def _match_library_to_polar_fast(
         the correlation between the integrated image and the integrated
         templates. (shape = (N,))
     """
-    coors = (integrated_templates*polar_sum).sum(axis=1)
-    return coors/template_norms/polar_norm
+    return (integrated_templates*polar_sum).sum(axis=1)
 
 
 def _prepare_image_and_templates(
@@ -900,13 +849,15 @@ def _prepare_image_and_templates(
     intensity_transform_function,
     find_direct_beam,
     direct_beam_position,
+    normalize_image,
+    normalize_templates,
 ):
     """
     Prepare a single cartesian coordinate image and a template library for comparison
 
     Parameters
     ----------
-    image : 2D numpy array
+    image : 2D np or cp ndarray
         The diffraction pattern in cartesian coordinates
     simulations : list
         list of diffsims.sims.diffraction_simulation.DiffractionSimulation
@@ -925,20 +876,26 @@ def _prepare_image_and_templates(
     direct_beam_position : 2-tuple of floats
         the (x, y) position of the direct beam in the image to override any
         defaults
-
+    normalize_image : bool
+        Whether to normalize the image
+    normalize_templates : bool
+        Whether to normalize the template intensities
+        
     Returns
     -------
-    polar_image : 2D numpy array
+    polar_image : 2D np or cp ndarray
         The image in polar coordinates
-    r : 2D numpy array
+    indexes : 1D np or cp ndarray
+        The indexes of the original template library that are passed on
+    r : 2D np or cp ndarray
         The r coordinates in the polar image corresponding to template spots.
         shape = (N, R) with N the number of templates and R the number of spots
         contained by the template with the most spots
-    theta : 2D numpy array
+    theta : 2D np or cp ndarray
         The theta coordinates in the polar image corresponding to template spots.
         shape = (N, R) with N the number of templates and R the number of spots
         contained by the template with the most spots
-    intensities :  2D numpy array
+    intensities :  2D np or cp ndarray
         The intensities corresponding to template spots.
         shape = (N, R) with N the number of templates and R the number of spots
         contained by the template with the most spots
@@ -951,32 +908,38 @@ def _prepare_image_and_templates(
         find_direct_beam=find_direct_beam,
         direct_beam_position=direct_beam_position,
     )
+    dispatcher = get_array_module(polar_image)
     max_radius = polar_image.shape[1] * delta_r
     positions, intensities = _simulations_to_arrays(simulations, max_radius=max_radius)
-    if intensity_transform_function is not None:
-        intensities = intensity_transform_function(intensities)
-        polar_image = intensity_transform_function(polar_image)
     r, theta = _cartesian_positions_to_polar(
         positions[:, 0], positions[:, 1], delta_r, delta_theta
     )
-    return (polar_image.astype(np.float32),
-            r.astype(np.int32),
-            theta.astype(np.int32),
-            intensities.astype(np.float32))
+    if is_cupy_array(polar_image):
+        # send data to GPU
+        r = cp.asarray(r)
+        theta = cp.asarray(theta)
+        intensities = cp.asarray(intensities)
+    if intensity_transform_function is not None:
+        intensities = intensity_transform_function(intensities)
+        polar_image = intensity_transform_function(polar_image)
+    if normalize_image:
+        polar_image = polar_image / dispatcher.linalg.norm(polar_image)
+    if normalize_templates:
+        intensities = _norm_rows(intensities)
+    return (polar_image,
+            r,
+            theta,
+            intensities)
 
 
 def _mixed_matching_lib_to_polar(
     polar_image,
-    polar_norm,
-    polar_sum,
-    polar_sum_norm,
     integrated_templates,
-    integrated_template_norms,
     r_templates,
     theta_templates,
     intensities_templates,
-    template_norms,
-    fraction,
+    n_keep,
+    frac_keep,
     n_best,
     threadsperblock=(16, 16),
 ):
@@ -989,28 +952,20 @@ def _mixed_matching_lib_to_polar(
 
     Parameters
     ----------
-    polar_image : 2D numpy array
+    polar_image : 2D ndarray
         image in polar coordinates
-    polar_norm : float
-        norm of the polar image
-    polar_sum : 1D numpy array
-        azimuthally integrated polar image
-    polar_sum_norm : float
-        norm of the azimuthally integrated polar image
-    integrated_templates : 2D numpy array, (N, r_max)
+    integrated_templates : 2D ndarray, (N, r_max)
         azimuthally integrated templates
-    integrated_template_norms : 1D numpy array, (N,)
-        norms of azimuthally integrated templates
-    r_templates : 2D numpy array, (N, R)
+    r_templates : 2D ndarray, (N, R)
         r coordinates of diffraction spots in all N templates
-    theta_templates : 2D numpy array, (N, R)
+    theta_templates : 2D ndarray, (N, R)
         theta coordinates of diffraction spots in all N templates
-    intensities_templates : 2D numpy array, (N, R)
+    intensities_templates : 2D ndarray, (N, R)
         intensities of diffraction spots in all N templates
-    template_norms : 1D numpy array, (N,)
-        Norms of templates
-    fraction : float
-        fraction of N templates to throw away
+    frac_keep : float
+        fraction of templates to pass on to the full indexation
+    n_keep : float
+        number of templates to pass to the full indexation
     n_best : int
         number of solutions to return in decending order of fit
     threadsperblock : 2-tuple of ints
@@ -1024,95 +979,63 @@ def _mixed_matching_lib_to_polar(
         matched and -1 if the mirror template is matched
     """
     dispatcher = get_array_module(polar_image)
-    template_indexes = dispatcher.arange(theta_templates.shape[0])
-
-    # filter based on azimuthal matches if necessary
-    if fraction<1:
-        # match azimuthally integrated templates and patterns
-        coors = _match_library_to_polar_fast(
-            polar_sum, integrated_templates, polar_sum_norm, integrated_template_norms
-        )
-        lowest = dispatcher.percentile(coors, fraction * 100)
-        condition = coors >= lowest
-        r_templates_filter = r_templates[condition]
-        theta_templates_filter = theta_templates[condition]
-        intensities_templates_filter = intensities_templates[condition]
-        template_indexes_filter = template_indexes[condition]
-        template_norms_filter = template_norms[condition]
-    else:
-        r_templates_filter = r_templates
-        theta_templates_filter = theta_templates
-        intensities_templates_filter = intensities_templates
-        template_indexes_filter = template_indexes
-        template_norms_filter = template_norms
-
+    # b
+    (template_indexes,
+     r_templates,
+     theta_templates,
+     intensities_templates) = _prefilter_templates(polar_image, r_templates, theta_templates, intensities_templates, integrated_templates, frac_keep, n_keep)
     # get a full match on the filtered data - we must branch for CPU/GPU
-    if is_cupy_array(polar_image):
-        blockspergrid_x = int(np.ceil(polar_image.shape[0] / threadsperblock[0]))
-        blockspergrid_y = int(np.ceil(polar_image.shape[1] / threadsperblock[1]))
-        blockspergrid = (blockspergrid_x, blockspergrid_y)    
-        correlation, correlation_m = _match_polar_to_polar_library_gpu(
-                                                polar_image,
-                                                r_templates_filter,
-                                                theta_templates_filter,
-                                                intensities_templates_filter,
-                                                polar_norm,
-                                                template_norms_filter,
-                                                blockspergrid,
-                                                threadsperblock
-                                                )
-    else:
-        correlation, correlation_m = _match_polar_to_polar_library_cpu(
-                                                polar_image,
-                                                r_templates_filter,
-                                                theta_templates_filter,
-                                                intensities_templates_filter,
-                                                polar_norm,
-                                                template_norms_filter,
-                                                )
-
-    # find the best in-plane angles and correlations
-    best_in_plane_shift, best_in_plane_shift_m, best_in_plane_corr, best_in_plane_corr_m = _get_best_correlations_and_angles(correlation, correlation_m)
+    (best_in_plane_shift,
+     best_in_plane_corr,
+     best_in_plane_shift_m,
+     best_in_plane_corr_m) = _get_full_correlations(
+             polar_image,
+             r_templates,
+             theta_templates,
+             intensities_templates,
+             threadsperblock = threadsperblock,
+             )
     # compare positive and negative templates and combine
-    positive_is_best = best_in_plane_corr > best_in_plane_corr_m
-    negative_is_best = dispatcher.invert(positive_is_best)
-    best_sign = positive_is_best*1 + negative_is_best*(-1)
-    best_cors = positive_is_best*best_in_plane_corr + negative_is_best*best_in_plane_corr_m
-    best_angles = positive_is_best*best_in_plane_shift + negative_is_best*best_in_plane_shift
-    answer = dispatcher.empty((n_best, 4), dtype=np.float32)
+    positive_is_best = best_in_plane_corr >= best_in_plane_corr_m
+    negative_is_best = ~positive_is_best
+    # multiplication method is faster than dispatcher.choose
+    best_sign = positive_is_best * 1 + negative_is_best * (-1)
+    best_cors = positive_is_best * best_in_plane_corr + negative_is_best * best_in_plane_corr_m
+    best_angles = positive_is_best * best_in_plane_shift + negative_is_best * best_in_plane_shift
     if n_best >= best_cors.shape[0]:
-        n_best = best_cors.shape[0] - 1  #otherwise argpartition below doesn't work
+        n_best = best_cors.shape[0]
+    if n_best < 1:
+        nbest = 1
+    answer = dispatcher.empty((n_best, 4), dtype=np.float32)
     if n_best == 1:
         max_index_filter = dispatcher.argmax(best_cors)
         max_cor = best_cors[max_index_filter]
         max_angle = best_angles[max_index_filter]
-        max_index = template_indexes_filter[max_index_filter]
+        max_index = template_indexes[max_index_filter]
         max_sign = best_sign[max_index_filter]
         answer[0] = dispatcher.array((max_index, max_cor, max_angle, max_sign))
     else:
         # a partial sort
-        indices_nbest = dispatcher.argpartition(-best_cors, n_best)[:n_best]
+        indices_nbest = dispatcher.argpartition(-best_cors, n_best - 1)[:n_best]
         nbest_cors = best_cors[indices_nbest]
         # a full sort on this subset
         indices_sorted = dispatcher.argsort(-nbest_cors)
         n_best_indices = indices_nbest[indices_sorted]
-        for j, i in enumerate(n_best_indices):
-            answer[j, 0] = template_indexes_filter[i]
-            answer[j, 1] = best_cors[i]
-            answer[j, 2] = best_angles[i]
-            answer[j, 3] = best_sign[i]
+        answer[:, 0] = template_indexes[n_best_indices]
+        answer[:, 1] = best_cors[n_best_indices]
+        answer[:, 2] = best_angles[n_best_indices]
+        answer[:, 3] = best_sign[n_best_indices]
     return answer
 
 
 def _index_chunk(
     polar_images,
     integrated_templates,
-    integrated_template_norms,
     r_templates,
     theta_templates,
     intensities_templates,
-    template_norms,
-    fraction,
+    n_keep,
+    frac_keep,
     n_best,
     norm_images,
     threadsperblock=(16, 16),
@@ -1120,36 +1043,25 @@ def _index_chunk(
     dispatcher = get_array_module(polar_images)
     # prepare an empty results chunk
     indexation_result_chunk = dispatcher.empty(
-        (polar_images.shape[0], polar_images.shape[1], n_best, 4), dtype=dispatcher.float32
+        (polar_images.shape[0], polar_images.shape[1], n_best, 4), dtype=polar_images.dtype
     )
-    # norm of the images
+    # norm the images if necessary
     if norm_images:
-        pattern_norms = dispatcher.linalg.norm(polar_images, axis = (2, 3))
-    else:
-        pattern_norms = dispatcher.ones(polar_images.shape[:2])
+        pattern_norms = dispatcher.linalg.norm(polar_images, axis=(2, 3))
+        polar_images = polar_images / pattern_norms[:, :, np.newaxis, np.newaxis]
 
     for index in np.ndindex(polar_images.shape[:2]):
-        pattern = polar_images[index]
-        integrated_pattern = pattern.sum(axis=0)
-        polar_norm = float(pattern_norms[index])
-        integrated_pattern_norm = dispatcher.linalg.norm(integrated_pattern)
-
-        indexresult = _mixed_matching_lib_to_polar(
-            pattern,
-            polar_norm,
-            integrated_pattern,
-            integrated_pattern_norm,
+        indexation_result_chunk[index] = _mixed_matching_lib_to_polar(
+            polar_images[index],
             integrated_templates,
-            integrated_template_norms,
             r_templates,
             theta_templates,
             intensities_templates,
-            template_norms,
-            fraction,
+            n_keep,
+            frac_keep,
             n_best,
             threadsperblock,
         )
-        indexation_result_chunk[index] = indexresult
     return indexation_result_chunk
 
 
@@ -1210,109 +1122,44 @@ def get_in_plane_rotation_correlation(
         find_direct_beam=find_direct_beam,
         direct_beam_position=direct_beam_position,
     )
-    r, theta, intensities = get_template_polar_coordinates(
+    r, theta, intensity = get_template_polar_coordinates(
         simulation,
         in_plane_angle=0.0,
         delta_r=delta_r,
         delta_theta=delta_theta,
-        max_r=max_r,
+        max_r=polar_image.shape[1],
     )
-    r = np.rint(r).astype(np.int32)
-    theta = np.rint(theta).astype(np.int32)
-    condition = (r > 0) & (r < polar_image.shape[1])
-    r = r[condition]
-    theta = theta[condition]
-    intensity = intensities[condition]
     if intensity_transform_function is not None:
         intensity = intensity_transform_function(intensity)
         polar_image = intensity_transform_function(polar_image)
-    image_norm = 1.0 if not normalize_image else np.linalg.norm(polar_image)
-    template_norm = 1.0 if not normalize_template else np.linalg.norm(intensity)
+    if normalize_image:
+        polar_image = polar_image / np.linalg.norm(polar_image)
+    if normalize_template:
+        intensity = intensity / np.linalg.norm(intensity)
     correlation_array = _match_polar_to_polar_template(
-        polar_image, r, theta, intensity, image_norm, template_norm
+        polar_image, r, theta, intensity,
     )
     angle_array = np.arange(correlation_array.shape[0]) * delta_theta
     return angle_array, correlation_array
 
 
-def correlate_library_to_pattern(
-    image,
-    simulations,
-    delta_r=1,
-    delta_theta=1,
-    max_r=None,
-    intensity_transform_function=None,
-    find_direct_beam=False,
-    direct_beam_position=None,
-    normalize_image=True,
-    normalize_templates=True,
-):
-    """
-    Get the best angle and associated correlation values, as well as the correlation with the inverted templates
-
-    Parameters
-    ----------
-    image : 2D numpy.ndarray
-        The image of the diffraction pattern
-    simulations : list of diffsims.sims.diffraction_simulation.DiffractionSimulation
-        The diffraction pattern simulation
-    delta_r : float, optional
-        The sampling interval of the radial coordinate in pixels
-    delta_theta : float, optional
-        The sampling interval of the azimuthal coordinate in degrees
-    max_r : float, optional
-        Maximum radius to consider in pixel units. By default it is the
-        distance from the center of the image to a corner
-    intensity_transform_function : Callable, optional
-        Function to apply to both image and template intensities on an
-        element by element basis prior to comparison
-    find_direct_beam : bool, optional
-        Whether to optimize the direct beam, otherwise the center of the image
-        is chosen
-    direct_beam_position : 2-tuple of floats, optional
-        (x, y) coordinate of the direct beam in pixel units. Overrides other
-        settings for finding the direct beam
-    normalize_image : bool, optional
-        normalize the image to calculate the correlation coefficient
-    normalize_templates : bool, optional
-        normalize the templates to calculate the correlation coefficient
-
-    Returns
-    -------
-    angles : 1D numpy.ndarray
-        best fit in-plane angle for each template of length N
-    correlations : 1D numpy.ndarray
-        best correlation for each template of length N
-    angles_mirrored : 1D numpy.ndarray
-        best fit in-plane angle for each mirrored template of length N
-    correlations_mirrored : 1D numpy.ndarray
-        best correlation for each mirrored template of length N
-
-    Notes
-    -----
-    The mirrored templates correspond to inverted euler angle coordinates
-    (0, -Phi, -phi2)
-    """
-    polar_image, r, theta, intensities = _prepare_image_and_templates(
-        image,
-        simulations,
-        delta_r,
-        delta_theta,
-        max_r,
-        intensity_transform_function,
-        find_direct_beam,
-        direct_beam_position,
+def _get_fast_correlation_index(
+        polar_image,
+        r,
+        intensities,
+        normalize_image,
+        normalize_templates,
+        ):
+    integrated_polar = polar_image.sum(axis=0)
+    integrated_templates = _get_integrated_polar_templates(
+        integrated_polar.shape[0], r, intensities, normalize_templates,
     )
-    polar_image_norm = 1 if not normalize_image else np.linalg.norm(polar_image)
-    template_norms = (
-        np.ones(r.shape[0], dtype=np.float64)
-        if not normalize_templates
-        else _get_row_norms(intensities)
+    if normalize_image:
+        integrated_polar = integrated_polar / np.linalg.norm(integrated_polar)
+    correlations = _match_library_to_polar_fast(
+        integrated_polar, integrated_templates,
     )
-    correlations, angles, correlations_mirrored, angles_mirrored = _match_polar_to_polar_library(
-        polar_image, r, theta, intensities, polar_image_norm, template_norms
-    )
-    return angles, correlations, angles_mirrored, correlations_mirrored
+    return correlations
 
 
 def correlate_library_to_pattern_fast(
@@ -1376,36 +1223,109 @@ def correlate_library_to_pattern_fast(
         intensity_transform_function,
         find_direct_beam,
         direct_beam_position,
+        False,  # it is not necessary to normalize these here
+        False,
     )
-    integrated_polar = polar_image.sum(axis=0)
-    integrated_templates = _get_integrated_polar_templates(
-        integrated_polar.shape[0], r, intensities
-    )
-    polar_norm = 1 if not normalize_image else np.linalg.norm(integrated_polar)
-    template_norms = (
-        np.ones(r.shape[0], dtype=np.float64)
-        if not normalize_templates
-        else _get_row_norms(integrated_templates)
-    )
-    correlations = _match_library_to_polar_fast(
-        integrated_polar, integrated_templates, polar_norm, template_norms
-    )
-    return correlations
+    return _get_fast_correlation_index(
+            polar_image,
+            r,
+            intensities,
+            normalize_image,
+            normalize_templates
+            )
 
 
-def correlate_library_to_pattern_partial(
+def _get_max_n(N, n_keep, frac_keep):
+    """
+    Determine the number of templates to allow through
+    """
+    max_keep = N
+    if frac_keep is not None:
+        max_keep = max(round(frac_keep * N), 1)
+    # n_keep overrides fraction
+    if n_keep is not None:
+        max_keep = max(n_keep, 1)
+    return int(min(max_keep, N))
+
+
+def _prefilter_templates(
+        polar_image,
+        r,
+        theta,
+        intensities,
+        integrated_templates,
+        frac_keep,
+        n_keep,
+        ):
+    dispatcher = get_array_module(polar_image)
+    max_keep = _get_max_n(r.shape[0], n_keep, frac_keep)
+    template_indexes = dispatcher.arange(r.shape[0], dtype=np.int32)
+    if max_keep != r.shape[0]:
+        polar_sum = polar_image.sum(axis=0)
+        correlations_fast = _match_library_to_polar_fast(
+            polar_sum, integrated_templates,
+        )
+        sorted_cor_indx = dispatcher.argsort(-correlations_fast)[:max_keep]
+        r = r[sorted_cor_indx]
+        theta = theta[sorted_cor_indx]
+        intensities = intensities[sorted_cor_indx]
+        template_indexes = template_indexes[sorted_cor_indx]
+    return template_indexes, r, theta, intensities
+
+
+def _get_full_correlations(
+        polar_image,
+        r,
+        theta,
+        intensities,
+        threadsperblock=(16,16),
+        ):
+    # get a full match on the filtered data - we must branch for CPU/GPU
+    if is_cupy_array(polar_image):
+        blockspergrid_x = int(np.ceil(polar_image.shape[0] / threadsperblock[0]))
+        blockspergrid_y = int(np.ceil(polar_image.shape[1] / threadsperblock[1]))
+        blockspergrid = (blockspergrid_x, blockspergrid_y)
+        (best_in_plane_shift,
+         best_in_plane_shift_m,
+         best_in_plane_corr,
+         best_in_plane_corr_m) = _match_polar_to_polar_library_gpu(
+                                                polar_image,
+                                                r,
+                                                theta,
+                                                intensities,
+                                                blockspergrid,
+                                                threadsperblock
+                                                )
+    else:
+        (best_in_plane_shift,
+         best_in_plane_shift_m, 
+         best_in_plane_corr,
+         best_in_plane_corr_m) = _match_polar_to_library_cpu(
+                                                polar_image,
+                                                r,
+                                                theta,
+                                                intensities,
+                                                )
+    return (best_in_plane_shift,
+            best_in_plane_corr,
+            best_in_plane_shift_m,
+            best_in_plane_corr_m)
+
+
+def correlate_library_to_pattern(
     image,
     simulations,
-    n_keep=100,
-    frac_keep=None,
-    delta_r=1,
-    delta_theta=1,
+    frac_keep=1.,
+    n_keep=None,
+    delta_r=1.,
+    delta_theta=1.,
     max_r=None,
     intensity_transform_function=None,
     find_direct_beam=False,
     direct_beam_position=None,
     normalize_image=True,
     normalize_templates=True,
+    threadsperblock=(16, 16),
 ):
     """
     Get the best angle and associated correlation values, as well as the correlation with the inverted templates
@@ -1416,11 +1336,12 @@ def correlate_library_to_pattern_partial(
         The image of the diffraction pattern
     simulations : list of diffsims.sims.diffraction_simulation.DiffractionSimulation
         The diffraction pattern simulation
-    n_keep : int
-        Number of templates to do a full matching on
     frac_keep : float
-        Fraction (between 0-1) of templates to do a full matching on. When set
-        n_keep will be ignored
+        Fraction (between 0-1) of templates to do a full matching on. By default
+        all patterns are fully matched.
+    n_keep : int
+        Number of templates to do a full matching on. When set frac_keep will be 
+        ignored
     delta_r : float, optional
         The sampling interval of the radial coordinate in pixels
     delta_theta : float, optional
@@ -1441,6 +1362,9 @@ def correlate_library_to_pattern_partial(
         normalize the image to calculate the correlation coefficient
     normalize_templates : bool, optional
         normalize the templates to calculate the correlation coefficient
+    threadsperblock : 2-Tuple of int
+        Determines how the code is executed on GPU, only relevant if
+        the polar image is a cupy array.
 
     Returns
     -------
@@ -1469,71 +1393,51 @@ def correlate_library_to_pattern_partial(
         intensity_transform_function,
         find_direct_beam,
         direct_beam_position,
+        normalize_image,
+        normalize_templates,
     )
-    N = r.shape[0]
-    fraction = max((N - abs(n_keep)) / N, 0.0)
-    if frac_keep is not None:
-        fraction = max(1.0 - abs(frac_keep), 0.0)
-    # fast matching
-    integrated_polar = polar_image.sum(axis=0)
     integrated_templates = _get_integrated_polar_templates(
-        integrated_polar.shape[0], r, intensities
+        polar_image.shape[1], r, intensities, normalize_templates,
     )
-    polar_norm = 1 if not normalize_image else np.linalg.norm(integrated_polar)
-    template_norms = (
-        np.ones(N, dtype=np.float64)
-        if not normalize_templates
-        else _get_row_norms(integrated_templates)
-    )
-    correlations_fast = _match_library_to_polar_fast(
-        integrated_polar, integrated_templates, polar_norm, template_norms
-    )
-    # full matching
-    template_indexes = np.arange(N)
-    lowest = np.percentile(correlations_fast, fraction * 100)
-    condition = correlations_fast >= lowest
-    r_templates_filter = r[condition]
-    theta_templates_filter = theta[condition]
-    intensities_templates_filter = intensities[condition]
-    template_indexes_filter = template_indexes[condition]
-    polar_image_norm = 1 if not normalize_image else np.linalg.norm(polar_image)
-    template_norms = (
-        np.ones(intensities_templates_filter.shape[0], dtype=np.float64)
-        if not normalize_templates
-        else _get_row_norms(intensities_templates_filter)
-    )
-    full_cors, full_angles, full_cors_mirrored, full_angles_mirrored = _match_polar_to_polar_library(
-        polar_image,
-        r_templates_filter,
-        theta_templates_filter,
-        intensities_templates_filter,
-        polar_image_norm,
-        template_norms,
-    )
-    return template_indexes_filter, full_angles, full_cors, full_angles_mirrored, full_cors_mirrored
+    indexes, r, theta, intensities = _prefilter_templates(
+            polar_image, r, theta, intensities, integrated_templates,
+            frac_keep, n_keep)
+    angles, cor, angles_m, cor_m = _get_full_correlations(
+                    polar_image,
+                    r,
+                    theta,
+                    intensities,
+                    threadsperblock,
+                    )
+    return (indexes,
+            (angles * delta_theta).astype(polar_image.dtype),
+            cor,
+            (angles_m * delta_theta).astype(polar_image.dtype),
+            cor_m)
 
 
 def get_n_best_matches(
     image,
     simulations,
     n_best=1,
-    n_keep=100,
-    frac_keep=None,
-    delta_r=1,
-    delta_theta=1,
+    frac_keep=1.,
+    n_keep=None,
+    delta_r=1.,
+    delta_theta=1.,
     max_r=None,
     intensity_transform_function=None,
     find_direct_beam=False,
     direct_beam_position=None,
     normalize_image=True,
     normalize_templates=True,
+    threadsperblock=(16, 16)
 ):
     """
     Get the n templates best matching an image in descending order
 
     Parameters
     ----------
-    image : 2D numpy.ndarray
+    image : 2D numpy or cupy ndarray
         The image of the diffraction pattern
     simulations : list of diffsims.sims.diffraction_simulation.DiffractionSimulation
         The diffraction pattern simulation
@@ -1564,16 +1468,19 @@ def get_n_best_matches(
         normalize the image to calculate the correlation coefficient
     normalize_templates : bool, optional
         normalize the templates to calculate the correlation coefficient
+    threadsperblock : 2-Tuple of int
+        number of threads per block in the cuda matching operation. Only
+        important when using a gpu.
 
     Returns
     -------
-    indexes : 1D numpy.ndarray
+    indexes : 1D numpy or cupy ndarray
         indexes of best fit templates
-    angles : 1D numpy.ndarray
+    angles : 1D numpy or cupy ndarray
         corresponding best fit in-plane angles
-    correlations : 1D numpy.ndarray
+    correlations : 1D numpy or cupy ndarray
         corresponding correlation values
-    signs : 1D numpy.ndarray
+    signs : 1D numpy or cupy ndarray
         1 if the positive template (0, Phi, phi2) is best matched, -1 if
         the negative template (0, -Phi, -phi2) is best matched
     """
@@ -1586,44 +1493,24 @@ def get_n_best_matches(
         intensity_transform_function,
         find_direct_beam,
         direct_beam_position,
+        normalize_image,
+        normalize_templates,
     )
-    N = r.shape[0]
-    fraction = max((N - abs(n_keep)) / N, 0.0)
-    if frac_keep is not None:
-        fraction = max(1.0 - abs(frac_keep), 0.0)
-    polar_norm = 1.0 if not normalize_image else np.linalg.norm(polar_image)
-    integrated_polar = polar_image.sum(axis=0)
-    polar_sum_norm = 1.0 if not normalize_image else np.linalg.norm(integrated_polar)
-    integrated_templates = _get_integrated_polar_templates(
-        integrated_polar.shape[0], r, intensities
-    )
-    integrated_template_norms = (
-        np.ones(N, dtype=np.float64)
-        if not normalize_templates
-        else _get_row_norms(integrated_templates)
-    )
-    template_norms = (
-        np.ones(N, dtype=np.float64)
-        if not normalize_templates
-        else _get_row_norms(intensities)
-    )
+    integrated_templates = _get_integrated_polar_templates(polar_image.shape[1], r, intensities, normalize_templates)
     answer = _mixed_matching_lib_to_polar(
         polar_image,
-        polar_norm,
-        integrated_polar,
-        polar_sum_norm,
         integrated_templates,
-        integrated_template_norms,
         r,
         theta,
         intensities,
-        template_norms,
-        fraction,
+        n_keep,
+        frac_keep,
         n_best,
+        threadsperblock,
     )
     indices = answer[:, 0].astype(np.int32)
     cors = answer[:, 1]
-    angles = answer[:, 2]
+    angles = (answer[:, 2] * delta_theta).astype(polar_image.dtype)
     sign = answer[:,3]
     return indices, angles, cors, sign
 
@@ -1633,14 +1520,12 @@ def index_dataset_with_template_rotation(
     library,
     phases=None,
     n_best=1,
-    n_keep=100,
-    frac_keep=None,
+    frac_keep=1.,
+    n_keep=None,
     delta_r=1.0,
     delta_theta=1.0,
     max_r=None,
     intensity_transform_function=None,
-    find_direct_beam=False,
-    direct_beam_positions=None,
     normalize_images=True,
     normalize_templates=True,
     chunks="auto",
@@ -1648,6 +1533,7 @@ def index_dataset_with_template_rotation(
     target="cpu",
     threadsperblock=(16,16),
     scheduler="threads",
+    precision=np.float64,
 ):
     """
     Index a dataset with template_matching while simultaneously optimizing in-plane rotation angle of the templates
@@ -1655,83 +1541,91 @@ def index_dataset_with_template_rotation(
     Parameters
     ----------
     signal : hyperspy.signals.Signal2D
-        The 4D-STEM dataset
+        The 4D-STEM dataset.
     library : diffsims.libraries.diffraction_library.DiffractionLibrary
-        The library of simulated diffraction patterns
+        The library of simulated diffraction patterns.
     phases : list, optional
         Names of phases in the library to do an indexation for. By default this is
         all phases in the library.
     n_best : int, optional
-        Number of best solutions to return, in order of descending match
-    n_keep : int, optional
-        Number of templates to do a full matching on in the second matching step
+        Number of best solutions to return, in order of descending match.
     frac_keep : float, optional
-        Fraction (between 0-1) of templates to do a full matching on. When set
-        n_keep will be ignored
+        Fraction (between 0-1) of templates to do a full matching on. By default
+        all templates will be fully matched. See notes for details.
+    n_keep : int, optional
+        Number of templates to do a full matching on. Overrides frac_keep.
     delta_r : float, optional
-        The sampling interval of the radial coordinate in pixels
+        The sampling interval of the radial coordinate in pixels.
     delta_theta : float, optional
-        The sampling interval of the azimuthal coordinate in degrees
+        The sampling interval of the azimuthal coordinate in degrees. This will
+        determine the maximum accuracy of the in-plane correlation.
     max_r : float, optional
         Maximum radius to consider in pixel units. By default it is the
-        distance from the center of the image to a corner
+        distance from the center of the patterns to a corner of the image.
     intensity_transform_function : Callable, optional
         Function to apply to both image and template intensities on an
         element by element basis prior to comparison. Note that when using the
-        gpu, the function should be gpu compatible.
-    find_direct_beam : bool, optional
-        Whether to optimize the direct beam, otherwise the center of the image
-        is chosen
-    direct_beam_positions : 2-tuple of floats or 3D numpy array of shape (scan_x, scan_y, 2), optional
-        (x, y) coordinates of the direct beam in pixel units. Overrides other
-        settings for finding the direct beam
+        gpu, the function must be gpu compatible.
     normalize_images : bool, optional
-        normalize the images to calculate the correlation coefficient
+        Normalize the images in the correlation coefficient calculation
     normalize_templates : bool, optional
-        normalize the templates to calculate the correlation coefficient
+        Normalize the templates in the correlation coefficient calculation
     chunks : string or 4-tuple, optional
-        internally the work is done on dask datasets and this parameter determines
+        Internally the work is done on dask arrays and this parameter determines
         the chunking. If set to None then no re-chunking will happen if the dataset
         was loaded lazily. If set to "auto" then dask attempts to find the optimal
         chunk size.
     parallel_workers: int, optional
-        the number of workers to use in parallel. If set to "auto", the number
+        The number of workers to use in parallel. If set to "auto", the number
         will be determined from os.cpu_count()
     target: string, optional
         Use "cpu" or "gpu". If "gpu" is selected, the majority of the calculation
-        intensive work will be performed on the GPU.
+        intensive work will be performed on the CUDA enabled GPU. Fails if no
+        such hardware is available.
     threadsperblock: 2-tuple of ints
         Only relevant when using GPU, determines how many threads in a block
         the cuda kernel is executed over when indexing patterns
     scheduler: string
         The scheduler used by dask to compute the result
+    precision: np.float32 or np.float64
+        The level of precision to work with on internal calculations
 
     Returns
     -------
     result : dict
-        Results dictionary containing keys [template_index, orientation], with
-        values numpy arrays of shape (scan_x, scan_y, n_best) and (scan_x, scan_y, n_best, 3)
-        respectively
+        Results dictionary containing for each phase a dictionary that contains
+        keys [template_index, orientation], each representing numpy arrays of 
+        shape (scan_x, scan_y, n_best) and (scan_x, scan_y, n_best, 3)
+        respectively. Orientation is expressed in Bunge convention 
+        Euler angles.
 
     Notes
     -----
-    For running the calculation on the GPU, note that the calculation is performed
-    on the entire template library (full matching) and all arguments related to
-    frac_keep and n_keep are ignored.
+    It is possible to run the indexation using a subset of the templates. This
+    two-stage procedure is controlled through `n_keep` or `frac_keep`. If one
+    of these parameters is set, the azimuthally integrated patterns are
+    compared to azimuthally integrated templates in a first stage, which is
+    very fast. The top matching patterns are passed to a second stage of 
+    full matching, whereby the in-plane angle is determined. Setting these 
+    parameters can usually achieve the same answer faster, but it is also
+    possible an incorrect match is found.
     """
     # get the dataset as a dask array
     data = _get_dask_array(signal)
     # check if we have a 4D dataset, and if not, make it
     navdim = signal.axes_manager.navigation_dimension
     if navdim == 0:
+        # we assume we have a single image
         data = data[np.newaxis, np.newaxis, ...]
     elif navdim == 1:
+        # we assume we have a line of images with the first dimension the line
         data = data[np.newaxis, ...]
     elif navdim == 2:
+        # correct dimensions
         pass
     else:
         raise ValueError(f"Dataset has {navdim} navigation dimensions, max " "is 2")
-    # change the chunking of the dataset
+    # change the chunking of the dataset if necessary
     if chunks is None:
         pass
     elif chunks == "auto":
@@ -1741,35 +1635,36 @@ def index_dataset_with_template_rotation(
 
     if target == "gpu":
         from pyxem.utils.cuda_utils import dask_array_to_gpu
+        # an error will be raised if cupy is not available
         data = dask_array_to_gpu(data)
         dispatcher = cp
     else:
         dispatcher = np
 
     # convert to polar dataset
-    theta_dim, r_dim = get_polar_pattern_shape(
+    output_shape = get_polar_pattern_shape(
         data.shape[-2:], delta_r, delta_theta, max_r=max_r
     )
+    theta_dim, r_dim = output_shape
+    max_radius = r_dim * delta_r
+    center = (data.shape[-2] / 2, data.shape[-1] / 2)
     polar_chunking = (data.chunks[0], data.chunks[1], theta_dim, r_dim)
     polar_data = data.map_blocks(
-        chunk_to_polar,
-        delta_r,
-        delta_theta,
-        max_r,
-        find_direct_beam,
-        direct_beam_positions,
-        dtype=np.float32,
+        _chunk_to_polar,
+        center,
+        max_radius,
+        output_shape,
+        precision,
+        dtype=precision,
         drop_axis=signal.axes_manager.signal_indices_in_array,
         chunks=polar_chunking,
         new_axis=(2, 3),
     )
-
     # apply the intensity transform function to the images
     if intensity_transform_function is not None:
         polar_data = polar_data.map_blocks(intensity_transform_function)
     if phases is None:
         phases = library.keys()
-    max_radius = r_dim * delta_r
 
     result = {}
 
@@ -1789,41 +1684,35 @@ def index_dataset_with_template_rotation(
             x, y, delta_r=delta_r, delta_theta=delta_theta
         )
         # integrated intensity library for fast comparison
-        integrated_templates = _get_integrated_polar_templates(r_dim, r, intensities)
-        # determining the number of patterns to do a full indexation on
-        N = r.shape[0]
-        fraction = max((N - abs(n_keep)) / N, 0.0)
-        if frac_keep is not None:
-            fraction = max(1.0 - abs(frac_keep), 0.0)
-        # calculate the norms of the templates
+        integrated_templates = _get_integrated_polar_templates(r_dim, r, intensities, normalize_templates)
+        # normalize the templates if required
         if normalize_templates:
-            integrated_template_norms = _get_row_norms(integrated_templates)
-            template_norms = _get_row_norms(intensities)
-        else:
-            integrated_template_norms = np.ones(N, dtype=np.float32)
-            template_norms = np.ones(N, dtype=np.float32)
+            integrated_templates = _norm_rows(integrated_templates)
+            intensities = _norm_rows(intensities)
         # copy relevant data to GPU memory if necessary
         if target == "gpu":
             integrated_templates = cp.asarray(integrated_templates)
-            integrated_template_norms = cp.asarray(integrated_template_norms)
             r = cp.asarray(r)
             theta = cp.asarray(theta)
             intensities = cp.asarray(intensities)
-            template_norms = cp.asarray(template_norms)
+
+        # put a limit on n_best
+        max_n = _get_max_n(r.shape[0], n_keep, frac_keep)
+        if n_best > max_n:
+            n_best = max_n
 
         indexation = polar_data.map_blocks(
             _index_chunk,
             integrated_templates,
-            integrated_template_norms,
             r,
             theta,
             intensities,
-            template_norms,
-            fraction,
+            n_keep,
+            frac_keep,
             n_best,
             normalize_images,
             threadsperblock,
-            dtype=np.float32,
+            dtype=precision,
             drop_axis=signal.axes_manager.signal_indices_in_array,
             chunks=(polar_data.chunks[0], polar_data.chunks[1], n_best, 4),
             new_axis=(2, 3),
@@ -1834,16 +1723,16 @@ def index_dataset_with_template_rotation(
             res_index = indexation.compute(
                 scheduler=scheduler, num_workers=parallel_workers, optimize_graph=True
             )
-        # in case the data is on the GPU
+        # in case the data is on the GPU, retrieve it
         res_index = to_numpy(res_index)
         # wrangle data to (template_index), (orientation), (correlation)
         result[phase_key] = {}
-        result[phase_key]["template_index"] = res_index[:, :, :, 0].astype(np.uint64)
+        result[phase_key]["template_index"] = res_index[:, :, :, 0].astype(np.int32)
         oris = phase_library["orientations"]
-        orimap = oris[res_index[:, :, :, 0].astype(np.uint64)]
+        orimap = oris[res_index[:, :, :, 0].astype(np.int32)]
         orimap[:, :, :, 1] = orimap[:, :, :, 1] * res_index[:,:,:,3]  # multiply by the sign
         orimap[:, :, :, 2] = orimap[:, :, :, 2] * res_index[:,:,:,3]  # multiply by the sign
-        orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_r
+        orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta
         result[phase_key]["orientation"] = orimap
         result[phase_key]["correlation"] = res_index[:, :, :, 1]
         result[phase_key]["mirrored_template"] = res_index[:,:,:,3] == -1

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -846,6 +846,11 @@ def _prepare_image_and_templates(
     r, theta = _cartesian_positions_to_polar(
         positions[:, 0], positions[:, 1], delta_r, delta_theta
     )
+    condition = r >= polar_image.shape[1]
+    # we don't set r to 0 because it may quit the loop in the matching early
+    r[condition] = polar_image.shape[1]  - 1 
+    theta[condition] = 0
+    intensities[condition] = 0.
     if is_cupy_array(polar_image):
         # send data to GPU
         r = cp.asarray(r)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1103,8 +1103,9 @@ def _get_fast_correlation_index(
     normalize_image,
     normalize_templates,
 ):
+    dispatcher = get_array_module(polar_image)
     integrated_polar = polar_image.sum(axis=0)
-    rrr = np.arange(integrated_polar.shape[0]) / integrated_polar.shape[0]
+    rrr = dispatcher.arange(integrated_polar.shape[0]) / integrated_polar.shape[0]
     integrated_polar = integrated_polar * rrr
     integrated_templates = _get_integrated_polar_templates(
         integrated_polar.shape[0],
@@ -1217,7 +1218,7 @@ def _prefilter_templates(
     template_indexes = dispatcher.arange(r.shape[0], dtype=np.int32)
     if max_keep != r.shape[0]:
         polar_sum = polar_image.sum(axis=0)
-        rrr = np.arange(polar_sum.shape[0]) / polar_sum.shape[0]
+        rrr = dispatcher.arange(polar_sum.shape[0]) / polar_sum.shape[0]
         polar_sum = polar_sum * rrr
         correlations_fast = _match_library_to_polar_fast(
             polar_sum,

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -16,6 +16,7 @@ def plot_template_over_pattern(
     max_r=None,
     find_direct_beam=True,
     direct_beam_position=None,
+    mirrored_template=False,
     coordinate_system="cartesian",
     marker_color="red",
     marker_type="x",
@@ -43,6 +44,8 @@ def plot_template_over_pattern(
     direct_beam_position: 2-tuple
         The (x, y) position of the direct beam in pixel coordinates. Takes
         precedence over `find_direct_beam`
+    mirrored_template: bool, optional
+        Whether to mirror the given template
     coordinate_system : str, optional
         Type of coordinate system to plot the image and template in. Either
         `cartesian` or `polar`
@@ -77,7 +80,8 @@ def plot_template_over_pattern(
             direct_beam_position=direct_beam_position,
         )
         x, y, intensities = get_template_polar_coordinates(
-            simulation, in_plane_angle=in_plane_angle, max_r=max_r
+            simulation, in_plane_angle=in_plane_angle, max_r=max_r,
+            mirrored=mirrored_template,
         )
     elif coordinate_system == "cartesian":
         if direct_beam_position is not None:
@@ -91,6 +95,7 @@ def plot_template_over_pattern(
             center=(c_x, c_y),
             in_plane_angle=in_plane_angle,
             window_size=(pattern.shape[1], pattern.shape[0]),
+            mirrored=mirrored_template,
         )
     else:
         raise NotImplementedError(

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -69,12 +69,6 @@ def plot_template_over_pattern(
     """
     if ax is None:
         _, ax = plt.subplots()
-    if direct_beam_position is not None:
-        c_x, c_y = direct_beam_position
-    elif find_direct_beam:
-        c_y, c_x = find_beam_center_blur(pattern, 1)
-    else:
-        c_y, c_x = pattern.shape[0] // 2, pattern.shape[1] // 2
     if coordinate_system == "polar":
         pattern = image_to_polar(
             pattern,
@@ -86,11 +80,17 @@ def plot_template_over_pattern(
             simulation, in_plane_angle=in_plane_angle, max_r=max_r
         )
     elif coordinate_system == "cartesian":
+        if direct_beam_position is not None:
+            c_x, c_y = direct_beam_position
+        elif find_direct_beam:
+            c_x, c_y = find_beam_center_blur(pattern, 1)
+        else:
+            c_y, c_x = pattern.shape[0] / 2, pattern.shape[1] / 2
         x, y, intensities = get_template_cartesian_coordinates(
             simulation,
             center=(c_x, c_y),
             in_plane_angle=in_plane_angle,
-            window_size=pattern.shape[::-1],
+            window_size=(pattern.shape[1], pattern.shape[0]),
         )
     else:
         raise NotImplementedError(

--- a/pyxem/utils/polar_transform_utils.py
+++ b/pyxem/utils/polar_transform_utils.py
@@ -53,6 +53,7 @@ def get_template_polar_coordinates(
     delta_r=1,
     delta_theta=1,
     max_r=None,
+    mirrored=False,
 ):
     """
     Convert a single simulation to polar coordinates
@@ -74,6 +75,8 @@ def get_template_polar_coordinates(
     max_r : float, optional
         Maximum radial distance to consider. In units of pixels, not scaled
         by delta_r = the width of the polar image.
+    mirrored : bool, optional
+        Whether to mirror the template
 
     Returns
     -------
@@ -95,12 +98,15 @@ def get_template_polar_coordinates(
         r = r[condition]
         theta = theta[condition]
         intensities = intensities[condition]
-    theta = np.mod(theta + in_plane_angle / delta_r, 360 / delta_r).astype(np.int32)
+    theta = np.mod(theta + in_plane_angle / delta_theta, 360 / delta_theta).astype(np.int32)
+    if mirrored:
+        theta = (360 / delta_theta - theta).astype(np.int32)
     return r, theta, intensities
 
 
 def get_template_cartesian_coordinates(
-    simulation, center=(0.0, 0.0), in_plane_angle=0.0, window_size=None
+    simulation, center=(0.0, 0.0), in_plane_angle=0.0, window_size=None,
+    mirrored=False,
 ):
     """
     Get the cartesian coordinates of the diffraction spots in a template
@@ -117,6 +123,8 @@ def get_template_cartesian_coordinates(
     window_size : 2-tuple, optional
         Only return the reflections within the (width, height) in pixels
         of the image
+    mirrored : bool, optional
+        Whether to mirror the template
 
     Returns
     -------
@@ -129,6 +137,8 @@ def get_template_cartesian_coordinates(
     """
     ox = simulation.calibrated_coordinates[:, 0]
     oy = simulation.calibrated_coordinates[:, 1]
+    if mirrored:
+        oy = -oy
     intensities = simulation.intensities
     c = np.cos(np.deg2rad(in_plane_angle))
     s = np.sin(np.deg2rad(in_plane_angle))

--- a/pyxem/utils/polar_transform_utils.py
+++ b/pyxem/utils/polar_transform_utils.py
@@ -7,6 +7,7 @@ from pyxem.utils.cuda_utils import get_array_module
 try:
     import cupy as cp
     import cupyx.scipy.ndimage as ndigpu
+
     CUPY_INSTALLED = True
 except ImportError:
     CUPY_INSTALLED = False
@@ -39,8 +40,10 @@ def _cartesian_positions_to_polar(x, y, delta_r=1, delta_theta=1):
     theta : 1D numpy.ndarray
         theta coordinate or y coordinate in the polar image
     """
-    r = np.rint(np.sqrt(x**2 + y**2) / delta_r).astype(np.int32)
-    theta = np.rint(np.mod(np.rad2deg(np.arctan2(y, x)), 360) / delta_theta).astype(np.int32)
+    r = np.rint(np.sqrt(x ** 2 + y ** 2) / delta_r).astype(np.int32)
+    theta = np.rint(np.mod(np.rad2deg(np.arctan2(y, x)), 360) / delta_theta).astype(
+        np.int32
+    )
     return r, theta
 
 
@@ -130,8 +133,8 @@ def get_template_cartesian_coordinates(
     c = np.cos(np.deg2rad(in_plane_angle))
     s = np.sin(np.deg2rad(in_plane_angle))
     # rotate it
-    x = c*ox - s*oy + center[0]
-    y = s*ox + c*oy + center[1]
+    x = c * ox - s * oy + center[0]
+    y = s * ox + c * oy + center[1]
     if window_size is not None:
         condition = (x < window_size[0]) & (y < window_size[1]) & (y >= 0) & (x >= 0)
         x = x[condition]
@@ -179,16 +182,15 @@ def _get_map_function(dispatcher):
     return ndimage.map_coordinates if dispatcher == np else ndigpu.map_coordinates
 
 
-def _warp_polar_custom(image, center, radius, output_shape,
-                       order=1):
+def _warp_polar_custom(image, center, radius, output_shape, order=1):
     """
     Function to emulate warp_polar in skimage.transform on both CPU and GPU. Not all
     parameters are supported
-    
+
     Parameters
     ----------
     image: numpy.ndarray or cupy.ndarray
-        Input image. Only 2-D arrays are accepted.         
+        Input image. Only 2-D arrays are accepted.
     center: tuple (row, col)
         Point in image that represents the center of the transformation
         (i.e., the origin in cartesian space). Values can be of type float.
@@ -295,7 +297,7 @@ def _chunk_to_polar(
     center,
     radius,
     output_shape,
-    precision = np.float64,
+    precision=np.float64,
 ):
     """
     Convert a chunk of images to polar coordinates
@@ -304,7 +306,7 @@ def _chunk_to_polar(
     ----------
     images : (scan_x, scan_y, x, y) np.ndarray or cp.ndarray
         diffraction patterns
-    center : 2-Tuple of float 
+    center : 2-Tuple of float
         center of the images in pixels (row, col) = (c_y, c_x)
     radius : float
         maximum radius to consider in the image. This gets mapped onto

--- a/pyxem/utils/polar_transform_utils.py
+++ b/pyxem/utils/polar_transform_utils.py
@@ -173,7 +173,7 @@ def get_polar_pattern_shape(image_shape, delta_r, delta_theta, max_r=None):
         half_x = image_shape[1] / 2
         r_dim = int(np.ceil(np.sqrt(half_x ** 2 + half_y ** 2)) / delta_r)
     else:
-        r_dim = int(max_r / delta_r)
+        r_dim = int(round(max_r / delta_r))
     theta_dim = int(round(360 / delta_theta))
     return (theta_dim, r_dim)
 
@@ -182,7 +182,7 @@ def _get_map_function(dispatcher):
     return ndimage.map_coordinates if dispatcher == np else ndigpu.map_coordinates
 
 
-def _warp_polar_custom(image, center, radius, output_shape, order=1):
+def _warp_polar_custom(image, center, radius, output_shape, order=1, precision=np.float64):
     """
     Function to emulate warp_polar in skimage.transform on both CPU and GPU. Not all
     parameters are supported
@@ -198,8 +198,10 @@ def _warp_polar_custom(image, center, radius, output_shape, order=1):
         Radius of the circle that bounds the area to be transformed.
     output_shape: tuple (row, col)
         Shape of the output polar image
-    order: int
+    order: int, optional
         Order of interpolation between pixels
+    precision: np.float64 or np.float32
+        Double or single precision output
 
     Returns
     -------
@@ -226,7 +228,7 @@ def _warp_polar_custom(image, center, radius, output_shape, order=1):
     Y = R * delta_r * dispatcher.sin(dispatcher.deg2rad(T * delta_theta)) + cy
     coordinates = dispatcher.stack([Y, X])
     map_function = _get_map_function(dispatcher)
-    polar = map_function(image.astype(np.float64), coordinates, order=order)
+    polar = map_function(image.astype(precision), coordinates, order=order)
     return polar
 
 


### PR DESCRIPTION
---
name: GPU template matching and polar image transformation
about: First ventures into GPU accelerated analysis of 4D-STEM data
---

**Checklist**
- [ ] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
Since I found a bug in the template matching approach, which should be resolved with #740, I looked again into the details. This PR continues from that branch, so #740 is more urgent. 

There is a lot of untapped potential in analyzing 4D-STEM data with the GPU as most problems are embarrassingly parallel and involve "dumb" linear algebra operations. As a test-case, since I was looking into template matching, I tried to re-implement it using cupy and numba.cuda as described in #739. It also served as a little test to see how well all these components work together with dask; from my experience it seems pretty seamless - dask arrays can also be cupy arrays it computes.

The template matching approach involves a conversion to polar coordinates of all the images and templates, then shifting all the templates across the theta axis of the polar image and calculating the correlation. Both the polar conversion and template shifting approach were parallelized on GPU with incredible performance gains. For the polar transform I could get a speed up of 40-400x depending on the image size (scikit-image's warp-polar against the implementation in this PR), for the indexing of a single pattern I could achieve a speed up of 5-10 depending on the size of the template library compared to 40 cpu cores. Larger data generally yields larger relative speed gains when using the GPU.

In order to support analysis of large 4D-STEM datasets, pyxem could get a real edge by thinking about GPU and HPC implementations of the algorithms a priori. Even in the upstream libraries like scikit-image this is still a point of active development. I would welcome a discussion on where else in the code-base we could make an impact. I'm pretty sure vector based analysis and peak finding may also seriously benefit from the GPU.

Another thing I changed is I removed the argument for parallelizing the polar transform during the indexation process. This was previously implemented with a hacky `njit` function that includes `objmode` blocks to do the actual polar transform. There seemed to be limited gain in using this function over the simple python for-loop implementation, so I default to this unless the GPU is used.

**Describe alternatives you've considered**
I was already parallelizing the heck out of the problem with dask and numba, which worked fine on a cluster or heavy duty workstation. With CUDA we can gain 1-2 orders of magnitude in speed up, which gives us a serious edge over commercial software, and maybe warrants a little publication - would anyone like to contribute on this point?

**Are there any known issues? Do you need help?**
I have absolutely no idea how to deal with unit testing. Does Github actions support GPU code? How can one create unit tests that only run when there is a CUDA enabled GPU on the system? Or is there a way to emulate a GPU but run it on CPU for unit testing?

**Work in progress?**
- [x] Needs quite a bit more testing, optimization and benchmarking. Just opening this up already for any feedback.
