### PR TITLE
Add better support for correcting for shift of diffraction pattern as function of probe position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Getting and plot integrated intensity now support signals containing nan (#722)
 - Add Symmetry1D signal class and symmetry analysis methods (#724)
+- BeamShift class, which includes the `make_linear_plane` method for better correction of the beam shift when scanning large regions in STEM (#746)
 
 ### Removed
 - lazy_* virtual imaging has been removed, use get_integrated_intensity (#722)

--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -137,6 +137,18 @@ signals:
     dtype: real
     lazy: False
     module: pyxem.signals.diffraction_variance2d
+  BeamShift:
+    signal_type: beam_shift
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    module: pyxem.signals.beam_shift
+  LazyBeamShift:
+    signal_type: beam_shift
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: pyxem.signals.beam_shift
   DPCBaseSignal:
     signal_type: "dpc"
     signal_dimension: 0

--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -139,13 +139,13 @@ signals:
     module: pyxem.signals.diffraction_variance2d
   BeamShift:
     signal_type: beam_shift
-    signal_dimension: 2
+    signal_dimension: 1
     dtype: real
     lazy: False
     module: pyxem.signals.beam_shift
   LazyBeamShift:
     signal_type: beam_shift
-    signal_dimension: 2
+    signal_dimension: 1
     dtype: real
     lazy: True
     module: pyxem.signals.beam_shift

--- a/pyxem/signals/__init__.py
+++ b/pyxem/signals/__init__.py
@@ -18,6 +18,7 @@
 
 from .common_diffraction import CommonDiffraction
 from .correlation2d import Correlation2D, LazyCorrelation2D
+from .beam_shift import BeamShift, LazyBeamShift
 from .differential_phase_contrast import (
     DPCBaseSignal,
     DPCSignal1D,
@@ -49,6 +50,8 @@ __all__ = [
     "CommonDiffraction",
     "Correlation2D",
     "LazyCorrelation2D",
+    "BeamShift",
+    "LazyBeamShift",
     "DPCBaseSignal",
     "DPCSignal1D",
     "DPCSignal2D",

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2021 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Signal class for working with shift of the direct beam."""
+
+from hyperspy._signals.lazy import LazySignal
+from hyperspy._signals.signal1d import Signal1D
+
+
+class BeamShift(Signal1D):
+
+    _signal_type = "beam_shift"
+
+    def make_linear_plane(self, mask=None):
+        if self._lazy:
+            raise ValueError(
+                "make_linear_plane is not implemented for lazy signals, "
+                "run compute() first"
+            )
+        s_shift_x = self.isig[0].T
+        s_shift_y = self.isig[1].T
+        plane_image_x = _get_linear_plane_from_signal2d(s_shift_x, mask=mask)
+        plane_image_y = _get_linear_plane_from_signal2d(s_shift_y, mask=mask)
+        plane_image = np.stack((plane_image_x, plane_image_y), -1)
+        self.data[:] = plane_image
+        self.events.data_changed.trigger(None)
+
+    def to_dpcsignal(self):
+        s_dpc = self.T
+        s_dpc.set_signal_type("dpc")
+        return s_dpc
+
+
+class LazyBeamShift(BeamShift, LazySignal):
+    _signal_type = "beam_shift"
+
+    pass

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -18,6 +18,8 @@
 
 """Signal class for working with shift of the direct beam."""
 
+import numpy as np
+import pyxem.utils.pixelated_stem_tools as pst
 from hyperspy._signals.lazy import LazySignal
 from hyperspy._signals.signal1d import Signal1D
 
@@ -34,10 +36,10 @@ class BeamShift(Signal1D):
             )
         s_shift_x = self.isig[0].T
         s_shift_y = self.isig[1].T
-        plane_image_x = _get_linear_plane_from_signal2d(s_shift_x, mask=mask)
-        plane_image_y = _get_linear_plane_from_signal2d(s_shift_y, mask=mask)
+        plane_image_x = pst._get_linear_plane_from_signal2d(s_shift_x, mask=mask)
+        plane_image_y = pst._get_linear_plane_from_signal2d(s_shift_y, mask=mask)
         plane_image = np.stack((plane_image_x, plane_image_y), -1)
-        self.data[:] = plane_image
+        self.data = plane_image
         self.events.data_changed.trigger(None)
 
     def to_dpcsignal(self):

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -29,6 +29,48 @@ class BeamShift(Signal1D):
     _signal_type = "beam_shift"
 
     def make_linear_plane(self, mask=None):
+        """Fit linear planes to the beam shifts, which replaces the original data.
+
+        In many scanning transmission electron microscopes, the center position of the
+        diffraction pattern will change as a function of the scan position. This is most
+        apparent when scanning over large regions (100+ nanometers). Thus, when working
+        with datasets, it is typically necessary to correct for this.
+        However, other effects can also affect the apparent center point, like
+        diffraction contrast. So while it is possible to correct for the beam shift
+        by finding the center position in each diffraction pattern, this can lead to
+        features such as interfaces or grain boundaries affecting the centering of the
+        diffraction pattern. As the shift caused by the scan system is a slow and
+        monotonic, it can often be approximated by fitting linear planes to
+        the x- and y- beam shifts.
+
+        In addition, for regions within the scan where the center point of the direct
+        beam is hard to ascertain precisely, for example in very thick or heavily
+        diffracting regions, a mask can be used to ignore fitting the plane to
+        these regions.
+
+        This method does this, and replaces the original beam shift data with these
+        fitted planes. The beam shift signal can then be directly used in the
+        Diffraction2D.center_direct_beam method.
+
+        Note that for very large regions, this linear plane will probably not
+        approximate the beam shift very well. In those cases a higher order plane
+        will likely be necessary. Alternatively, a vacuum scan with exactly the same
+        scanning parameters should be used.
+
+        Parameters
+        ----------
+        mask : HyperSpy signal, optional
+            Must be the same shape as the navigation dimensions of the beam
+            shift signal. The True values will be masked.
+
+        Examples
+        --------
+        >>> s = pxm.signals.BeamShift(np.random.randint(0, 99, (100, 120, 2)))
+        >>> s_mask = hs.signals.Signal2D(np.zeros((100, 120), dtype=np.bool))
+        >>> s_mask.data[20:-20, 20:-20] = True
+        >>> s.make_linear_plane(mask=s_mask)
+
+        """
         if self._lazy:
             raise ValueError(
                 "make_linear_plane is not implemented for lazy signals, "
@@ -36,6 +78,8 @@ class BeamShift(Signal1D):
             )
         s_shift_x = self.isig[0].T
         s_shift_y = self.isig[1].T
+        if mask is not None:
+            mask = mask.__array__()
         plane_image_x = pst._get_linear_plane_from_signal2d(s_shift_x, mask=mask)
         plane_image_y = pst._get_linear_plane_from_signal2d(s_shift_y, mask=mask)
         plane_image = np.stack((plane_image_x, plane_image_y), -1)
@@ -43,6 +87,14 @@ class BeamShift(Signal1D):
         self.events.data_changed.trigger(None)
 
     def to_dpcsignal(self):
+        """Get DPCSignal from the BeamShift signal
+
+        The DPCSignal class is focused on analysing the shifts of the beam, for example
+        caused by magnetic or electric fields.
+
+        In practice, the signal and navigation dimensions are switched.
+
+        """
         s_dpc = self.T
         s_dpc.set_signal_type("dpc")
         return s_dpc

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -160,6 +160,14 @@ class DPCSignal1D(Signal1D):
         return s_hist
 
     def to_beamshift(self):
+        """Get BeamShift signal from the DPCSignal.
+
+        The BeamShift signal is a utility signal focused on correcting the shift of the
+        center beam in the Diffraction2D signal.
+
+        In practice, the signal and navigation dimensions are switched.
+
+        """
         s_beam_shift = self.T
         s_beam_shift.set_signal_type("beam_shift")
         return s_beam_shift
@@ -184,7 +192,8 @@ class DPCSignal2D(Signal2D):
     def correct_ramp(self, corner_size=0.05, only_offset=False, out=None):
         """Subtract a plane from the signal by fitting a plane to the corners.
 
-        Useful for removing the effects of d-scan in a STEM beam shift dataset.
+        Useful for removing the effects of the center of the diffraction
+        pattern shifting as a function of scan position.
 
         The plane is calculated by fitting a plane to the corner values
         of the signal. This will only work well when the property one
@@ -223,7 +232,9 @@ class DPCSignal2D(Signal2D):
         else:
             output = out
 
-        corner_slice_list = pst._get_corner_slices(self.inav[0], corner_size=corner_size)
+        corner_slice_list = pst._get_corner_slices(
+            self.inav[0], corner_size=corner_size
+        )
         mask = np.ones_like(self.inav[0].data, dtype=np.bool)
         for corner_slice in corner_slice_list:
             mask[corner_slice] = False
@@ -237,6 +248,14 @@ class DPCSignal2D(Signal2D):
             return output
 
     def to_beamshift(self):
+        """Get BeamShift signal from the DPCSignal.
+
+        The BeamShift signal is a utility signal focused on correcting the shift of the
+        center beam in the Diffraction2D signal.
+
+        In practice, the signal and navigation dimensions are switched.
+
+        """
         s_beam_shift = self.T
         s_beam_shift.set_signal_type("beam_shift")
         return s_beam_shift

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -231,6 +231,10 @@ class DPCSignal2D(Signal2D):
         if out is None:
             return output
 
+    def to_beamshift(self):
+        s_beam_shift = self.T
+        s_beam_shift.set_signal_type("beam_shift")
+
     def get_magnitude_signal(self, autolim=True, autolim_sigma=4):
         """Get DPC magnitude image visualized as greyscale.
 

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -159,6 +159,11 @@ class DPCSignal1D(Signal1D):
 
         return s_hist
 
+    def to_beamshift(self):
+        s_beam_shift = self.T
+        s_beam_shift.set_signal_type("beam_shift")
+        return s_beam_shift
+
 
 class DPCSignal2D(Signal2D):
     """
@@ -234,6 +239,7 @@ class DPCSignal2D(Signal2D):
     def to_beamshift(self):
         s_beam_shift = self.T
         s_beam_shift.set_signal_type("beam_shift")
+        return s_beam_shift
 
     def get_magnitude_signal(self, autolim=True, autolim_sigma=4):
         """Get DPC magnitude image visualized as greyscale.

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -45,6 +45,7 @@ from pyxem.signals import (
     LazyDPCBaseSignal,
     LazyDPCSignal1D,
     LazyDPCSignal2D,
+    LazyBeamShift,
 )
 from pyxem.utils.pyfai_utils import (
     get_azimuthal_integrator,
@@ -810,7 +811,9 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             else:
                 align_kwargs["order"] = 0
 
-        shifts_dask_array = _get_dask_array(shifts)
+        nav_dims = self.axes_manager.navigation_dimension
+        nav_chunks = data_dask_array.chunks[:nav_dims]
+        shifts_dask_array = _get_dask_array(shifts, chunk_shape=nav_chunks)
 
         output_dask_array = _process_dask_array(
             data_dask_array,

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -698,7 +698,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             )
             shifts = origin_coordinates - centers
 
-        s_shifts = LazySignal1D(shifts)
+        s_shifts = LazyBeamShift(shifts)
 
         if not lazy_result:
             s_shifts.compute()

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -35,14 +35,14 @@ class TestToDPCSignal:
         s_dpc = s.to_dpcsignal()
         assert s_dpc.axes_manager.shape == (2, probe_x)
 
-    def test_to_dpcsignal2d(self):
+    def test_to_dpcsignal2d_lazy(self):
         probe_x, probe_y = 100, 200
         s = LazyBeamShift(da.zeros((probe_y, probe_x, 2)))
         s_dpc = s.to_dpcsignal()
         assert s_dpc._lazy
         assert s_dpc.axes_manager.shape == (2, probe_x, probe_y)
 
-    def test_to_dpcsignal1d(self):
+    def test_to_dpcsignal1d_lazy(self):
         probe_x = 200
         s = LazyBeamShift(da.zeros((probe_x, 2)))
         s_dpc = s.to_dpcsignal()

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2021 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import numpy as np
+import dask.array as da
+from pyxem.signals import BeamShift, LazyBeamShift, Diffraction2D
+
+
+class TestToDPCSignal:
+    def test_to_dpcsignal2d(self):
+        probe_x, probe_y = 100, 200
+        s = BeamShift(np.zeros((probe_y, probe_x, 2)))
+        s_dpc = s.to_dpcsignal()
+        assert s_dpc.axes_manager.shape == (2, probe_x, probe_y)
+
+    def test_to_dpcsignal1d(self):
+        probe_x = 200
+        s = BeamShift(np.zeros((probe_x, 2)))
+        s_dpc = s.to_dpcsignal()
+        assert s_dpc.axes_manager.shape == (2, probe_x)
+
+    def test_to_dpcsignal2d(self):
+        probe_x, probe_y = 100, 200
+        s = LazyBeamShift(da.zeros((probe_y, probe_x, 2)))
+        s_dpc = s.to_dpcsignal()
+        assert s_dpc._lazy
+        assert s_dpc.axes_manager.shape == (2, probe_x, probe_y)
+
+    def test_to_dpcsignal1d(self):
+        probe_x = 200
+        s = LazyBeamShift(da.zeros((probe_x, 2)))
+        s_dpc = s.to_dpcsignal()
+        assert s_dpc._lazy
+        assert s_dpc.axes_manager.shape == (2, probe_x)
+
+
+class TestMakeLinearPlane:
+    def test_simple(self):
+        data_x, data_y = np.meshgrid(
+            np.arange(-50, 50, dtype=np.float32), np.arange(-256, 0, dtype=np.float32)
+        )
+        data = np.stack((data_y, data_x), -1)
+        s = BeamShift(data)
+        s.change_dtype("float32")
+        s_orig = s.deepcopy()
+        s.make_linear_plane()
+        np.testing.assert_almost_equal(s.data, s_orig, decimal=7)
+
+    def test_mask(self):
+        data_x, data_y = np.meshgrid(
+            np.arange(-50, 50, dtype=np.float32), np.arange(-256, 0, dtype=np.float32)
+        )
+        data = np.stack((data_y, data_x), -1)
+        mask = np.zeros_like(data[:, :, 0], dtype=np.bool)
+        mask[45:50, 36:41] = True
+        s = BeamShift(data)
+        s.change_dtype("float32")
+        s_orig = s.deepcopy()
+        s.data[45:50, 36:41, 0] = 100000
+        s.data[45:50, 36:41, 1] = -100000
+        s.make_linear_plane(mask=mask)
+        np.testing.assert_almost_equal(s.data, s_orig, decimal=7)
+
+    def test_lazy_input_error(self):
+        s = LazyBeamShift(da.zeros((50, 40, 2)))
+        with pytest.raises(ValueError):
+            s.make_linear_plane()
+        s.compute()
+        s.make_linear_plane()
+
+
+class TestFullDirectBeamCentering:
+    def setup_method(self):
+        data = np.zeros((3, 3, 16, 16), dtype=np.float32)
+        data[0, 0, 6, 7] = 10
+        data[0, 1, 6, 8] = 10
+        data[0, 2, 6, 9] = 10
+        data[1, 0, 7, 7] = 10
+        data[1, 1, 7, 8] = 10
+        data[1, 2, 7, 9] = 10
+        data[2, 0, 8, 7] = 10
+        data[2, 1, 8, 8] = 10
+        data[2, 2, 8, 9] = 10
+        s = Diffraction2D(data)
+        s.axes_manager[0].scale = 0.5
+        s.axes_manager[1].scale = 1.5
+        s.axes_manager[2].scale = 5
+        s.axes_manager[3].scale = 5
+        s.axes_manager[0].offset = -10
+        s.axes_manager[1].offset = 20
+        s.axes_manager[2].offset = 30
+        s.axes_manager[3].offset = 30
+        self.s = s
+
+    def test_simple(self):
+        s = self.s
+        s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        s.center_direct_beam(shifts=s_beam_shift)
+        assert (s.data[:, :, 8, 8] == 10).all()
+        s.data[:, :, 8, 8] = 0
+        assert not s.data.any()
+
+    def test_simple_1d(self):
+        s = self.s.inav[0]
+        s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        s.center_direct_beam(shifts=s_beam_shift)
+        assert (s.data[:, 8, 8] == 10).all()
+        s.data[:, 8, 8] = 0
+        assert not s.data.any()
+
+    def test_simple_lazy(self):
+        s = self.s
+        s = s.as_lazy()
+        s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        s.center_direct_beam(shifts=s_beam_shift)
+        s.compute()
+        assert (s.data[:, :, 8, 8] == 10).all()
+        s.data[:, :, 8, 8] = 0
+        assert not s.data.any()
+
+    def test_mask(self):
+        s = self.s
+        s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        s_beam_shift.make_linear_plane()
+        s.center_direct_beam(shifts=s_beam_shift)
+        assert (s.data[:, :, 8, 8] == 10).all()
+        s.data[:, :, 8, 8] = 0
+        np.testing.assert_almost_equal(s.data, 0.0, decimal=7)
+
+    def test_mask_lazy(self):
+        s = self.s.as_lazy()
+        s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
+        s_beam_shift.compute()
+        s_beam_shift.make_linear_plane()
+        s.center_direct_beam(shifts=s_beam_shift)
+        s.compute()
+        assert (s.data[:, :, 8, 8] == 10).all()
+        s.data[:, :, 8, 8] = 0
+        np.testing.assert_almost_equal(s.data, 0.0, decimal=7)

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -136,20 +136,29 @@ class TestFullDirectBeamCentering:
 
     def test_mask(self):
         s = self.s
+        s.data[1, 2, 2, 3] = 1000
+        mask = np.zeros((3, 3), dtype=np.bool)
+        mask[1, 2] = True
         s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
-        s_beam_shift.make_linear_plane()
+        s_beam_shift.make_linear_plane(mask=mask)
         s.center_direct_beam(shifts=s_beam_shift)
         assert (s.data[:, :, 8, 8] == 10).all()
         s.data[:, :, 8, 8] = 0
-        np.testing.assert_almost_equal(s.data, 0.0, decimal=7)
+        s.data[1, 2, 3, 2] = 0
+        np.testing.assert_almost_equal(s.data, 0.0, decimal=5)
 
     def test_mask_lazy(self):
+        s = self.s
+        s.data[1, 2, 2, 3] = 1000
         s = self.s.as_lazy()
+        mask = np.zeros((3, 3), dtype=np.bool)
+        mask[1, 2] = True
         s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
         s_beam_shift.compute()
-        s_beam_shift.make_linear_plane()
+        s_beam_shift.make_linear_plane(mask=mask)
         s.center_direct_beam(shifts=s_beam_shift)
         s.compute()
         assert (s.data[:, :, 8, 8] == 10).all()
         s.data[:, :, 8, 8] = 0
-        np.testing.assert_almost_equal(s.data, 0.0, decimal=7)
+        s.data[1, 2, 3, 2] = 0
+        np.testing.assert_almost_equal(s.data, 0.0, decimal=5)

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -73,6 +73,34 @@ class TestDpcSignal2dCreate:
         LazyDPCSignal2D(data)
 
 
+class TestToBeamShift:
+    def test_dpc_signal2d(self):
+        probe_x, probe_y = 100, 200
+        s = pxm.signals.DPCSignal2D(np.zeros((2, probe_y, probe_x)))
+        s_beam_shift = s.to_beamshift()
+        assert s_beam_shift.axes_manager.shape == (probe_x, probe_y, 2)
+
+    def test_dpc_signal1d(self):
+        probe_x = 200
+        s = pxm.signals.DPCSignal1D(np.zeros((2, probe_x)))
+        s_beam_shift = s.to_beamshift()
+        assert s_beam_shift.axes_manager.shape == (probe_x, 2)
+
+    def test_lazy_dpc_signal2d(self):
+        probe_x, probe_y = 100, 200
+        s = pxm.signals.LazyDPCSignal2D(da.zeros((2, probe_y, probe_x)))
+        s_beam_shift = s.to_beamshift()
+        assert s_beam_shift._lazy
+        assert s_beam_shift.axes_manager.shape == (probe_x, probe_y, 2)
+
+    def test_lazy_dpc_signal1d(self):
+        probe_x = 200
+        s = pxm.signals.LazyDPCSignal1D(da.zeros((2, probe_x)))
+        s_beam_shift = s.to_beamshift()
+        assert s_beam_shift._lazy
+        assert s_beam_shift.axes_manager.shape == (probe_x, 2)
+
+
 class TestDpcSignal2dCorrectRamp:
     def test_correct_ramp_flat(self):
         data0 = np.ones(shape=(2, 64, 64))

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -573,6 +573,11 @@ class TestGetChunking:
         chunks = dt._get_chunking(s, chunk_shape=16)
         assert chunks == ((16, 16), (16, 16), (256,), (256,))
 
+    def test_chunk_shape_list(self):
+        s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
+        chunks = dt._get_chunking(s, chunk_shape=((20, 12), (15, 17)))
+        assert chunks == ((20, 12), (15, 17), (256,), (256,))
+
     def test_chunk_bytes(self):
         s = LazyDiffraction2D(da.zeros((32, 32, 256, 256), dtype=np.uint16))
         chunks = dt._get_chunking(s, chunk_bytes="15MiB")

--- a/pyxem/tests/utils/test_dpc_signal_tools.py
+++ b/pyxem/tests/utils/test_dpc_signal_tools.py
@@ -271,8 +271,8 @@ class TestGetLinearPlaneFromSignal2d:
         with pytest.raises(ValueError):
             pst._get_linear_plane_from_signal2d(s)
 
-    def test_wrong_map_dimensions(self):
-        s = hs.signals.Signal2D(np.ones((2, 10, 10)))
+    def test_wrong_mask_dimensions(self):
+        s = hs.signals.Signal2D(np.ones((10, 10)))
         mask = np.zeros((11, 9), dtype=np.bool)
         with pytest.raises(ValueError):
             pst._get_linear_plane_from_signal2d(s, mask=mask)

--- a/pyxem/tests/utils/test_dpc_signal_tools.py
+++ b/pyxem/tests/utils/test_dpc_signal_tools.py
@@ -117,164 +117,148 @@ class TestMakeBivariateHistogram:
         assert not s.data.any()
 
 
-class TestGetCornerValues:
-    def test_simple(self):
-        s = hs.signals.Signal2D(np.zeros((101, 101)))
-        corner_values = pst._get_corner_values(s)
-        assert corner_values.shape == (3, 4)
-        # tl: top left, bl: bottom right, tr: top right, br: bottom right
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (2.5, 2.5, 0.0)).all()
-        assert (corner_bl == (2.5, 97.5, 0.0)).all()
-        assert (corner_tr == (97.5, 2.5, 0.0)).all()
-        assert (corner_br == (97.5, 97.5, 0.0)).all()
+class TestGetCornerSlices:
+    @pytest.mark.parametrize("corner_size", [0.02, 0.05, 0.20, 0.23])
+    def test_corner_size(self, corner_size):
+        size = 100
+        s = hs.signals.Signal2D(np.zeros((size, size)))
+        corner_slice_list = pst._get_corner_slices(s, corner_size=corner_size)
+        corner_shape = (round(size * corner_size), round(size * corner_size))
+        for corner_slice in corner_slice_list:
+            s_corner = s.isig[corner_slice]
+            assert s_corner.axes_manager.shape == corner_shape
 
-    def test_non_square_shape(self):
-        s = hs.signals.Signal2D(np.zeros((201, 101)))
-        corner_values = pst._get_corner_values(s)
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (2.5, 5.0, 0.0)).all()
-        assert (corner_bl == (2.5, 195.0, 0.0)).all()
-        assert (corner_tr == (97.5, 5.0, 0.0)).all()
-        assert (corner_br == (97.5, 195.0, 0.0)).all()
+    def test_signal_slice_values(self):
+        data = np.zeros((100, 200), dtype=np.uint16)
+        data[:20, :20] = 2
+        data[:20, -20:] = 5
+        data[-20:, :20] = 10
+        data[-20:, -20:] = 8
+        s = hs.signals.Signal2D(data)
+        corner_slice_list = pst._get_corner_slices(s, corner_size=0.05)
+        assert (s.isig[corner_slice_list[0]].data == 2).all()
+        assert (s.isig[corner_slice_list[1]].data == 10).all()
+        assert (s.isig[corner_slice_list[2]].data == 5).all()
+        assert (s.isig[corner_slice_list[3]].data == 8).all()
 
-    def test_corner_size_parameters(self):
-        s = hs.signals.Signal2D(np.zeros((101, 101)))
-        corner_values = pst._get_corner_values(s, corner_size=0.1)
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (5.0, 5.0, 0.0)).all()
-        assert (corner_bl == (5.0, 95.0, 0.0)).all()
-        assert (corner_tr == (95.0, 5.0, 0.0)).all()
-        assert (corner_br == (95.0, 95.0, 0.0)).all()
-
-    def test_different_corner_values(self):
-        s = hs.signals.Signal2D(np.zeros((100, 100)))
-        s.data[:5, :5] = 10
-        s.data[-5:, :5] = 20
-        s.data[:5, -5:] = 30
-        s.data[-5:, -5:] = 40
-        corner_values = pst._get_corner_values(s)
-        assert (corner_values[2] == (10, 20, 30, 40)).all()
-        corner_values = pst._get_corner_values(s, corner_size=0.1)
-        assert (corner_values[2] == (2.5, 5.0, 7.5, 10.0)).all()
-
-    def test_different_corner_values_non_square(self):
-        s = hs.signals.Signal2D(np.zeros((200, 100)))
-        s.data[:10, :5] = 10
-        s.data[-10:, :5] = 20
-        s.data[:10, -5:] = 30
-        s.data[-10:, -5:] = 40
-        corner_values = pst._get_corner_values(s)
-        assert (corner_values[2] == (10, 20, 30, 40)).all()
-        corner_values = pst._get_corner_values(s, corner_size=0.1)
-        assert (corner_values[2] == (2.5, 5.0, 7.5, 10.0)).all()
-
-    def test_offset(self):
-        s = hs.signals.Signal2D(np.zeros((101, 101)))
-        s.axes_manager[0].offset = 10
-        s.axes_manager[1].offset = -10
-        corner_values = pst._get_corner_values(s)
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (12.5, -7.5, 0.0)).all()
-        assert (corner_bl == (12.5, 87.5, 0.0)).all()
-        assert (corner_tr == (107.5, -7.5, 0.0)).all()
-        assert (corner_br == (107.5, 87.5, 0.0)).all()
-
-    def test_scale(self):
-        s = hs.signals.Signal2D(np.zeros((101, 101)))
-        s.axes_manager[0].scale = 0.5
-        s.axes_manager[1].scale = 2
-        corner_values = pst._get_corner_values(s)
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (1.25, 5.0, 0.0)).all()
-        assert (corner_bl == (1.25, 195.0, 0.0)).all()
-        assert (corner_tr == (48.75, 5.0, 0.0)).all()
-        assert (corner_br == (48.75, 195.0, 0.0)).all()
-
-    def test_crop_square(self):
-        s = hs.signals.Signal2D(np.zeros((200, 200))).isig[50:150, 50:150]
-        corner_values = pst._get_corner_values(s)
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (52.0, 52, 0.0)).all()
-        assert (corner_bl == (52.0, 147.0, 0.0)).all()
-        assert (corner_tr == (147.0, 52.0, 0.0)).all()
-        assert (corner_br == (147.0, 147.0, 0.0)).all()
-
-    def test_crop_square_values(self):
-        s = hs.signals.Signal2D(np.zeros((200, 200)))
-        s.data[50:60, 50:60] = 10
-        s.data[140:150, 50:60] = 20
-        s.data[50:60, 140:150] = 30
-        s.data[140:150, 140:150] = 40
-        s = s.isig[50:150, 50:150]
-        corner_values = pst._get_corner_values(s)
-        corner_tl, corner_bl = corner_values[:, 0], corner_values[:, 1]
-        corner_tr, corner_br = corner_values[:, 2], corner_values[:, 3]
-        assert (corner_tl == (52.0, 52, 10.0)).all()
-        assert (corner_bl == (52.0, 147.0, 20.0)).all()
-        assert (corner_tr == (147.0, 52.0, 30.0)).all()
-        assert (corner_br == (147.0, 147.0, 40.0)).all()
+    def test_non_square_signal(self):
+        corner_size = 0.05
+        size_x, size_y = 100, 200
+        s = hs.signals.Signal2D(np.zeros((size_y, size_x)))
+        corner_slice_list = pst._get_corner_slices(s, corner_size=0.05)
+        corner_shape = (round(size_x * corner_size), round(size_y * corner_size))
+        for corner_slice in corner_slice_list:
+            s_corner = s.isig[corner_slice]
+            assert s_corner.axes_manager.shape == corner_shape
 
     def test_wrong_input_dimensions(self):
         s = hs.signals.Signal2D(np.ones((2, 10, 10)))
         with pytest.raises(ValueError):
-            pst._get_corner_values(s)
+            pst._get_corner_slices(s)
         s = hs.signals.Signal2D(np.ones((2, 2, 10, 10)))
         with pytest.raises(ValueError):
-            pst._get_corner_values(s)
+            pst._get_corner_slices(s)
         s = hs.signals.Signal1D(np.ones(10))
         with pytest.raises(ValueError):
-            pst._get_corner_values(s)
+            pst._get_corner_slices(s)
+
+
+class TestPlaneParametersToImage:
+    def test_simple(self):
+        p = [0, 0, 1, 0]
+        xaxis, yaxis = range(100), range(110)
+        image = pst._plane_parameters_to_image(p, xaxis, yaxis)
+        assert_allclose(image, 0)
+
+    def test_offset(self):
+        p = [0, 0, 1, 3]
+        xaxis, yaxis = range(100), range(110)
+        image = pst._plane_parameters_to_image(p, xaxis, yaxis)
+        assert_allclose(image, -3)
+
+    def test_x_plane(self):
+        p = [1, 0, 1, 0]
+        xaxis, yaxis = range(100), range(110)
+        image = pst._plane_parameters_to_image(p, xaxis, yaxis)
+        assert image[0, 0] > image[0, -1]
+
+    def test_y_plane(self):
+        p = [0, 1, 1, 0]
+        xaxis, yaxis = range(100), range(110)
+        image = pst._plane_parameters_to_image(p, xaxis, yaxis)
+        assert image[0, 0] > image[-1, 0]
+
+    def test_last_parameter(self):
+        p = [0, 0, 2, 4]
+        xaxis, yaxis = range(100), range(110)
+        image = pst._plane_parameters_to_image(p, xaxis, yaxis)
+        assert_allclose(image, -2)
 
 
 class TestGetLinearPlaneFromSignal2d:
-    def test_zero_values(self):
-        data = np.zeros((100, 100))
-        s = hs.signals.Signal2D(data)
-        ramp = pst._fit_ramp_to_image(s, corner_size=0.05)
-        assert_allclose(ramp, data, atol=1e-15)
+    def test_linear_ramp(self):
+        s0, s1 = hs.signals.Signal2D(np.meshgrid(range(100), range(110)))
+        s0.change_dtype("float64")
+        s1.change_dtype("float64")
+        s0_plane = pst._get_linear_plane_from_signal2d(s0)
+        s1_plane = pst._get_linear_plane_from_signal2d(s1)
+        np.testing.assert_almost_equal(s0_plane.data, s0.data)
+        np.testing.assert_almost_equal(s1_plane.data, s1.data)
+
+    def test_zeros_values(self):
+        s = hs.signals.Signal2D(np.zeros((100, 200), dtype=np.float32))
+        s_plane = pst._get_linear_plane_from_signal2d(s)
+        np.testing.assert_almost_equal(s_plane.data, s.data)
 
     def test_ones_values(self):
-        data = np.ones((100, 100))
-        s = hs.signals.Signal2D(data)
-        ramp = pst._fit_ramp_to_image(s, corner_size=0.05)
-        assert_allclose(ramp, data, atol=1e-30)
+        s = hs.signals.Signal2D(np.ones((100, 200), dtype=np.float32))
+        s_plane = pst._get_linear_plane_from_signal2d(s)
+        np.testing.assert_almost_equal(s_plane.data, s.data)
 
     def test_negative_values(self):
-        data = np.ones((100, 100)) * -10
+        data = np.ones((110, 100)) * -10
         s = hs.signals.Signal2D(data)
-        ramp = pst._fit_ramp_to_image(s, corner_size=0.05)
-        assert_allclose(ramp, data, atol=1e-30)
+        s_plane = pst._get_linear_plane_from_signal2d(s)
+        np.testing.assert_almost_equal(s_plane.data, s.data)
 
-    def test_large_values_in_middle(self):
-        data = np.zeros((100, 100))
-        data[5:95, :] = 10
-        data[:, 5:95] = 10
+    def test_mask(self):
+        data = np.ones((110, 200), dtype=np.float32)
+        mask = np.zeros_like(data, dtype=np.bool)
+        data[50, 51] = 10000
+        mask[50, 51] = True
         s = hs.signals.Signal2D(data)
-        ramp05 = pst._fit_ramp_to_image(s, corner_size=0.05)
-        assert_allclose(ramp05, np.zeros((100, 100)), atol=1e-15)
-        ramp10 = pst._fit_ramp_to_image(s, corner_size=0.1)
-        assert (ramp05 != ramp10).all()
+        plane_no_mask = pst._get_linear_plane_from_signal2d(s)
+        plane_mask = pst._get_linear_plane_from_signal2d(s, mask=mask)
+        assert plane_no_mask != approx(1.0)
+        assert plane_mask == approx(1.0)
 
-    def test_different_corner_values(self):
-        data = np.zeros((100, 100))
-        data[:5, :5], data[:5, -5:] = -10, 10
-        data[-5:, :5] = 10
-        data[-5:, -5:] = 30
-        s = hs.signals.Signal2D(data)
-        ramp = pst._fit_ramp_to_image(s, corner_size=0.05)
-        s.data = s.data - ramp
-        assert approx(s.data[:5, :5].mean()) == 0.0
-        assert approx(s.data[:5, -5:].mean()) == 0.0
-        assert approx(s.data[-5:, :5].mean()) == 0.0
-        assert approx(s.data[-5:, -5:].mean()) == 0.0
-        assert s.data[5:95, 5:95].mean() != 0
+    def test_offest_and_scale(self):
+        s, _ = hs.signals.Signal2D(np.meshgrid(range(100), range(110)))
+        s.axes_manager[0].offset = -40
+        s.axes_manager[1].offset = 50
+        s.axes_manager[0].scale = -0.22
+        s.axes_manager[1].scale = 5.2
+        s_orig = s.deepcopy()
+        mask = np.zeros_like(s.data, dtype=np.bool)
+        s.data[50, 51] = 10000
+        mask[50, 51] = True
+        plane_mask = pst._get_linear_plane_from_signal2d(s, mask=mask)
+        np.testing.assert_almost_equal(plane_mask, s_orig.data)
+
+    def test_crop_signal(self):
+        s, _ = hs.signals.Signal2D(np.meshgrid(range(100), range(110)))
+        s.change_dtype("float32")
+        s.axes_manager[0].offset = -40
+        s.axes_manager[1].offset = 50
+        s.axes_manager[0].scale = -0.22
+        s.axes_manager[1].scale = 5.2
+        s_crop = s.isig[10:-20, 21:-11]
+        s_crop_orig = s_crop.deepcopy()
+        s_crop.data[50, 51] = 10000
+        mask = np.zeros_like(s_crop.data, dtype=np.bool)
+        mask[50, 51] = True
+        plane = pst._get_linear_plane_from_signal2d(s_crop, mask=mask)
+        np.testing.assert_almost_equal(plane, s_crop_orig.data, decimal=6)
 
     def test_wrong_input_dimensions(self):
         s = hs.signals.Signal2D(np.ones((2, 10, 10)))
@@ -286,81 +270,3 @@ class TestGetLinearPlaneFromSignal2d:
         s = hs.signals.Signal1D(np.ones(10))
         with pytest.raises(ValueError):
             pst._get_linear_plane_from_signal2d(s)
-
-
-class TestGetSignalMeanPositionAndValue:
-    def test_simple(self):
-        s = hs.signals.Signal2D(np.zeros((10, 10)))
-        # s has the values 0 to 9, so middle position will be 4.5
-        output = pst._get_signal_mean_position_and_value(s)
-        assert len(output) == 3
-        assert output[0] == 4.5  # x-position
-        assert output[1] == 4.5  # y-position
-        assert output[2] == 0.0  # Mean value
-
-    def test_mean_value(self):
-        s = hs.signals.Signal2D(np.ones((10, 10)) * 9)
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output[2] == 9.0
-
-    def test_non_square_shape(self):
-        s = hs.signals.Signal2D(np.zeros((10, 5)))
-        # s gets the shape 5, 10. Due to the axes being reversed
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output[0] == 2.0
-        assert output[1] == 4.5
-
-    def test_wrong_input_dimensions(self):
-        s = hs.signals.Signal2D(np.ones((2, 10, 10)))
-        with pytest.raises(ValueError):
-            pst._get_signal_mean_position_and_value(s)
-        s = hs.signals.Signal2D(np.ones((2, 2, 10, 10)))
-        with pytest.raises(ValueError):
-            pst._get_signal_mean_position_and_value(s)
-        s = hs.signals.Signal1D(np.ones(10))
-        with pytest.raises(ValueError):
-            pst._get_signal_mean_position_and_value(s)
-
-    def test_origin(self):
-        s = hs.signals.Signal2D(np.zeros((20, 10)))
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (4.5, 9.5, 0)
-        s.axes_manager[0].offset = 10
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (14.5, 9.5, 0)
-        s.axes_manager[1].offset = 6
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (14.5, 15.5, 0)
-        s.axes_manager[1].offset = -5
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (14.5, 4.5, 0)
-        s.axes_manager[1].offset = -50
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (14.5, -40.5, 0)
-
-    def test_scale(self):
-        s = hs.signals.Signal2D(np.ones((20, 10)))
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (4.5, 9.5, 1)
-        s.axes_manager[0].scale = 2
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (9, 9.5, 1)
-        s.axes_manager[0].scale = 0.5
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (2.25, 9.5, 1)
-        s.axes_manager[1].scale = 10
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (2.25, 95.0, 1)
-
-    def test_origin_and_scale(self):
-        s = hs.signals.Signal2D(np.zeros((30, 10)))
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (4.5, 14.5, 0)
-        s.axes_manager[0].offset = 10
-        s.axes_manager[0].scale = 0.5
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (12.25, 14.5, 0)
-        s.axes_manager[1].offset = -50
-        s.axes_manager[1].scale = 2
-        output = pst._get_signal_mean_position_and_value(s)
-        assert output == (12.25, -21.0, 0)

--- a/pyxem/tests/utils/test_dpc_signal_tools.py
+++ b/pyxem/tests/utils/test_dpc_signal_tools.py
@@ -233,7 +233,7 @@ class TestGetCornerValues:
             pst._get_corner_values(s)
 
 
-class TestFitRampToImage:
+class TestGetLinearPlaneFromSignal2d:
     def test_zero_values(self):
         data = np.zeros((100, 100))
         s = hs.signals.Signal2D(data)
@@ -279,13 +279,13 @@ class TestFitRampToImage:
     def test_wrong_input_dimensions(self):
         s = hs.signals.Signal2D(np.ones((2, 10, 10)))
         with pytest.raises(ValueError):
-            pst._fit_ramp_to_image(s)
+            pst._get_linear_plane_from_signal2d(s)
         s = hs.signals.Signal2D(np.ones((2, 2, 10, 10)))
         with pytest.raises(ValueError):
-            pst._fit_ramp_to_image(s)
+            pst._get_linear_plane_from_signal2d(s)
         s = hs.signals.Signal1D(np.ones(10))
         with pytest.raises(ValueError):
-            pst._fit_ramp_to_image(s)
+            pst._get_linear_plane_from_signal2d(s)
 
 
 class TestGetSignalMeanPositionAndValue:

--- a/pyxem/tests/utils/test_dpc_signal_tools.py
+++ b/pyxem/tests/utils/test_dpc_signal_tools.py
@@ -270,3 +270,10 @@ class TestGetLinearPlaneFromSignal2d:
         s = hs.signals.Signal1D(np.ones(10))
         with pytest.raises(ValueError):
             pst._get_linear_plane_from_signal2d(s)
+
+    def test_wrong_map_dimensions(self):
+        s = hs.signals.Signal2D(np.ones((2, 10, 10)))
+        mask = np.zeros((11, 9), dtype=np.bool)
+        with pytest.raises(ValueError):
+            pst._get_linear_plane_from_signal2d(s, mask=mask)
+

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -21,6 +21,7 @@ import dask.array as da
 from skimage.feature import match_template, blob_dog, blob_log
 import scipy.ndimage as ndi
 from skimage import morphology
+from hyperspy.misc.utils import isiterable
 
 
 def align_single_frame(image, shifts, **kwargs):
@@ -124,13 +125,16 @@ def _get_chunking(signal, chunk_shape=None, chunk_bytes=None):
         chunk_bytes = "30MiB"
     nav_dim = signal.axes_manager.navigation_dimension
     sig_dim = signal.axes_manager.signal_dimension
-
+    if chunk_shape is not None:
+        if not isiterable(chunk_shape):
+            chunk_shape = [chunk_shape] * nav_dim
+    
     chunks_dict = {}
     for i in range(nav_dim):
         if chunk_shape is None:
             chunks_dict[i] = "auto"
         else:
-            chunks_dict[i] = chunk_shape
+            chunks_dict[i] = chunk_shape[i]
     for i in range(nav_dim, nav_dim + sig_dim):
         chunks_dict[i] = -1
 

--- a/pyxem/utils/pixelated_stem_tools.py
+++ b/pyxem/utils/pixelated_stem_tools.py
@@ -100,45 +100,6 @@ def _make_circular_mask(centerX, centerY, imageSizeX, imageSizeY, radius):
     return mask
 
 
-def _get_signal_mean_position_and_value(signal):
-    """Get the scaled position and mean data value from a signal.
-
-    Note: due to how HyperSpy numbers the axis values, the results
-    can sometimes be not as expected. For example, the signal
-    initialized Signal2D(np.zeros((10, 10))) will the output of this
-    function will be (4.5, 4.5, 0), due to the axis values being
-    from 0 to 9 (see example).
-
-    Parameters
-    ----------
-    signal : HyperSpy signal
-        Must have 2 signal dimensions and 0 navigation dimensions.
-
-    Returns
-    -------
-    output_values : tuple (x_mean, y_mean, value_mean)
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> import hyperspy.api as hs
-    >>> import pyxem.utils.pixelated_stem_tools as pst
-    >>> s = hs.signals.Signal2D(np.zeros((10, 10)))
-    >>> pst._get_signal_mean_position_and_value(s)
-    (4.5, 4.5, 0.0)
-
-    """
-    if len(signal.axes_manager.navigation_axes) != 0:
-        raise ValueError("signal need to have 0 navigation dimensions")
-    if len(signal.axes_manager.signal_axes) != 2:
-        raise ValueError("signal need to have 2 signal dimensions")
-    sam = signal.axes_manager.signal_axes
-    x_mean = sam[0].axis.mean()
-    y_mean = sam[1].axis.mean()
-    value_mean = signal.data.mean()
-    return (x_mean, y_mean, value_mean)
-
-
 def _get_corner_slices(s, corner_size=0.05):
     """Get signal slices for the corner positions for a Signal2D.
 


### PR DESCRIPTION
## Background

A common artifact in scanning electron diffraction is dscan, where the center position of the diffraction position shifts as a function of scan position. This effect is typically a slow and monotonic "shift" of the center position, in (most) cases being close to linear. There are ways of removing this effect in pyxem, for example via `Diffraction2D.center_direct_beam`. It works by finding the direct beam position in each scan position, and moving this to the center of the signal dimensions. This works for a large number of samples, where the direct beam is clearly visible, and fairly homogeneous.

However, for parts of some samples, the material can be so thick or heavily diffracting, that the center position of the direct beam is hard to resolve. In that situation, we can use some more ideal reference region to find the amount of dscan. Next, a linear plane can be fitted to these regions to find the dscan in the thick/heavily diffracting regions.

----------
## Changes

This pull request implements a new class, `BeamShift`, to handle exactly this. It inherits Signal1D, and has the beam position in the signal dimension, and the scan positions in the navigation dimensions.

- `get_direct_beam_position` now return this new class
- The class has the `make_linear_plane` method which fits a linear plane to the x and y beam positions, and replaces the original data with this plane. This function has a `mask` parameter, which is used to mask any "bad" regions.
    * This can then be passed as `center_direct_beam(shifts=s_beam_shift)`
- The class also has a `to_dpcsignal()`, which transposes the `BeamShift` class, and returns a `DPCSignal` object (which is more focused on analysing the beam shift itself, for example magnetic or ferroelectric materials).

In addition, the pull request changes the `_fit_ramp_to_image` to make it more general, to facilitate the aforementioned processing.

----------
## Todo list

- [x]  Is `BeamShift` a good class name?
- [x]  Finish implementation
- [x]  Change and add new unit tests
- [ ]  Add this functionality to a notebook

--------
## Comments

- This type of processing might be tricky for lazy processing, as the scan positions are no longer independent from each other. Thus, currently `make_linear_plane` does not have a lazy version. In practice, the easiest way of doing this is by first running `s_beam_shift.compute()`.

The functionality can also be useful for getting potentially better direct beam centering, since currently inhomogeneities in the direct beam can lead to erroneous shifting of the direct beam. For example in the image, where many of the variations are due to grain boundaries:

![beam_shift_x](https://user-images.githubusercontent.com/1690979/111919588-0a21b300-8a8b-11eb-81d0-a9ce104a5210.png)

By replacing this "raw" direct beam position with a fitted linear plane, the effect from the grain boundaries will be diminished.

--------
## Future work

- For larger scan areas, a linear plane isn't enough to model the dscan. For this, a vacuum scan might be necessary. There should be some functionality for handling this.