### PR TITLE
Applies a numpy-object deprecation and a patch for .map 1.6.2

### DIFF
--- a/pyxem/dummy_data/dummy_data.py
+++ b/pyxem/dummy_data/dummy_data.py
@@ -709,7 +709,7 @@ def get_nanobeam_electron_diffraction_signal():
     di2 = di0.copy()
     di2.rotation = -10
 
-    position_array0 = np.zeros((50, 50), dtype=np.bool)
+    position_array0 = np.zeros((50, 50), dtype=bool)
     r = np.array([15, 15, 0, 0])
     c = np.array([0, 15, 31, 0])
     rr, cc = polygon(r, c)
@@ -720,7 +720,7 @@ def get_nanobeam_electron_diffraction_signal():
     rr, cc = polygon(r, c)
     position_array0[rr, cc] = True
 
-    position_array1 = np.zeros((50, 50), dtype=np.bool)
+    position_array1 = np.zeros((50, 50), dtype=bool)
     r = np.array([32, 41, 41, 49, 49])
     c = np.array([0, 18, 49, 49, 0])
     rr, cc = polygon(r, c)

--- a/pyxem/dummy_data/make_diffraction_test_data.py
+++ b/pyxem/dummy_data/make_diffraction_test_data.py
@@ -884,7 +884,7 @@ def _make_4d_peak_array_test_data(xf, yf, semi0, semi1, rot, nt=20):
     >>> mt.add_peak_array_to_signal_as_markers(s, peak_array)
 
     """
-    peak_array = np.empty_like(xf, dtype=np.object)
+    peak_array = np.empty_like(xf, dtype=object)
     for iy, ix in np.ndindex(peak_array.shape):
         params = (xf[iy, ix], yf[iy, ix], semi0[iy, ix], semi1[iy, ix], rot[iy, ix], nt)
         ellipse_points = ret.make_ellipse_data_points(*params)
@@ -1115,7 +1115,7 @@ class DiffractionTestDataset:
         >>> di_rot = di.copy()
         >>> di_rot.rotation = 10
         >>> dtd = mdtd.DiffractionTestDataset(10, 10, 256, 256)
-        >>> position_array = np.ones((10, 10), dtype=np.bool)
+        >>> position_array = np.ones((10, 10), dtype=bool)
         >>> position_array[:5] = False
         >>> dtd.add_diffraction_image(di, position_array)
         >>> dtd.add_diffraction_image(di_rot, np.invert(position_array))
@@ -1150,7 +1150,7 @@ class DiffractionTestDataset:
         detector_x, detector_y = self.detector_x, self.detector_y
         image = diffraction_test_image.get_diffraction_test_image()
         if position_array is None:
-            position_array = np.ones((probe_x, probe_y), dtype=np.bool)
+            position_array = np.ones((probe_x, probe_y), dtype=bool)
         for ix, iy in np.ndindex(probe_x, probe_y):
             if position_array[ix, iy]:
                 self.data[ix, iy, :, :] = image

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -471,7 +471,7 @@ def _refine_best_orientations(
         top_matches[i] = result[0]
         res_rhkls.append(result[1])
 
-    res = np.empty(2, dtype=np.object)
+    res = np.empty(2, dtype=object)
     res[0] = top_matches
     res[1] = np.asarray(res_rhkls)
     return res
@@ -607,7 +607,7 @@ def _refine_orientation(
         center_y=center_y,
     )
 
-    res = np.empty(2, dtype=np.object)
+    res = np.empty(2, dtype=object)
     res[0] = orientation
     res[1] = rhklss
 

--- a/pyxem/generators/subpixelrefinement_generator.py
+++ b/pyxem/generators/subpixelrefinement_generator.py
@@ -103,7 +103,7 @@ def _get_pixel_vectors(dp, vectors, calibration, center):
     """
 
     def _floor(vectors, calibration, center):
-        if vectors.shape == (1,) and vectors.dtype == np.object:
+        if vectors.shape == (1,) and vectors.dtype == object:
             vectors = vectors[0]
         return np.floor((vectors.astype(np.float64) / calibration) + center).astype(
             np.int

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -465,7 +465,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         Using a mask array
 
         >>> import numpy as np
-        >>> mask_array = np.zeros((128, 128), dtype=np.bool)
+        >>> mask_array = np.zeros((128, 128), dtype=bool)
         >>> mask_array[:, 100:] = True
         >>> s = pxm.dummy_data.get_dead_pixel_signal()
         >>> s_dead_pixels = s.find_dead_pixels(
@@ -528,7 +528,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         Using a mask array
 
         >>> import numpy as np
-        >>> mask_array = np.zeros((128, 128), dtype=np.bool)
+        >>> mask_array = np.zeros((128, 128), dtype=bool)
         >>> mask_array[:, 100:] = True
         >>> s = pxm.dummy_data.get_hot_pixel_signal()
         >>> s_hot_pixels = s.find_hot_pixels(
@@ -1064,8 +1064,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         edge = r_outer - r_inner
         edge_slice = np.s_[edge:-edge, edge:-edge]
 
-        ring_inner = morphology.disk(r_inner, dtype=np.bool)
-        ring = morphology.disk(r_outer, dtype=np.bool)
+        ring_inner = morphology.disk(r_inner, dtype=bool)
+        ring = morphology.disk(r_outer, dtype=bool)
         ring[edge_slice] = ring[edge_slice] ^ ring_inner
         s = self.template_match_with_binary_image(
             ring, lazy_result=lazy_result, show_progressbar=show_progressbar
@@ -1502,7 +1502,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         warnings.warn("This method is depreacted and will be removed in the next version",FutureWarning)
         det_shape = self.axes_manager.signal_shape
         if (cx is None) or (cy is None) or (r is None):
-            mask_array = np.zeros(det_shape[::-1], dtype=np.bool)
+            mask_array = np.zeros(det_shape[::-1], dtype=bool)
         else:
             mask_array = pst._make_circular_mask(cx, cy, det_shape[0], det_shape[1], r)
             mask_array = np.invert(mask_array)

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 import warnings
 
 import hyperspy.api as hs
-from hyperspy.signals import Signal2D
+from hyperspy.signals import Signal2D, BaseSignal
 from hyperspy._signals.lazy import LazySignal
 from hyperspy._signals.signal1d import LazySignal1D
 from hyperspy._signals.signal2d import LazySignal2D
@@ -200,18 +200,18 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             shift_x, shift_y = pst._make_centre_array_from_signal(
                 self, x=shift_x, y=shift_y
             )
-        shift_x = shift_x.flatten()
-        shift_y = shift_y.flatten()
-        iterating_kwargs = [("shift_x", shift_x), ("shift_y", shift_y)]
+        s_shift_x = BaseSignal(shift_x).T
+        s_shift_y = BaseSignal(shift_y).T
 
-        s_shift = self._map_iterate(
+        s_shift = self.map(
             pst._shift_single_frame,
-            iterating_kwargs=iterating_kwargs,
             inplace=inplace,
             ragged=False,
             parallel=parallel,
             show_progressbar=show_progressbar,
             interpolation_order=interpolation_order,
+            shift_x=s_shift_x,
+            shift_y=s_shift_y,
         )
         if not inplace:
             return s_shift

--- a/pyxem/signals/segments.py
+++ b/pyxem/signals/segments.py
@@ -239,7 +239,7 @@ class LearningSegment:
                 threshold=threshold,
                 exclude_border=exclude_border,
             ),
-            dtype=np.object,
+            dtype=object,
         )
 
         segments, factors_of_segments = [], []

--- a/pyxem/signals/virtual_dark_field_image.py
+++ b/pyxem/signals/virtual_dark_field_image.py
@@ -98,7 +98,7 @@ class VirtualDarkFieldImage(Signal2D):
         # TODO : Add aperture radius as an attribute of VDFImage?
 
         # Create an array of length equal to the number of vectors where each
-        # element is a np.object with shape (n: number of segments for this
+        # element is a object with shape (n: number of segments for this
         # VDFImage, VDFImage size x, VDFImage size y).
         vdfsegs = np.array(
             vdfs.map(
@@ -113,7 +113,7 @@ class VirtualDarkFieldImage(Signal2D):
                 threshold=threshold,
                 exclude_border=exclude_border,
             ),
-            dtype=np.object,
+            dtype=object,
         )
 
         segments, vectors_of_segments = [], []

--- a/pyxem/tests/signals/test_differential_phase_contrast.py
+++ b/pyxem/tests/signals/test_differential_phase_contrast.py
@@ -254,7 +254,7 @@ class TestBivariateHistogram:
         s_hist = s.get_bivariate_histogram(bins=10, histogram_range=(-5, 5))
         assert s_hist.isig[3.0, 0.0] == float(value)
 
-        masked = np.zeros((11, 11), dtype=np.bool)
+        masked = np.zeros((11, 11), dtype=bool)
         masked[0, 0] = True
         s_hist = s.get_bivariate_histogram(
             bins=10, histogram_range=(-5, 5), masked=masked

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -1290,7 +1290,7 @@ class TestFindHotPixels:
         assert not s_hot_pixels.data.any()
 
     def test_mask_array(self, hot_pixel_data_2d):
-        mask_array = np.ones_like(hot_pixel_data_2d.data, dtype=np.bool)
+        mask_array = np.ones_like(hot_pixel_data_2d.data, dtype=bool)
         s_hot_pixels = hot_pixel_data_2d.find_hot_pixels(mask_array=mask_array)
         assert not s_hot_pixels.data.any()
 
@@ -1347,7 +1347,7 @@ class TestFindDeadPixels:
         assert not s_dead_pixels.data.any()
 
     def test_mask_array(self, dead_pixel_data_2d):
-        mask_array = np.ones_like(dead_pixel_data_2d.data, dtype=np.bool)
+        mask_array = np.ones_like(dead_pixel_data_2d.data, dtype=bool)
         s_dead_pixels = dead_pixel_data_2d.find_dead_pixels(mask_array=mask_array)
         assert not s_dead_pixels.data.any()
 

--- a/pyxem/tests/signals/test_pixelated_stem_class.py
+++ b/pyxem/tests/signals/test_pixelated_stem_class.py
@@ -91,7 +91,7 @@ class TestDiffraction2DFlipDiffraction:
 class TestAddPeakArrayAsMarkers:
     def test_simple(self):
         s = Diffraction2D(np.zeros((2, 3, 100, 100)))
-        peak_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
         for index in np.ndindex(peak_array.shape):
             islice = np.s_[index]
             peak_array[islice] = np.random.randint(20, 80, (100, 2))
@@ -99,7 +99,7 @@ class TestAddPeakArrayAsMarkers:
 
     def test_color(self):
         s = Diffraction2D(np.zeros((2, 3, 100, 100)))
-        peak_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
         for index in np.ndindex(peak_array.shape):
             islice = np.s_[index]
             peak_array[islice] = np.random.randint(20, 80, (100, 2))
@@ -109,7 +109,7 @@ class TestAddPeakArrayAsMarkers:
 
     def test_size(self):
         s = Diffraction2D(np.zeros((2, 3, 100, 100)))
-        peak_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
         for index in np.ndindex(peak_array.shape):
             islice = np.s_[index]
             peak_array[islice] = np.random.randint(20, 80, (100, 2))
@@ -119,7 +119,7 @@ class TestAddPeakArrayAsMarkers:
 
     def test_3d_nav_dims(self):
         s = Diffraction2D(np.zeros((2, 3, 4, 100, 100)))
-        peak_array = np.empty((2, 3, 4), dtype=np.object)
+        peak_array = np.empty((2, 3, 4), dtype=object)
         for index in np.ndindex(peak_array.shape):
             islice = np.s_[index]
             peak_array[islice] = np.random.randint(20, 80, (100, 2))
@@ -130,7 +130,7 @@ class TestAddPeakArrayAsMarkers:
     def test_1d_nav_dims(self):
         nav_dim = 3
         s = Diffraction2D(np.zeros((nav_dim, 100, 100)))
-        peak_array = np.empty(nav_dim, dtype=np.object)
+        peak_array = np.empty(nav_dim, dtype=object)
         for index in np.ndindex(peak_array.shape):
             islice = np.s_[index]
             peak_array[islice] = np.random.randint(20, 80, (100, 2))

--- a/pyxem/tests/utils/test_cluster_tools.py
+++ b/pyxem/tests/utils/test_cluster_tools.py
@@ -149,7 +149,7 @@ class TestFilterPeakListRadius:
 
 class TestFilterPeakArrayRadius:
     def test_simple(self):
-        peak_array = np.empty(shape=(2, 3), dtype=np.object)
+        peak_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_array[ix, iy] = np.random.randint(30, 70, size=(1000, 2))
         peak_array_filtered = ct._filter_peak_array_radius(peak_array, 50, 50, r_min=10)
@@ -158,7 +158,7 @@ class TestFilterPeakArrayRadius:
             assert len(peak_array_filtered[ix, iy]) != 1000
 
     def test_r_lim(self):
-        peak_array = np.empty(shape=(2, 3), dtype=np.object)
+        peak_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_array[ix, iy] = np.random.randint(30, 70, size=(1000, 2))
         peak_array_filtered = ct._filter_peak_array_radius(peak_array, 50, 50, r_min=50)
@@ -166,7 +166,7 @@ class TestFilterPeakArrayRadius:
             assert len(peak_array_filtered[ix, iy]) == 0
 
     def test_r_max(self):
-        peak_array = np.empty(shape=(2, 3), dtype=np.object)
+        peak_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_array[ix, iy] = np.random.randint(30, 70, size=(1000, 2))
         peak_array_filtered0 = ct._filter_peak_array_radius(peak_array, 0, 0, r_max=20)
@@ -177,7 +177,7 @@ class TestFilterPeakArrayRadius:
             assert len(peak_array_filtered1[ix, iy]) == 1000
 
     def test_r_min_and_r_max(self):
-        peak_array = np.empty(shape=(2, 3), dtype=np.object)
+        peak_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_array[ix, iy] = np.random.randint(30, 70, size=(1000, 2))
         peak_array_filtered0 = ct._filter_peak_array_radius(
@@ -197,7 +197,7 @@ class TestFilterPeakArrayRadius:
             assert len(peak_array_filtered2[ix, iy]) == 0
 
     def test_xc(self):
-        peak_array = np.empty(shape=(2, 3), dtype=np.object)
+        peak_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_array[ix, iy] = np.random.randint(30, 70, size=(1000, 2))
         peak_array_filtered = ct._filter_peak_array_radius(peak_array, 10, 50, r_min=10)
@@ -205,7 +205,7 @@ class TestFilterPeakArrayRadius:
             assert len(peak_array_filtered[ix, iy]) == 1000
 
     def test_yc(self):
-        peak_array = np.empty(shape=(2, 3), dtype=np.object)
+        peak_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_list = np.random.randint(30, 70, size=(999, 2)).tolist()
             peak_list.append([10, 50])
@@ -437,7 +437,7 @@ class TestGetPeakArrayShape:
     @pytest.mark.parametrize("ndim", [0, 1, 2, 3, 4, 5, 6])
     def test_dtype_object(self, ndim):
         shape = tuple(np.random.randint(2, 5, size=ndim))
-        peak_array = np.empty(shape, dtype=np.object)
+        peak_array = np.empty(shape, dtype=object)
         shape_output = ct._get_peak_array_shape(peak_array)
         assert shape == shape_output
 

--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -169,7 +169,7 @@ class TestProcessChunk:
 
     @pytest.mark.parametrize(
         "dtype",
-        [np.float16, np.float32, np.uint8, np.uint32, np.int8, np.int32, np.bool],
+        [np.float16, np.float32, np.uint8, np.uint32, np.int8, np.int32, bool],
     )
     def test_dtype(self, dtype):
         chunk_input = np.zeros((3, 4, 10, 8), dtype=np.int16)
@@ -300,7 +300,7 @@ class TestProcessDaskArray:
 
     @pytest.mark.parametrize(
         "dtype",
-        [np.float16, np.float32, np.uint8, np.uint32, np.int8, np.int32, np.bool],
+        [np.float16, np.float32, np.uint8, np.uint32, np.int8, np.int32, bool],
     )
     def test_dtype(self, dtype):
         dask_input = da.zeros((4, 6, 8, 10), chunks=(2, 2, 2, 2), dtype=np.uint16)
@@ -348,12 +348,12 @@ class TestProcessDaskArray:
             test_function,
             chunks=(2, 2),
             drop_axis=(2, 3),
-            dtype=np.object,
+            dtype=object,
             new_axis=None,
             output_signal_size=(),
         )
         array_output = dask_output.compute()
-        assert array_output.dtype == np.object
+        assert array_output.dtype == object
         for iy, ix in np.ndindex(array_output.shape):
             assert array_output[iy, ix] == list(range(11))
 
@@ -719,8 +719,8 @@ class TestThresholdArray:
         data = dt._threshold_array(dask_array, threshold_value=1)
         data = data.compute()
         assert data.shape == shape
-        assert data.dtype == np.bool
-        assert (data[slice_array] == np.ones((10, 12), dtype=np.bool)).all()
+        assert data.dtype == bool
+        assert (data[slice_array] == np.ones((10, 12), dtype=bool)).all()
         data[slice_array] = False
         assert (data == np.zeros(shape)).all()
 
@@ -1087,8 +1087,8 @@ class TestPeakPositionRefinementCOM:
         numpy_array = np.zeros(shape)
         numpy_array[:, :, 25, 25] = 1
 
-        peak_array = np.zeros((shape[0], shape[1], 1, 1), dtype=np.object)
-        real_array = np.zeros((shape[:-2]), dtype=np.object)
+        peak_array = np.zeros((shape[0], shape[1], 1, 1), dtype=object)
+        real_array = np.zeros((shape[:-2]), dtype=object)
         for index in np.ndindex(shape[:-2]):
             islice = np.s_[index]
             peak_array[islice][0, 0] = np.asarray([(27, 27)])
@@ -1111,8 +1111,8 @@ class TestPeakPositionRefinementCOM:
         numpy_array = np.zeros((10, 10, 50, 50))
         numpy_array[:, :, 25, 25] = 1
 
-        peak_array = np.zeros((numpy_array.shape[:-2]), dtype=np.object)
-        real_array = np.zeros((numpy_array.shape[:-2]), dtype=np.object)
+        peak_array = np.zeros((numpy_array.shape[:-2]), dtype=object)
+        real_array = np.zeros((numpy_array.shape[:-2]), dtype=object)
         for index in np.ndindex(numpy_array.shape[:-2]):
             islice = np.s_[index]
             peak_array[islice] = np.asarray([(27, 27)])
@@ -1137,7 +1137,7 @@ class TestPeakPositionRefinementCOM:
         chunks = [1] * nav_dims
         chunks.extend([25, 25])
         dask_array = da.random.random(size=shape, chunks=chunks)
-        peak_array = np.zeros((dask_array.shape[:-2]), dtype=np.object)
+        peak_array = np.zeros((dask_array.shape[:-2]), dtype=object)
         for index in np.ndindex(dask_array.shape[:-2]):
             islice = np.s_[index]
             peak_array[islice] = np.asarray([(27, 27)])
@@ -1368,7 +1368,7 @@ class TestIntensityArray:
         numpy_array[:, :, 27, 27] = 1
 
         peak_array = np.zeros(
-            (numpy_array.shape[0], numpy_array.shape[1]), dtype=np.object
+            (numpy_array.shape[0], numpy_array.shape[1]), dtype=object
         )
         for index in np.ndindex(numpy_array.shape[:-2]):
             islice = np.s_[index]
@@ -1388,7 +1388,7 @@ class TestIntensityArray:
         numpy_array[:, :, 27, 27] = 1
 
         peak_array = np.zeros(
-            (numpy_array.shape[0], numpy_array.shape[1]), dtype=np.object
+            (numpy_array.shape[0], numpy_array.shape[1]), dtype=object
         )
         for index in np.ndindex(numpy_array.shape[:-2]):
             islice = np.s_[index]
@@ -1409,7 +1409,7 @@ class TestIntensityArray:
         chunks = [1] * nav_dims
         chunks.extend([25, 25])
         dask_array = da.random.random(size=shape, chunks=chunks)
-        peak_array = np.zeros((dask_array.shape[:-2]), dtype=np.object)
+        peak_array = np.zeros((dask_array.shape[:-2]), dtype=object)
         for index in np.ndindex(dask_array.shape[:-2]):
             islice = np.s_[index]
             peak_array[islice] = np.asarray([(27, 27)])
@@ -1428,7 +1428,7 @@ class TestIntensityArray:
     def test_non_dask_array(self):
         data_array = np.ones((10, 10, 50, 50))
         data_array_dask = da.ones((10, 10, 50, 50), chunks=(2, 2, 25, 25))
-        peak_array = np.empty((10, 10), dtype=np.object)
+        peak_array = np.empty((10, 10), dtype=object)
         peak_array_dask = da.from_array(peak_array, chunks=(2, 2))
         with pytest.raises(ValueError):
             dt._intensity_peaks_image(data_array, peak_array_dask, 5)
@@ -1440,12 +1440,12 @@ class TestIntensityArray:
 
     def test_non_square_datasets(self):
         data_array_dask = da.ones((6, 16, 100, 50), chunks=(2, 2, 25, 25))
-        peak_array_dask = da.empty((6, 16), chunks=(2, 2), dtype=np.object)
+        peak_array_dask = da.empty((6, 16), chunks=(2, 2), dtype=object)
         dt._intensity_peaks_image(data_array_dask, peak_array_dask, 5)
 
     def test_different_chunks(self):
         data_array_dask = da.ones((6, 16, 100, 50), chunks=(6, 4, 50, 25))
-        peak_array_dask = da.empty((6, 16), chunks=(3, 2), dtype=np.object)
+        peak_array_dask = da.empty((6, 16), chunks=(3, 2), dtype=object)
         dt._intensity_peaks_image(data_array_dask, peak_array_dask, 5)
 
 

--- a/pyxem/tests/utils/test_marker_tools.py
+++ b/pyxem/tests/utils/test_marker_tools.py
@@ -27,7 +27,7 @@ import pyxem.utils.marker_tools as mt
 
 class TestGet4DMarkerList:
     def test_simple(self):
-        peak_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
         peak_array[0, 0] = [[2, 4]]
         peak_array[0, 1] = [[8, 2]]
         peak_array[0, 2] = [[1, 8]]
@@ -76,11 +76,11 @@ class TestGet4DMarkerList:
         assert len(marker_list) == 3
 
     def test_bool_array(self):
-        peak_array = np.empty((2, 3), dtype=np.object)
-        bool_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
+        bool_array = np.empty((2, 3), dtype=object)
         for ix, iy in np.ndindex(peak_array.shape):
             peak_array[ix, iy] = np.random.randint(9, size=(1, 2))
-            bool_array[ix, iy] = np.random.randint(0, 2, size=1, dtype=np.bool)
+            bool_array[ix, iy] = np.random.randint(0, 2, size=1, dtype=bool)
 
         s = Diffraction2D(np.zeros(shape=(2, 3, 10, 10)))
         marker_list = mt._get_4d_points_marker_list(
@@ -102,7 +102,7 @@ class TestGet4DMarkerList:
                 assert marker.get_data_position("y1") == -1000.0
 
     def test_several_markers_different_peak_array_size(self):
-        peak_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
         peak_array[0, 0] = [[2, 4], [1, 9]]
         peak_array[0, 1] = [[8, 2]]
         s = Diffraction2D(np.zeros(shape=(2, 3, 10, 10)))
@@ -119,8 +119,8 @@ class TestFilterPeakArrayListBoolArray:
             mt._filter_peak_array_with_bool_array(peak_array, bool_array)
 
     def test_filter(self):
-        peak_array = np.empty((2, 3), dtype=np.object)
-        bool_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
+        bool_array = np.empty((2, 3), dtype=object)
         peak_array[0, 0] = [[2, 4], [1, 9], [4, 5]]
         peak_array[0, 1] = [[8, 2]]
         bool_array[0, 0] = [True, False, True]
@@ -133,8 +133,8 @@ class TestFilterPeakArrayListBoolArray:
         assert_equal(peak_array_filter[0, 1], [[8, 2]])
 
     def test_bool_invert(self):
-        peak_array = np.empty((2, 3), dtype=np.object)
-        bool_array = np.empty((2, 3), dtype=np.object)
+        peak_array = np.empty((2, 3), dtype=object)
+        bool_array = np.empty((2, 3), dtype=object)
         peak_array[0, 0] = [[2, 4], [1, 9], [4, 5]]
         peak_array[0, 1] = [[8, 2]]
         bool_array[0, 0] = [True, False, True]

--- a/pyxem/tests/utils/test_pixelated_stem_tools.py
+++ b/pyxem/tests/utils/test_pixelated_stem_tools.py
@@ -254,7 +254,7 @@ class TestGetAngleSectorMask:
         data = np.ones(data_shape) * 100.0
         s = Signal2D(data)
         mask0 = pst._get_angle_sector_mask(s, angle0=0.0, angle1=np.pi / 2)
-        np.testing.assert_array_equal(mask0, np.zeros_like(mask0, dtype=np.bool))
+        np.testing.assert_array_equal(mask0, np.zeros_like(mask0, dtype=bool))
         assert mask0.shape == data_shape
 
         s.axes_manager.signal_axes[0].offset = -5
@@ -262,7 +262,7 @@ class TestGetAngleSectorMask:
         mask1 = pst._get_angle_sector_mask(s, angle0=0.0, angle1=np.pi / 2)
         assert mask1[:5, :5].all()
         mask1[:5, :5] = False
-        np.testing.assert_array_equal(mask1, np.zeros_like(mask1, dtype=np.bool))
+        np.testing.assert_array_equal(mask1, np.zeros_like(mask1, dtype=bool))
 
         s.axes_manager.signal_axes[0].offset = -15
         s.axes_manager.signal_axes[1].offset = -15
@@ -293,7 +293,7 @@ class TestGetAngleSectorMask:
         data = np.ones(data_shape) * 100.0
         s = Signal2D(data)
         mask0 = pst._get_angle_sector_mask(s, angle0=0.0, angle1=np.pi / 2)
-        np.testing.assert_array_equal(mask0, np.zeros_like(mask0, dtype=np.bool))
+        np.testing.assert_array_equal(mask0, np.zeros_like(mask0, dtype=bool))
         assert mask0.shape == data_shape
 
         s.axes_manager.signal_axes[0].offset = -5
@@ -301,7 +301,7 @@ class TestGetAngleSectorMask:
         mask1 = pst._get_angle_sector_mask(s, angle0=0.0, angle1=np.pi / 2)
         assert mask1[:, :4, :5].all()
         mask1[:, :4, :5] = False
-        np.testing.assert_array_equal(mask1, np.zeros_like(mask1, dtype=np.bool))
+        np.testing.assert_array_equal(mask1, np.zeros_like(mask1, dtype=bool))
 
     def test_2d(self):
         data_shape = (3, 5, 7, 10)

--- a/pyxem/tests/utils/test_ransac_ellipse_tools.py
+++ b/pyxem/tests/utils/test_ransac_ellipse_tools.py
@@ -768,7 +768,7 @@ class TestGetInlierOutlierPeakArrays:
     def test_simple(self):
         x, y, n = 2, 3, 10
         peak_array = np.arange(y * x * n * 2).reshape((y, x, n, 2))
-        inlier_array = np.ones((y, x, n), dtype=np.bool)
+        inlier_array = np.ones((y, x, n), dtype=bool)
         inlier_parray0, outlier_parray0 = ret._get_inlier_outlier_peak_arrays(
             peak_array, inlier_array
         )
@@ -784,7 +784,7 @@ class TestGetInlierOutlierPeakArrays:
     def test_some_true_some_false(self):
         x, y, n = 2, 3, 10
         peak_array = np.arange(y * x * n * 2).reshape((y, x, n, 2))
-        inlier_array = np.ones((y, x, n), dtype=np.bool)
+        inlier_array = np.ones((y, x, n), dtype=bool)
         inlier_array[:, :, 4:] = False
         inlier_parray, outlier_parray = ret._get_inlier_outlier_peak_arrays(
             peak_array, inlier_array
@@ -798,7 +798,7 @@ class TestGetInlierOutlierPeakArrays:
     def test_inlier_none(self):
         x, y, n = 2, 3, 10
         peak_array = np.arange(y * x * n * 2).reshape((y, x, n, 2))
-        inlier_array = np.empty((y, x), dtype=np.object)
+        inlier_array = np.empty((y, x), dtype=object)
         for iy, ix in np.ndindex(inlier_array.shape):
             inlier_array[iy, ix] = None
 
@@ -834,7 +834,7 @@ class TestGetLinesArrayFromEllipseArray:
         sx_array = np.random.randint(70, 80, size=(2, 3))
         sy_array = np.random.randint(89, 99, size=(2, 3))
         ro_array = np.zeros((2, 3))
-        ellipse_array = np.empty((2, 3), dtype=np.object)
+        ellipse_array = np.empty((2, 3), dtype=object)
         for iy, ix in np.ndindex(ellipse_array.shape):
             xc, yc = xc_array[iy, ix], yc_array[iy, ix]
             sx, sy = sx_array[iy, ix], sy_array[iy, ix]
@@ -853,7 +853,7 @@ class TestGetLinesArrayFromEllipseArray:
             assert approx(lines_list[3]) == [yc, xc - sx, yc + sy, xc]
 
     def test_ellipse_array_none(self):
-        ellipse_array = np.empty(shape=(2, 3), dtype=np.object)
+        ellipse_array = np.empty(shape=(2, 3), dtype=object)
         for ix, iy in np.ndindex(ellipse_array.shape):
             ellipse_array[ix, iy] = None
         lines_array = ret._get_lines_array_from_ellipse_array(ellipse_array)
@@ -918,7 +918,7 @@ class TestGetEllipseMarkerListFromEllipseArray:
         sx_array = np.random.randint(70, 80, size=(2, 3))
         sy_array = np.random.randint(89, 99, size=(2, 3))
         ro_array = np.zeros((2, 3))
-        ellipse_array = np.empty((2, 3), dtype=np.object)
+        ellipse_array = np.empty((2, 3), dtype=object)
         for iy, ix in np.ndindex(ellipse_array.shape):
             xc, yc = xc_array[iy, ix], yc_array[iy, ix]
             sx, sy = sx_array[iy, ix], sy_array[iy, ix]

--- a/pyxem/utils/cluster_tools.py
+++ b/pyxem/utils/cluster_tools.py
@@ -91,7 +91,7 @@ def _filter_4D_peak_array(
         max_x_index = signal_axes[0].high_index
         max_y_index = signal_axes[1].high_index
     peak_array_shape = _get_peak_array_shape(peak_array)
-    peak_array_filtered = np.empty(shape=peak_array_shape, dtype=np.object)
+    peak_array_filtered = np.empty(shape=peak_array_shape, dtype=object)
     for index in np.ndindex(peak_array_shape):
         islice = np.s_[index]
         peak_list_filtered = _filter_peak_list(
@@ -174,7 +174,7 @@ def _filter_peak_array_radius(peak_array, xc, yc, r_min=None, r_max=None):
         xc = np.ones(peak_array.shape[:2]) * xc
     if not isiterable(yc):
         yc = np.ones(peak_array.shape[:2]) * yc
-    peak_array_filtered = np.empty(shape=peak_array.shape[:2], dtype=np.object)
+    peak_array_filtered = np.empty(shape=peak_array.shape[:2], dtype=object)
     for iy, ix in np.ndindex(peak_array.shape[:2]):
         temp_xc, temp_yc = xc[iy, ix], yc[iy, ix]
         peak_list_filtered = _filter_peak_list_radius(
@@ -225,7 +225,7 @@ def _filter_peak_list_radius(peak_list, xc, yc, r_min=None, r_max=None):
             raise ValueError(
                 "r_min ({0}) must be smaller than r_max ({1})".format(r_min, r_max)
             )
-    filter_list = np.ones_like(dist, dtype=np.bool)
+    filter_list = np.ones_like(dist, dtype=bool)
     if r_min is not None:
         temp_filter_list = dist > r_min
         filter_list[:] = np.logical_and(filter_list, temp_filter_list)
@@ -352,7 +352,7 @@ def _get_peak_array_shape(peak_array):
     peak_array_shape : tuple
 
     """
-    if peak_array.dtype == np.object:
+    if peak_array.dtype == object:
         peak_array_shape = peak_array.shape
     else:
         peak_array_shape = peak_array.shape[:-2]
@@ -393,9 +393,9 @@ def _cluster_and_sort_peak_array(
 
     """
     peak_array_shape = _get_peak_array_shape(peak_array)
-    peak_centre_array = np.empty(shape=peak_array_shape, dtype=np.object)
-    peak_rest_array = np.empty(shape=peak_array_shape, dtype=np.object)
-    peak_none_array = np.empty(shape=peak_array_shape, dtype=np.object)
+    peak_centre_array = np.empty(shape=peak_array_shape, dtype=object)
+    peak_rest_array = np.empty(shape=peak_array_shape, dtype=object)
+    peak_none_array = np.empty(shape=peak_array_shape, dtype=object)
     for index in np.ndindex(peak_array_shape):
         islice = np.s_[index]
         cluster_dict = _get_cluster_dict(

--- a/pyxem/utils/dask_tools.py
+++ b/pyxem/utils/dask_tools.py
@@ -278,7 +278,7 @@ def _process_dask_array(
     Getting output which is different shape than the input. For example
     two coordinates. Note: the output size must be the same for all the
     navigation positions. If the size is variable, for example with peak
-    finding, use dtype=np.object (see below).
+    finding, use dtype=object (see below).
 
     >>> def test_function3(image):
     ...     return [10, 3]
@@ -290,7 +290,7 @@ def _process_dask_array(
     ...     new_axis=new_axis, output_signal_size=(2, ))
 
     For functions where we don't know the shape of the output data,
-    use dtype=np.object
+    use dtype=object
 
     >>> def test_function4(image):
     ...     return list(range(np.random.randint(20)))
@@ -298,7 +298,7 @@ def _process_dask_array(
     >>> drop_axis = (len(dask_array.shape) - 2, len(dask_array.shape) - 1)
     >>> output_dask_array = _process_dask_array(
     ...     dask_array, test_function4, chunks=chunks, drop_axis=drop_axis,
-    ...     new_axis=None, dtype=np.object, output_signal_size=())
+    ...     new_axis=None, dtype=object, output_signal_size=())
     >>> output_array = output_dask_array.compute()
 
     """
@@ -441,7 +441,7 @@ def _mask_array(dask_array, mask_array, fill_value=None):
                 mask_array.shape, dask_array.shape[-2:]
             )
         )
-    mask_array_4d = da.ones_like(dask_array, dtype=np.bool)
+    mask_array_4d = da.ones_like(dask_array, dtype=bool)
     mask_array_4d = mask_array_4d[:, :] * mask_array
     dask_array_masked = da.ma.masked_array(
         dask_array, mask_array_4d, fill_value=fill_value
@@ -758,7 +758,7 @@ def _peak_find_dog(dask_array, **kwargs):
         _peak_find_dog_chunk,
         dask_array_rechunked,
         drop_axis=drop_axis,
-        dtype=np.object,
+        dtype=object,
         **kwargs
     )
     return output_array
@@ -898,7 +898,7 @@ def _peak_find_log(dask_array, **kwargs):
         _peak_find_log_chunk,
         dask_array_rechunked,
         drop_axis=drop_axis,
-        dtype=np.object,
+        dtype=object,
         **kwargs
     )
     return output_array
@@ -1060,7 +1060,7 @@ def _find_dead_pixels(dask_array, dead_pixel_value=0, mask_array=None):
 
     With a mask
 
-    >>> mask_array = np.zeros((128, 128), dtype=np.bool)
+    >>> mask_array = np.zeros((128, 128), dtype=bool)
     >>> mask_array[:, :100] = True
     >>> dead_pixels = dt._find_dead_pixels(s.data, mask_array=mask_array)
 
@@ -1211,7 +1211,7 @@ def _intensity_peaks_image_chunk(data, peak_array, disk_r):
     >>> intensity = dt._intensity_peaks_image_chunk(s.data, peak_array, 5)
     """
 
-    output_array = np.empty(data.shape[:-2], dtype=np.object)
+    output_array = np.empty(data.shape[:-2], dtype=object)
     if peak_array.ndim < data.ndim:
         dim_dif = data.ndim - peak_array.ndim
         for i in range(dim_dif):
@@ -1291,7 +1291,7 @@ def _intensity_peaks_image(dask_array, peak_array, disk_r):
         dask_array_rechunked,
         peak_array_rechunked,
         drop_axis=drop_axis,
-        dtype=np.object,
+        dtype=object,
         **kwargs_intensity_peaks
     )
     return output_array
@@ -1651,7 +1651,7 @@ def _peak_refinement_centre_of_mass_chunk(data, peak_array, square_size):
 
 
     """
-    output_array = np.empty(data.shape[:-2], dtype=np.object)
+    output_array = np.empty(data.shape[:-2], dtype=object)
     if peak_array.ndim < data.ndim:
         dim_dif = data.ndim - peak_array.ndim
         for i in range(dim_dif):
@@ -1722,7 +1722,7 @@ def _peak_refinement_centre_of_mass(dask_array, peak_array, square_size):
         dask_array_rechunked,
         peak_array_rechunked,
         drop_axis=drop_axis,
-        dtype=np.object,
+        dtype=object,
         **kwargs_refinement
     )
     return output_array

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -283,7 +283,7 @@ def match_vectors(
             [phase index, rotation matrix, match rate, error hkls, total error]
 
     """
-    if peaks.shape == (1,) and peaks.dtype == np.object:
+    if peaks.shape == (1,) and peaks.dtype == object:
         peaks = peaks[0]
 
     # Assign empty array to hold indexation results. The n_best best results
@@ -423,7 +423,7 @@ def match_vectors(
     # when the two tuple values have the same first dimension), we cannot
     # return a tuple directly, but instead have to format the result as an
     # array ourselves.
-    res = np.empty(2, dtype=np.object)
+    res = np.empty(2, dtype=object)
     res[0] = top_matches
     res[1] = np.asarray(res_rhkls)
     return res

--- a/pyxem/utils/marker_tools.py
+++ b/pyxem/utils/marker_tools.py
@@ -63,7 +63,7 @@ def _get_4d_points_marker_list(
             peaks_list, bool_array, bool_invert=bool_invert
         )
     max_peaks = 0
-    if peaks_list.dtype == np.object:
+    if peaks_list.dtype == object:
         peaks_list_shape = peaks_list.shape
     else:
         peaks_list_shape = peaks_list.shape[:-2]
@@ -124,10 +124,10 @@ def _filter_peak_array_with_bool_array(peak_array, bool_array, bool_invert=False
             "bool_array {0} and peak_array {1} must have the"
             " same shape".format(bool_array.shape, peak_array.shape)
         )
-    peak_array_filter = np.empty(shape=(peak_array.shape[:2]), dtype=np.object)
+    peak_array_filter = np.empty(shape=(peak_array.shape[:2]), dtype=object)
     for ix, iy in np.ndindex(peak_array.shape[:2]):
         peak_list = np.array(peak_array[ix, iy])
-        bool_list = np.array(bool_array[ix, iy], dtype=np.bool)
+        bool_list = np.array(bool_array[ix, iy], dtype=bool)
         if bool_invert:
             bool_list = ~bool_list
         peak_list = peak_list[bool_list]

--- a/pyxem/utils/pixelated_stem_tools.py
+++ b/pyxem/utils/pixelated_stem_tools.py
@@ -396,7 +396,7 @@ def _get_angle_sector_mask(
             "angle1 ({0}) needs to be larger than angle0 ({1})".format(angle1, angle0)
         )
 
-    bool_array = np.zeros_like(signal.data, dtype=np.bool)
+    bool_array = np.zeros_like(signal.data, dtype=bool)
     for s in signal:
         indices = signal.axes_manager.indices[::-1]
         signal_axes = s.axes_manager.signal_axes

--- a/pyxem/utils/ransac_ellipse_tools.py
+++ b/pyxem/utils/ransac_ellipse_tools.py
@@ -401,8 +401,8 @@ def get_ellipse_model_ransac(
     if not isiterable(yf):
         yf = np.ones(data.shape[:2]) * yf
 
-    ellipse_array = np.zeros(data.shape[:2], dtype=np.object)
-    inlier_array = np.zeros(data.shape[:2], dtype=np.object)
+    ellipse_array = np.zeros(data.shape[:2], dtype=object)
+    inlier_array = np.zeros(data.shape[:2], dtype=object)
     num_total = data.shape[0] * data.shape[1]
     t = tqdm(np.ndindex(data.shape[:2]), disable=not show_progressbar, total=num_total)
     for iy, ix in t:
@@ -485,7 +485,7 @@ def _get_lines_array_from_ellipse_array(ellipse_array, nr=20):
     Examples
     --------
     >>> import pyxem.utils.ransac_ellipse_tools as ret
-    >>> ellipse_array = np.empty((2, 3), dtype=np.object)
+    >>> ellipse_array = np.empty((2, 3), dtype=object)
     >>> ellipse_array[0, 0] = (30, 70, 10, 20, 0.5)
     >>> ellipse_array[1, 0] = (31, 69, 10, 21, 0.5)
     >>> ellipse_array[0, 1] = (29, 68, 10, 21, 0.1)
@@ -495,7 +495,7 @@ def _get_lines_array_from_ellipse_array(ellipse_array, nr=20):
     >>> larray = ret._get_lines_array_from_ellipse_array(ellipse_array, nr=20)
 
     """
-    lines_array = np.empty(ellipse_array.shape[:2], dtype=np.object)
+    lines_array = np.empty(ellipse_array.shape[:2], dtype=object)
     for ix, iy in np.ndindex(ellipse_array.shape[:2]):
         ellipse_params = ellipse_array[ix, iy]
         if ellipse_params is not None:
@@ -507,8 +507,8 @@ def _get_lines_array_from_ellipse_array(ellipse_array, nr=20):
 
 
 def _get_inlier_outlier_peak_arrays(peak_array, inlier_array):
-    inlier_peak_array = np.empty(peak_array.shape[:2], dtype=np.object)
-    outlier_peak_array = np.empty(peak_array.shape[:2], dtype=np.object)
+    inlier_peak_array = np.empty(peak_array.shape[:2], dtype=object)
+    outlier_peak_array = np.empty(peak_array.shape[:2], dtype=object)
     for ix, iy in np.ndindex(peak_array.shape[:2]):
         inliers = inlier_array[ix, iy]
         if inliers is not None:


### PR DESCRIPTION
---
name: Applies a numpy-object deprecation and a patch for .map 1.6.2
about: Cherry pick from #760 + closes #757 

---

**Checklist**
- [x] Confirm that tests pass
- [ ] Update CHANGELOG.md
