### PR TITLE
Add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-docs/build/
-docs/Makefile
+doc/build/
+doc/Makefile
 develop-eggs/
 dist/
 downloads/
@@ -69,7 +69,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
 
 # PyBuilder
 target/

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -1,0 +1,17 @@
+@misc{allen2021fast,
+      title={Fast Grain Mapping with Sub-Nanometer Resolution Using 4D-STEM with Grain Classification by Principal Component Analysis and Non-Negative Matrix Factorization},
+      author={Frances I Allen and Thomas C Pekin and Arun Persaud and Steven J Rozeveld and Gregory F Meyers and Jim Ciston and Colin Ophus and Andrew M Minor},
+      year={2021},
+      eprint={2103.07076},
+      archivePrefix={arXiv},
+      primaryClass={physics.app-ph}
+}
+
+@misc{jeong2021automated,
+      title={Automated crystal orientation mapping by precession electron diffraction assisted four-dimensional scanning transmission electron microscopy (4D-STEM) using a scintillator based CMOS detector},
+      author={Jiwon Jeong and Niels Cautaerts and Gerhard Dehm and Christian H. Liebscher},
+      year={2021},
+      eprint={2102.09711},
+      archivePrefix={arXiv},
+      primaryClass={physics.ins-det}
+}

--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -1,0 +1,11 @@
+Bibliography
+=============
+
+The articles listed here are the papers which cited pyxem.  They might be useful places to start
+if you are interested in the capabilities of pyxem.
+
+If there are any additional papers you think which should be listed here please contact
+pyxem.team@gmail.com.
+
+.. bibliography:: bibliography.bib
+    :all:

--- a/doc/cite.rst
+++ b/doc/cite.rst
@@ -1,0 +1,8 @@
+Citing pyxem
+=============
+If analysis using pyxem forms a part of published work please cite the work using the DOI
+10.5281/zenodo.2649351.
+
+In addition if you are releasing the data and code related to the work please add the link to the data
+on the Open Datasets page.
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,8 @@ import requests
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append("../")
+sys.path.append("../../pyxem-demos/")
+
 
 # Project information
 project = "pyxem"
@@ -154,7 +156,7 @@ nbsphinx_prolog = (
 """
 )
 # https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
-nbsphinx_execute = "always"  # auto, always, never
+nbsphinx_execute = "never"  # auto, always, never
 
 # sphinxcontrib-bibtex configuration
 bibtex_bibfiles = ["bibliography.bib"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,220 @@
+# Configuration file for the Sphinx documentation app.
+
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+from datetime import datetime
+import inspect
+import os
+from os.path import relpath, dirname
+import re
+import sys
+
+from pyxem import release_info
+import pyxem
+import requests
+
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.append("../")
+
+# Project information
+project = "pyxem"
+copyright = release_info.copyright
+author = release_info.author
+version = release_info.version
+release = release_info.version
+
+master_doc = "index"
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    "sphinxcontrib.bibtex",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.linkcode",
+    "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
+    "sphinx_gallery.load_style",
+    "nbsphinx",
+]
+
+# Create links to references within kikuchipy's documentation to these packages.
+intersphinx_mapping = {
+    "dask": ("https://docs.dask.org/en/latest", None),
+    "diffpy.structure": ("https://www.diffpy.org/diffpy.structure", None),
+    "diffsims": ("https://diffsims.readthedocs.io/en/latest", None),
+    "hyperspy": ("http://hyperspy.org/hyperspy-doc/current", None),
+    "matplotlib": ("https://matplotlib.org", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "orix": ("https://orix.readthedocs.io/en/stable", None),
+    "python": ("https://docs.python.org/3", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "skimage": ("https://scikit-image.org/docs/stable", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
+    "h5py": ("http://docs.h5py.org/en/stable/", None),
+}
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = [
+    "_templates",
+]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files. This image also affects
+# html_static_path and html_extra_path.
+exclude_patterns = [
+    "build",
+    "_static/v0.2.0/*.ipynb",
+]
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for a
+# list of builtin themes.
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files, so
+# a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = [
+    "_static",
+]
+html_css_files = [
+    "style.css",
+]
+
+# Syntax highlighting
+pygments_style = "friendly"
+
+napoleon_google_docstring = False
+napoleon_use_param = False
+napoleon_use_ivar = True
+
+
+# Logo
+cmap = "hot"
+html_logo = f"_static/icon/logo.svg"
+html_favicon = f"_static/icon/logo.png"
+
+# Read the Docs theme options
+html_theme_options = {
+    "prev_next_buttons_location": "bottom",
+}
+
+# Figure references
+numfig = True
+
+# nbsphinx configuration
+# Taken from nbsphinx' own nbsphinx configuration file, with slight
+# modification to point nbviewer and Binder to the GitHub master links
+# when the documentation is launched from a kikuchipy version with
+# "dev" in the version.
+if "dev" in version:
+    release_version = "master"
+else:
+    release_version = "v" + version
+# This is processed by Jinja2 and inserted before each notebook
+nbsphinx_prolog = (
+    r"""
+{% set docname = 'doc/' + env.doc2path(env.docname, base=None) %}
+.. raw:: html
+    <style>a:hover { text-decoration: underline; }</style>
+    <div class="admonition note">
+      This page was generated from
+      <a class="reference external" href="https://github.com/pyxem/kikuchipy/blob/"""
+    + f"{release_version}"
+    + r"""/{{ docname|e }}">{{ docname|e }}</a>.
+      Interactive online version:
+      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/pyxem/kikuchipy/"""
+    + f"{release_version}"
+    + r"""?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
+      <script>
+        if (document.location.host) {
+          $(document.currentScript).replaceWith(
+            '<a class="reference external" ' +
+            'href="https://nbviewer.jupyter.org/url' +
+            (window.location.protocol == 'https:' ? 's/' : '/') +
+            window.location.host +
+            window.location.pathname.slice(0, -4) +
+            'ipynb">View in <em>nbviewer</em></a>.'
+          );
+        }
+      </script>
+    </div>
+.. raw:: latex
+    \nbsphinxstartnotebook{\scriptsize\noindent\strut
+    \textcolor{gray}{The following section was generated from
+    \sphinxcode{\sphinxupquote{\strut {{ docname | escape_latex }}}} \dotfill}}
+"""
+)
+# https://nbsphinx.readthedocs.io/en/0.8.0/never-execute.html
+nbsphinx_execute = "always"  # auto, always, never
+
+# sphinxcontrib-bibtex configuration
+bibtex_bibfiles = ["bibliography.bib"]
+
+
+def linkcode_resolve(domain, info):
+    """Determine the URL corresponding to Python object.
+    This is taken from SciPy's conf.py:
+    https://github.com/scipy/scipy/blob/master/doc/source/conf.py.
+    """
+    if domain != "py":
+        return None
+
+    modname = info["module"]
+    fullname = info["fullname"]
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except Exception:
+            return None
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except Exception:
+        fn = None
+    if not fn:
+        try:
+            fn = inspect.getsourcefile(sys.modules[obj.__module__])
+        except Exception:
+            fn = None
+    if not fn:
+        return None
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except Exception:
+        lineno = None
+
+    if lineno:
+        linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
+    else:
+        linespec = ""
+
+    startdir = os.path.abspath(os.path.join(dirname(pyxem.__file__), ".."))
+    fn = relpath(fn, start=startdir).replace(os.path.sep, "/")
+
+    if fn.startswith("pyxem/"):
+        m = re.match(r"^.*dev0\+([a-f0-9]+)$", pyxem.__version__)
+        pre_link = "https://github.com/pyxem/kikuchipy/blob/"
+        if m:
+            return pre_link + "%s/%s%s" % (m.group(1), fn, linespec)
+        elif "dev" in pyxem.__version__:
+            return pre_link + "master/%s%s" % (fn, linespec)
+        else:
+            return pre_link + "v%s/%s%s" % (pyxem.__version__, fn, linespec)
+    else:
+        return None

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,0 +1,208 @@
+=============
+Contributing
+=============
+
+pyxem is meant to be a community maintained project. We welcome
+contributions in the form of bug reports, documentation, code, feature requests,
+and more. These guidelines provide resources on how best to contribute.
+
+For new users, checking out the `GitHub guides <https://guides.github.com>`_ are
+recommended.
+
+Questions, comments, and feedback
+=================================
+
+Have any questions, comments, suggestions for improvements, or any other
+inquiries regarding the project? Feel free to
+`ask a question <https://github.com/pyxem/pyxem/discussions>`_,
+`open an issue <https://github.com/pyxem/pyxem/issues>`_ or
+`make a pull request <https://github.com/pyxem/pyxem/pulls>`_ in our GitHub
+repository.
+
+Code of Conduct
+===============
+
+pyxem has a Code of conduct that should be honoured
+by everyone who participates in the pyxem community.
+
+.. _setting-up-a-development-installation:
+
+Setting up a development installation
+=====================================
+
+You need a `fork <https://guides.github.com/activities/forking/#fork>`_ of the
+`repository <https://github.com/pyxem/pyxem>`_ in order to make changes
+to pyxem.
+
+Make a local copy of your forked repository and change directories::
+
+    $ git clone https://github.com/your-username/pyxem.git
+    $ cd pyxem
+
+Set the ``upstream`` remote to the main pyxem repository::
+
+    $ git remote add upstream https://github.com/pyxem/pyxem.git
+
+We recommend installing in a `conda environment
+<https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
+with the `Miniconda distribution
+<https://docs.conda.io/en/latest/miniconda.html>`_::
+
+   $ conda create --name pyxem
+   $ conda activate pyxem
+
+Then, install the required dependencies while making the development version
+available globally (in the ``conda`` environment)::
+
+   $ pip install --editable .[dev]
+
+This installs all necessary development dependencies, including those for
+running tests and building documentation.
+
+Code style
+==========
+
+The code making up pyxem is formatted closely following the `Style Guide for
+Python Code <https://www.python.org/dev/peps/pep-0008/>`_ with `The Black Code
+style <https://black.readthedocs.io/en/stable/the_black_code_style.html>`_. We
+use `pre-commit <https://pre-commit.com>`_ to run ``black`` automatically prior
+to each local commit. Please install it in your environment::
+
+    $ pre-commit install
+
+Next time you commit some code, your code will be formatted inplace according
+to our `black configuration
+<https://github.com/pyxem/pyxem/blob/master/pyproject.toml>`_.
+
+Note that ``black`` won't format `docstrings
+<https://www.python.org/dev/peps/pep-0257/>`_. We follow the `numpydoc
+<https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
+standard.
+
+Comment lines should preferably be limited to 72 characters.
+
+Package imports should be structured into three blocks with blank lines between
+them (descending order): standard library (like ``os`` and ``typing``), third
+party packages (like ``numpy`` and ``hyperspy``) and finally pyxem imports.
+
+Making changes
+==============
+
+Create a new feature branch::
+
+    $ git checkout master -b your-awesome-feature-name
+
+When you've made some changes you can view them with::
+
+    $ git status
+
+Add and commit your created, modified or deleted files::
+
+   $ git add my-file-or-directory
+   $ git commit -s -m "An explanatory commit message"
+
+The ``-s`` makes sure that you sign your commit with your `GitHub-registered
+email <https://github.com/settings/emails>`_ as the author. You can set this up
+following `this GitHub guide
+<https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address>`_.
+
+Keeping your branch up-to-date
+==============================
+
+Switch to the ``master`` branch::
+
+   $ git checkout master
+
+Fetch changes and update ``master``::
+
+   $ git pull upstream master --tags
+
+Update your feature branch::
+
+   $ git checkout your-awesome-feature-name
+   $ git merge master
+
+Sharing your changes
+====================
+
+Update your remote branch::
+
+   $ git push -u origin your-awesome-feature-name
+
+You can then make a `pull request
+<https://guides.github.com/activities/forking/#making-a-pull-request>`_ to
+pyxem's ``master`` branch. Good job!
+
+Building and writing documentation
+==================================
+
+We use `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for documenting
+functionality. Install necessary dependencies to build the documentation::
+
+   $ pip install --editable .[doc]
+
+Then, build the documentation from the ``doc`` directory::
+
+   $ cd doc
+   $ make html
+
+The documentation's HTML pages are built in the ``doc/build/html`` directory
+from files in the `reStructuredText (reST)
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+plaintext markup language. They should be accessible in the browser by typing
+``file:///your-absolute/path/to/pyxem/doc/build/html/index.html`` in the
+address bar.
+
+Tips for writing Jupyter Notebooks that are meant to be converted to reST text
+files by `nbsphinx <https://nbsphinx.readthedocs.io/en/latest/>`_:
+
+- Use ``_ = ax[0].imshow(...)`` to disable Matplotlib output if a Matplotlib
+  command is the last line in a cell.
+- Refer to our API reference with this general MD
+  ``[azimuthal_integrator2d()](reference.rst#pyxem.signals.DiffractionSignal2D.azimuthal_integrator2d)``. Remember
+  to add the parentheses ``()``.
+- Reference external APIs via standard MD like
+  ``[Signal2D](http://hyperspy.org/hyperspy-doc/current/api/hyperspy._signals.signal2d.html)``.
+- The Sphinx gallery thumbnail used for a notebook is set by adding the
+  ``nbsphinx-thumbnail`` tag to a code cell with an image output. The notebook
+  must be added to the gallery in the README.rst to be included in the
+  documentation pages.
+
+Running and writing tests
+=========================
+
+All functionality in pyxem is tested via the `pytest
+<https://docs.pytest.org>`_ framework. The tests reside in a ``test`` directory
+within each module. Tests are short methods that call functions in pyxem
+and compare resulting output values with known answers. Install necessary
+dependencies to run the tests::
+
+   $ pip install --editable .[tests]
+
+
+To run the tests::
+
+   $ pytest --cov --pyargs pyxem
+
+The ``--cov`` flag makes `coverage.py
+<https://coverage.readthedocs.io/en/latest/>`_ print a nice report in the
+terminal. For an even nicer presentation, you can use ``coverage.py`` directly::
+
+   $ coverage html
+
+Then, you can open the created ``htmlcov/index.html`` in the browser and inspect
+the coverage in more detail.
+
+Docstring examples are tested
+`with pytest <https://docs.pytest.org/en/stable/doctest.html>`_ as well::
+
+   $ pytest --doctest-modules --ignore-glob=pyxem/*/tests
+
+Continuous integration (CI)
+===========================
+
+We use `GitHub Actions <https://github.com/pyxem/pyxem/actions>`_ to ensure
+that pyxem can be installed on Windows, macOS and Linux (Ubuntu). After a
+successful installation, the CI server runs the tests. After the tests return no
+errors, code coverage is reported to `Coveralls
+<https://coveralls.io/github/pyxem/pyxem?branch=master>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,30 +24,30 @@ on some function then you can use the API reference or search the documentation.
 
 The Jupyter Notebooks should give you good workflows for analyzing your dataset
 
-What do I do if I get stuck?
------------------------------
-The first step is looking at the documentation. Often times there will be examples with
-the documentation which are good places to start.
+.. nbgallery::
+    :caption: User guide
+    :glob:
 
-If you are still confused after that you can submit an issue on GitHub.
-
-
-I published some work using pyxem
-----------------------------------
-If pyxem helped you in publishing some data citing pyxem is very helpful in keeping track
-of different papers.  If you are publishing any of the code associated with the project we
-would love to link that as further examples for workflows using pyxem.
+    00Importinglargemibdatasets.ipynb
+    01GaAsNanowireDataInspectionPreprocessingUnsupervisedMachineLearning.ipynb
+    02GaAsNanowirePhaseMappingOrientationMapping.ipynb
+    03ReferenceStandardsDimensionCalibrationsRotationCalibrations.ipynb
+    04SimulateDataPhaseMappingOrientationMapping.ipynb
+    05SimulateDataStrainMapping.ipynb
+    06NanocrystalSegmentationInSPEDDataDemonstrationOnPartlyOverlappingMgOcubes.ipynb
+    07AzimuthalIntegrationUsingpyFAIDetector.ipynb
+    08PairDistributionFunctionAnalysis.ipynb
+    09AngularCorrelationsofAmorphousMaterials.ipynb
 
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+    :maxdepth: 1
+    :caption: Help
 
+    reference.rst
+    bibliography.rst
+    contributing.rst
+    open_datasets.rst
+    cite.rst
+    related_projects.rst
 
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,53 @@
+.. pyxem documentation master file, created by
+   sphinx-quickstart on Mon May 10 13:49:29 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to pyxem's documentation!
+=================================
+Pyxem is an open source project working to bring together tools for the analysis of
+data from pixilated electron detectors.  Based on the Hyperspy project, pyxem has an active
+community of users who are interested in many different areas including:
+
+- Orientation Mapping of Crystals
+- Strain Mapping
+- Virtual Dark Field Imaging
+- Differential Phase Contrast
+- Structural Characterization of Amorphous Materials
+- And much more!
+
+Where do I start?
+------------------
+For most cases starting with one of the linked jupyter notebooks is the
+correct place to start.  Otherwise is you are searching for documentation
+on some function then you can use the API reference or search the documentation.
+
+The Jupyter Notebooks should give you good workflows for analyzing your dataset
+
+What do I do if I get stuck?
+-----------------------------
+The first step is looking at the documentation. Often times there will be examples with
+the documentation which are good places to start.
+
+If you are still confused after that you can submit an issue on GitHub.
+
+
+I published some work using pyxem
+----------------------------------
+If pyxem helped you in publishing some data citing pyxem is very helpful in keeping track
+of different papers.  If you are publishing any of the code associated with the project we
+would love to link that as further examples for workflows using pyxem.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/doc/open_datasets.rst
+++ b/doc/open_datasets.rst
@@ -1,0 +1,12 @@
+Open datasets
+=============
+
+Here are some open datasets which are helpful for running some of the functions using real data.
+
+For the most part the  `data <https://drive.google.com/open?id=11CV7_wkFIsOtDICOcil8Bo25fo0NlR9I>`__
+used for the example jupyter notebooks are useful for testing and understanding
+how each workflow works.
+
+
+Other databases of interest:
+https://emdb.msae.wisc.edu/emdb/

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1,13 +1,13 @@
-=============
+===============
 API reference
-=============
+===============
 
 This reference manual details the public modules, classes, and functions in
 pyxem, as generated from their docstrings. Many of the docstrings contain
 examples and continued effort to improve these examples is on going.
 
 
-.. module:: pyxem
+.. currentmodule:: pyxem
 
 The list of top modules (and the load function):
 

--- a/doc/refernce.rst
+++ b/doc/refernce.rst
@@ -129,7 +129,6 @@ CommonDiffraction
 .. autoclass:: pyxem.signals.CommonDiffraction
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 Correlation2D
@@ -140,18 +139,6 @@ Correlation2D
 .. autoclass:: pyxem.signals.Correlation2D
     :members:
     :undoc-members:
-    :inherited-members:
-    :show-inheritance:
-
-BeamShift
-------------------
-
-.. currentmodule:: pyxem.signals.BeamShift
-
-.. autoclass:: pyxem.signals.BeamShift
-    :members:
-    :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 DPCSignal1D
@@ -162,7 +149,6 @@ DPCSignal1D
 .. autoclass:: pyxem.signals.DPCSignal1D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 DPCSignal2D
@@ -173,7 +159,6 @@ DPCSignal2D
 .. autoclass:: pyxem.signals.DPCSignal2D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 DiffractionVariance1D
@@ -184,7 +169,6 @@ DiffractionVariance1D
 .. autoclass:: pyxem.signals.DiffractionVariance1D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 DiffractionVariance2D
@@ -195,7 +179,6 @@ DiffractionVariance2D
 .. autoclass:: pyxem.signals.DiffractionVariance2D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 Diffraction1D
@@ -206,7 +189,6 @@ Diffraction1D
 .. autoclass:: pyxem.signals.Diffraction1D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 Diffraction2D
@@ -217,8 +199,7 @@ Diffraction2D
 .. autoclass:: pyxem.signals.Diffraction2D
     :members:
     :undoc-members:
-    :inherited-members:
-    :show-inheritance:
+    :show-inheritance: False
 
 ElectronDiffraction1D
 ----------------------
@@ -228,7 +209,6 @@ ElectronDiffraction1D
 .. autoclass:: pyxem.signals.ElectronDiffraction1D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 ElectronDiffraction2D
@@ -239,7 +219,6 @@ ElectronDiffraction2D
 .. autoclass:: pyxem.signals.ElectronDiffraction2D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 TemplateMatchingResults
@@ -250,7 +229,6 @@ TemplateMatchingResults
 .. autoclass:: pyxem.signals.TemplateMatchingResults
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 VectorMatchingResults
@@ -261,7 +239,6 @@ VectorMatchingResults
 .. autoclass:: pyxem.signals.VectorMatchingResults
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 PairDistributionFunction1D
@@ -272,7 +249,6 @@ PairDistributionFunction1D
 .. autoclass:: pyxem.signals.PairDistributionFunction1D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 PolarDiffraction2D
@@ -283,7 +259,6 @@ PolarDiffraction2D
 .. autoclass:: pyxem.signals.PolarDiffraction2D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 Power2D
@@ -294,7 +269,6 @@ Power2D
 .. autoclass:: pyxem.signals.Power2D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 ReducedIntensity1D
@@ -305,7 +279,6 @@ ReducedIntensity1D
 .. autoclass:: pyxem.signals.ReducedIntensity1D
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 LearningSegment
@@ -316,7 +289,6 @@ LearningSegment
 .. autoclass:: pyxem.signals.LearningSegment
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 VDFSegment
@@ -327,7 +299,6 @@ VDFSegment
 .. autoclass:: pyxem.signals.VDFSegment
     :members:
     :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 StrainMap
@@ -338,18 +309,6 @@ StrainMap
 .. autoclass:: pyxem.signals.StrainMap
     :members:
     :undoc-members:
-    :inherited-members:
-    :show-inheritance:
-
-Symmetry1D
-------------------
-
-.. currentmodule:: pyxem.signals.symmetry1d.Symmetry1D
-
-.. autoclass:: pyxem.signals.symmetry1d.Symmetry1D
-    :members:
-    :undoc-members:
-    :inherited-members:
     :show-inheritance:
 
 DisplacementGradientMap
@@ -360,8 +319,6 @@ DisplacementGradientMap
 .. autoclass:: pyxem.signals.DisplacementGradientMap
     :members:
     :undoc-members:
-    :inherited-members:
-    :show-inheritance:
 
 VirtualDarkFieldImage
 ----------------------
@@ -371,5 +328,3 @@ VirtualDarkFieldImage
 .. autoclass:: pyxem.signals.VirtualDarkFieldImage
     :members:
     :undoc-members:
-    :inherited-members:
-    :show-inheritance:

--- a/doc/refernce.rst
+++ b/doc/refernce.rst
@@ -1,0 +1,375 @@
+=============
+API reference
+=============
+
+This reference manual details the public modules, classes, and functions in
+pyxem, as generated from their docstrings. Many of the docstrings contain
+examples and continued effort to improve these examples is on going.
+
+
+.. module:: pyxem
+
+The list of top modules (and the load function):
+
+.. autosummary::
+    components
+    components
+    detectors
+    generators
+    libraries
+    signals
+    utils
+
+....
+
+Detectors
+===============
+
+.. automodule:: pyxem.detectors
+
+.. currentmodule:: pyxem.detectors
+
+.. autosummary::
+    GenericFlatDetector
+    Medipix256x256Detector
+    Medipix515x515Detector
+
+.. autoclass:: GenericFlatDetector
+.. autofunction:: Medipix256x256Detector
+.. autofunction:: Medipix515x515Detector
+
+....
+
+Generators
+===========
+
+.. currentmodule:: pyxem.generators
+
+.. autosummary::
+    CalibrationGenerator
+    get_DisplacementGradientMap
+    get_single_DisplacementGradientTensor
+    IndexationGenerator
+    VectorIndexationGenerator
+    TemplateIndexationGenerator
+    ProfileIndexationGenerator
+    AcceleratedIndexationGenerator
+    IntegrationGenerator
+    PDFGenerator1D
+    ReducedIntensityGenerator1D
+    SubpixelrefinementGenerator
+    VarianceGenerator
+    VirtualImageGenerator
+    VirtualDarkFieldGenerator
+
+.. automodule:: pyxem.generators
+    :members:
+    :undoc-members:
+
+....
+
+Libraries
+=========
+
+.. automodule:: pyxem.libraries
+
+.. autosummary::
+    CalibrationDataLibrary
+
+
+Signals
+==========
+
+.. automodule:: pyxem.signals
+
+.. currentmodule:: pyxem.signals
+
+.. autosummary::
+    CommonDiffraction
+    Correlation2D
+    LazyCorrelation2D
+    DPCBaseSignal
+    DPCSignal1D
+    DPCSignal2D
+    LazyDPCBaseSignal
+    LazyDPCSignal1D
+    LazyDPCSignal2D
+    DiffractionVariance1D
+    DiffractionVariance2D
+    ImageVariance
+    DiffractionVectors
+    DiffractionVectors2D
+    Diffraction1D
+    LazyDiffraction1D
+    Diffraction2D
+    LazyDiffraction2D
+    ElectronDiffraction1D
+    LazyElectronDiffraction1D
+    ElectronDiffraction2D
+    LazyElectronDiffraction2D
+    TemplateMatchingResults
+    VectorMatchingResults
+    PairDistributionFunction1D
+    PolarDiffraction2D
+    LazyPolarDiffraction2D
+    Power2D
+    LazyPower2D
+    ReducedIntensity1D
+    LearningSegment
+    VDFSegment
+    StrainMap
+    DisplacementGradientMap
+    VirtualDarkFieldImage
+
+CommonDiffraction
+-------------------
+
+.. currentmodule:: pyxem.signals.CommonDiffraction
+
+.. autoclass:: pyxem.signals.CommonDiffraction
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+Correlation2D
+------------------
+
+.. currentmodule:: pyxem.signals.Correlation2D
+
+.. autoclass:: pyxem.signals.Correlation2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+BeamShift
+------------------
+
+.. currentmodule:: pyxem.signals.BeamShift
+
+.. autoclass:: pyxem.signals.BeamShift
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+DPCSignal1D
+------------------
+
+.. currentmodule:: pyxem.signals.DPCSignal1D
+
+.. autoclass:: pyxem.signals.DPCSignal1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+DPCSignal2D
+------------------
+
+.. currentmodule:: pyxem.signals.DPCSignal2D
+
+.. autoclass:: pyxem.signals.DPCSignal2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+DiffractionVariance1D
+----------------------
+
+.. currentmodule:: pyxem.signals.DiffractionVariance1D
+
+.. autoclass:: pyxem.signals.DiffractionVariance1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+DiffractionVariance2D
+----------------------
+
+.. currentmodule:: pyxem.signals.DiffractionVariance2D
+
+.. autoclass:: pyxem.signals.DiffractionVariance2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+Diffraction1D
+------------------
+
+.. currentmodule:: pyxem.signals.Diffraction1D
+
+.. autoclass:: pyxem.signals.Diffraction1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+Diffraction2D
+------------------
+
+.. currentmodule:: pyxem.signals.Diffraction2D
+
+.. autoclass:: pyxem.signals.Diffraction2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+ElectronDiffraction1D
+----------------------
+
+.. currentmodule:: pyxem.signals.ElectronDiffraction1D
+
+.. autoclass:: pyxem.signals.ElectronDiffraction1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+ElectronDiffraction2D
+----------------------
+
+.. currentmodule:: pyxem.signals.ElectronDiffraction2D
+
+.. autoclass:: pyxem.signals.ElectronDiffraction2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+TemplateMatchingResults
+------------------------
+
+.. currentmodule:: pyxem.signals.TemplateMatchingResults
+
+.. autoclass:: pyxem.signals.TemplateMatchingResults
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+VectorMatchingResults
+----------------------
+
+.. currentmodule:: pyxem.signals.VectorMatchingResults
+
+.. autoclass:: pyxem.signals.VectorMatchingResults
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+PairDistributionFunction1D
+---------------------------
+
+.. currentmodule:: pyxem.signals.PairDistributionFunction1D
+
+.. autoclass:: pyxem.signals.PairDistributionFunction1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+PolarDiffraction2D
+-------------------
+
+.. currentmodule:: pyxem.signals.PolarDiffraction2D
+
+.. autoclass:: pyxem.signals.PolarDiffraction2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+Power2D
+------------------
+
+.. currentmodule:: pyxem.signals.Power2D
+
+.. autoclass:: pyxem.signals.Power2D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+ReducedIntensity1D
+-------------------
+
+.. currentmodule:: pyxem.signals.ReducedIntensity1D
+
+.. autoclass:: pyxem.signals.ReducedIntensity1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+LearningSegment
+------------------
+
+.. currentmodule:: pyxem.signals.LearningSegment
+
+.. autoclass:: pyxem.signals.LearningSegment
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+VDFSegment
+------------------
+
+.. currentmodule:: pyxem.signals.VDFSegment
+
+.. autoclass:: pyxem.signals.VDFSegment
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+StrainMap
+------------------
+
+.. currentmodule:: pyxem.signals.StrainMap
+
+.. autoclass:: pyxem.signals.StrainMap
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+Symmetry1D
+------------------
+
+.. currentmodule:: pyxem.signals.symmetry1d.Symmetry1D
+
+.. autoclass:: pyxem.signals.symmetry1d.Symmetry1D
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+DisplacementGradientMap
+------------------------
+
+.. currentmodule:: pyxem.signals.DisplacementGradientMap
+
+.. autoclass:: pyxem.signals.DisplacementGradientMap
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+VirtualDarkFieldImage
+----------------------
+
+.. currentmodule:: pyxem.signals.VirtualDarkFieldImage
+
+.. autoclass:: pyxem.signals.VirtualDarkFieldImage
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -1,0 +1,24 @@
+================
+Related projects
+================
+
+This is a non-exhaustive list of related, open-source projects.  Each project has strengths/weaknesses
+so it is important to see what project is best for your use case.
+
+- `HyperSpy <https://hyperspy.org>`_: Python library with tools for
+  multi-dimensional data analysis, which kikuchipy builds upon.
+- `kikuchipy <https://kikuchipy.org/en/stable/>`_: Kikuchi py
+- `orix <https://github.com/pyxem/orix>`_: Python library for handling crystal
+  orientation mapping data. Detailed example Jupyter Notebooks are available.
+- `diffsims <https://github.com/pyxem/diffsims>`_: Python library for simulating
+  diffraction.
+- `py4dSTEM <https://github.com/py4dstem/py4DSTEM>`_: Python library for
+  4D-STEM microscopy.
+- `pycroscopy <https://pycroscopy.github.io/pycroscopy/>`_: Python library for
+  scientific imaging and materials science
+- `pixstem <https://pixstem.org/>`_: Python library for pixalated STEM.  Merged into pyxem
+  but the documentation for pixstem is still a great reference
+- `libertem <https://libertem.github.io/LiberTEM/>`_: Python library for high-throughput distributed
+  processing of large-scale binary data sets using a simplified MapReduce programming model.
+
+

--- a/pyxem/generators/displacement_gradient_tensor_generator.py
+++ b/pyxem/generators/displacement_gradient_tensor_generator.py
@@ -115,7 +115,7 @@ def get_single_DisplacementGradientTensor(Vs, Vu=None, weights=None):
 
     L = np.linalg.lstsq(Vu, Vs, rcond=-1)[
         0
-    ]  # only need the return array, see np,linalg.lstsq docs
+    ]  # only need the return array, see np,linalg.lstsq doc
     # Put caculated matrix values into 3 x 3 matrix to be returned.
     D = np.eye(3)
     D[0:2, 0:2] = L

--- a/pyxem/signals/differential_phase_contrast.py
+++ b/pyxem/signals/differential_phase_contrast.py
@@ -309,7 +309,7 @@ class DPCSignal2D(Signal2D):
         Parameters
         ----------
         method : 'kottler', 'arnison' or 'frankot', optional
-            the formula to use, 'kottler'[1], 'arnison'[2] and 'frankot'[3]
+            the formula to use, [kottler]_, [arnison]_ and [frankot]_
             are available. The default is 'kottler'.
         mirroring : bool, optional
             whether to mirror the phase gradients before Fourier transformed.
@@ -332,25 +332,26 @@ class DPCSignal2D(Signal2D):
 
         References
         ----------
-        .. [1] Kottler, C., David, C., Pfeiffer, F. and Bunk, O., 2007. A
-        two-directional approach for grating based differential phase contrast
-        imaging using hard x-rays. Optics Express, 15(3), p.1175. (Equation 4)
+        .. [kottler] Kottler, C., David, C., Pfeiffer, F. and Bunk, O., 2007. A
+           two-directional approach for grating based differential phase contrast
+           imaging using hard x-rays. Optics Express, 15(3), p.1175. (Equation 4)
 
-        .. [2] Arnison, M., Larkin, K., Sheppard, C., Smith, N. and
-        Cogswell, C., 2004. Linear phase imaging using differential
-        interference contrast microscopy. Journal of Microscopy, 214(1),
-        pp.7-12. (Equation 6)
+        .. [arnison] Arnison, M., Larkin, K., Sheppard, C., Smith, N. and
+           Cogswell, C., 2004. Linear phase imaging using differential
+           interference contrast microscopy. Journal of Microscopy, 214(1),
+           pp.7-12. (Equation 6)
 
-        .. [3] Frankot, R. and Chellappa, R., 1988. A method for enforcing
-        integrability in shape from shading algorithms.
-        IEEE Transactions on Pattern Analysis and Machine Intelligence,
-        10(4), pp.439-451. (Equation 21)
+        .. [frankot] Frankot, R. and Chellappa, R., 1988. A method for enforcing
+           integrability in shape from shading algorithms.
+           IEEE Transactions on Pattern Analysis and Machine Intelligence,
+           10(4), pp.439-451. (Equation 21)
 
         Examples
         --------
         >>> s = pxm.dummy_data.get_square_dpc_signal()
         >>> s_phase = s.phase_retrieval()
         >>> s_phase.plot()
+
         """
 
         method = method.lower()

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1144,7 +1144,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         show_progressbar : bool, optional
             Default True
         **kwargs :
-            Passed to the peakfinder, see skimage docs for details
+            Passed to the peakfinder, see skimage doc for details
 
         Returns
         -------

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -47,6 +47,7 @@ def crystal_from_vector_matching(z_matches):
     results_array : numpy.array
         Crystallographic mapping results in an array of shape (3) with entries
         [phase, np.array((z, x, z)), dict(metrics)]
+
     """
     if z_matches.shape == (1,):  # pragma: no cover
         z_matches = z_matches[0]
@@ -91,6 +92,7 @@ def _peaks_from_best_template(single_match_result, library, rank=0):
     -------
     peaks : array
         Coordinates of peaks in the matching results object in calibrated units.
+
     """
     best_fit = get_nth_best_solution(single_match_result, "template", rank=rank)
 
@@ -117,6 +119,7 @@ def _get_best_match(z):
     -------
     z_best : np.array
         array with shape (5,)
+
     """
     return z[np.argmax(z[:, -1]),:] 
 
@@ -132,6 +135,7 @@ class GenericMatchingResults:
         Returns
         -------
         orix.CrystalMap
+
         """
         _s = self.data.map(_get_best_match, inplace=False)
 
@@ -172,6 +176,7 @@ class TemplateMatchingResults(GenericMatchingResults):
     Exporting the best matches to a crystal map
 
     >>> xmap = TemplateMatchingResult.to_crystal_map()
+
     """
 
     def plot_best_matching_results_on_signal(
@@ -192,6 +197,7 @@ class TemplateMatchingResults(GenericMatchingResults):
             Arguments passed to signal.plot()
         **kwargs :
             Keyword arguments passed to signal.plot()
+
         """
         match_peaks = self.data.map(
             _peaks_from_best_template, library=library, inplace=False
@@ -234,14 +240,15 @@ class VectorMatchingResults(BaseSignal):
             Crystallographic mapping results containing the best matching phase
             and orientation at each navigation position with associated metrics.
             The Signal at each navigation position is an array of,
-                            [phase, np.array((z,x,z)), dict(metrics)]
+            [phase, np.array((z,x,z)), dict(metrics)]
             which defines the phase, orientation as Euler angles in the zxz
             convention and metrics associated with the matching.
             Metrics for template matching results are
-                'match_rate'
-                'total_error'
-                'orientation_reliability'
-                'phase_reliability'
+            'match_rate'
+            'total_error'
+            'orientation_reliability'
+            'phase_reliability'
+
         """
         crystal_map = self.map(
             crystal_from_vector_matching, inplace=False, *args, **kwargs
@@ -264,6 +271,7 @@ class VectorMatchingResults(BaseSignal):
         -------
         indexed_vectors : DiffractionVectors
             An indexed diffraction vectors object.
+
         """
         if overwrite is False:
             if vectors.hkls is not None:

--- a/pyxem/utils/radial_utils.py
+++ b/pyxem/utils/radial_utils.py
@@ -594,7 +594,12 @@ def _get_ellipse_from_parameters(x, y, semi_len0, semi_len1, rot, r_scale=0.05):
 
 
 def _get_marker_list(
-    ellipse_parameters, x_list=None, y_list=None, name=None, r_scale=0.05
+        ellipse_parameters,
+        x_list=None,
+        y_list=None,
+        name=None,
+        r_scale=0.05,
+        image_scale=1,
 ):
     xC, yC, semi_len0, semi_len1, rot, ecce = _get_ellipse_parameters(
         ellipse_parameters
@@ -602,6 +607,8 @@ def _get_marker_list(
     xx, yy = _get_ellipse_from_parameters(
         xC, yC, semi_len0, semi_len1, rot, r_scale=r_scale
     )
+    xx= xx*image_scale
+    yy= yy*image_scale
     marker_list = []
     if x_list is not None:
         for x, y in zip(x_list, y_list):
@@ -676,7 +683,10 @@ def fit_single_ellipse_to_signal(
     x, y = _get_xy_points_from_radius_angle_plot(s_ra)
     ellipse_parameters = _fit_ellipse_to_xy_points(x, y)
     xC, yC, semi0, semi1, rot, ecc = _get_ellipse_parameters(ellipse_parameters)
-    marker_list = _get_marker_list(ellipse_parameters, x_list=x, y_list=y)
+    marker_list = _get_marker_list(ellipse_parameters,
+                                   x_list=x,
+                                   y_list=y,
+                                   image_scale=s.axes_manager.signal_axes[0].scale)
     s_m = s.deepcopy()
     s_m.add_marker(marker_list, permanent=True, plot_marker=False)
     return s_m, xC, yC, semi0, semi1, rot, ecc

--- a/pyxem/utils/ransac_ellipse_tools.py
+++ b/pyxem/utils/ransac_ellipse_tools.py
@@ -648,6 +648,7 @@ def determine_ellipse(signal,
                             mask=mask,
                             num_points=num_points)
     if guess_starting_params:
+        print("starting center", np.mean(pos[:, 0]),np.mean(pos[:, 1]))
         el, _ = get_ellipse_model_ransac_single_frame(pos,
                                               xf=np.mean(pos[:, 0]),
                                               yf=np.mean(pos[:, 1]),
@@ -662,4 +663,19 @@ def determine_ellipse(signal,
     else:
         el, _ = get_ellipse_model_ransac_single_frame(pos,
                                                      **kwargs)
-        return el
+    if el is not None:
+        affine = ellipse_to_affine(el.params[3],el.params[2], el.params[4])
+        center = (el.params[0],el.params[1])
+        return center, affine
+    else:
+        print("Ransac Ellipse detection did not converge")
+        return None
+def ellipse_to_affine(major, minor, rot):
+    Q = [[np.cos(rot), -np.sin(rot), 0],
+         [np.sin(rot), np.cos(rot), 0],
+         [0, 0, 1]]
+    S = [[(major / minor), 0, 0],
+         [0, major / minor, 0],
+         [0, 0, 1]]
+    C = np.matmul(np.matmul(Q, S), np.transpose(Q))
+    return C

--- a/pyxem/utils/ransac_ellipse_tools.py
+++ b/pyxem/utils/ransac_ellipse_tools.py
@@ -617,6 +617,7 @@ def determine_ellipse(signal,
                       mask=None,
                       num_points=1000,
                       guess_starting_params=True,
+                      plot=True,
                       **kwargs,
                       ):
     """
@@ -635,6 +636,8 @@ def determine_ellipse(signal,
         The number of points to consider
     guess_starting_params: bool
         If True then the starting parameters will be guessed based on the points determined.
+    plot: bool
+        If true then the points chosen to fit the ellipse to are shown.
     **kwargs:
         Any other keywords for ` get_ellipse_model_ransac_single_frame`
 
@@ -648,8 +651,10 @@ def determine_ellipse(signal,
     pos = get_max_positions(signal,
                             mask=mask,
                             num_points=num_points)
-    import matplotlib.pyplot as plt
-    plt.scatter(pos[:,0], pos[:,1])
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.scatter(pos[:,0], pos[:,1])
+        plt.show()
     if guess_starting_params:
         el, _ = get_ellipse_model_ransac_single_frame(pos,
                                               xf=np.mean(pos[:, 0]),

--- a/pyxem/utils/ransac_ellipse_tools.py
+++ b/pyxem/utils/ransac_ellipse_tools.py
@@ -23,6 +23,7 @@ import numpy as np
 from skimage.measure import EllipseModel, ransac
 from hyperspy.misc.utils import isiterable
 import pyxem.utils.marker_tools as mt
+from hyperspy.signal import BaseSignal
 
 
 def is_ellipse_good(
@@ -574,3 +575,91 @@ def _get_ellipse_markers(
         marker_list.extend(marker_in_list)
         marker_list.extend(marker_out_list)
     return marker_list
+
+def get_max_positions(signal,
+                      mask=None,
+                      num_points=5000,
+                      ):
+    """ Gets the top num_points pixels in the dataset.
+
+    Parameters
+    --------------
+    signal: BaseSignal
+        The signal which we want to find the max positions for.
+    mask: np.array
+        A mask to be applied to the data for values to ignore
+    num_points: int
+        The number of points to be
+    :param num_points:
+    :param radius:
+    :return:
+    """
+    if isinstance(signal, BaseSignal):
+        data = signal.data
+    else:
+        data = signal
+    i_shape = np.shape(data)
+    flattened_array = data.flatten()
+    indexes = np.argsort(flattened_array)
+
+    if mask is not None:
+        flattened_mask = mask.flatten()
+        indexes = indexes[flattened_mask is False]
+    # take top 5000 points make sure exclude zero beam
+
+    cords = np.array([np.floor_divide(indexes[-num_points:], i_shape[1]),
+             np.remainder(indexes[-num_points:], i_shape[1])]) # [x axis (row),y axis (col)]
+    return cords.T
+
+
+def determine_ellipse(signal,
+                      mask=None,
+                      num_points=1000,
+                      guess_starting_params=True,
+                      **kwargs,
+                      ):
+    """
+    This method starts by taking some number of points which are the most intense
+    in the signal.  It then takes those points and guesses some starting parameters
+    for the `get_ellipse_model_ransac_single_frame` function. From there it will try
+    to determine the ellipse parameters.
+
+    Parameters
+    -----------
+    signal: Signal2D
+        The signal of interest
+    mask: Array-like
+        The mask to be applied to the data.  All of the masked values are ignored
+    num_points: int
+        The number of points to consider
+    guess_starting_params: bool
+        If True then the starting parameters will be guessed based on the points determined.
+    **kwargs:
+        Any other keywords for ` get_ellipse_model_ransac_single_frame`
+
+    Returns
+    -------
+    center: (x,y)
+        The center of the diffraction pattern
+    affine:
+        The affine transformation to make the diffraction pattern circular.
+    """
+    pos = get_max_positions(signal,
+                            mask=mask,
+                            num_points=num_points)
+    if guess_starting_params:
+        el, _ = get_ellipse_model_ransac_single_frame(pos,
+                                              xf=np.mean(pos[:, 0]),
+                                              yf=np.mean(pos[:, 1]),
+                                              rf_lim=np.shape(signal.data)[0]/10,
+                                              semi_len_min=np.std(pos[:, 1]),
+                                              semi_len_max=np.std(pos[:, 1])*2,
+                                              semi_len_ratio_lim=1.2,
+                                              min_samples=6,
+                                              residual_threshold=10,
+                                              max_trails=500)
+        return el
+    else:
+        el, _ = get_ellipse_model_ransac_single_frame(pos,
+                                                     **kwargs)
+        return el

--- a/pyxem/utils/ransac_ellipse_tools.py
+++ b/pyxem/utils/ransac_ellipse_tools.py
@@ -338,6 +338,7 @@ def get_ellipse_model_ransac_single_frame(
             if is_model_valid(model_ransac, None):
                 break
             else:
+                print("Model is outside of parameters:", model_ransac.params)
                 model_ransac, inliers = None, None
         else:
             break
@@ -647,19 +648,19 @@ def determine_ellipse(signal,
     pos = get_max_positions(signal,
                             mask=mask,
                             num_points=num_points)
+    import matplotlib.pyplot as plt
+    plt.scatter(pos[:,0], pos[:,1])
     if guess_starting_params:
-        print("starting center", np.mean(pos[:, 0]),np.mean(pos[:, 1]))
         el, _ = get_ellipse_model_ransac_single_frame(pos,
                                               xf=np.mean(pos[:, 0]),
                                               yf=np.mean(pos[:, 1]),
-                                              rf_lim=np.shape(signal.data)[0]/10,
+                                              rf_lim=np.shape(signal.data)[0]/5,
                                               semi_len_min=np.std(pos[:, 1]),
                                               semi_len_max=np.std(pos[:, 1])*2,
                                               semi_len_ratio_lim=1.2,
                                               min_samples=6,
-                                              residual_threshold=10,
-                                              max_trails=500)
-        return el
+                                              residual_threshold=20,
+                                              max_trails=1000)
     else:
         el, _ = get_ellipse_model_ransac_single_frame(pos,
                                                      **kwargs)
@@ -670,11 +671,12 @@ def determine_ellipse(signal,
     else:
         print("Ransac Ellipse detection did not converge")
         return None
+
 def ellipse_to_affine(major, minor, rot):
     Q = [[np.cos(rot), -np.sin(rot), 0],
          [np.sin(rot), np.cos(rot), 0],
          [0, 0, 1]]
-    S = [[(major / minor), 0, 0],
+    S = [[1, 0, 0],
          [0, major / minor, 0],
          [0, 0, 1]]
     C = np.matmul(np.matmul(Q, S), np.transpose(Q))


### PR DESCRIPTION
---
name: Add Documentation
about: This pull requests adds in some documentation to pyxem.

---
For the most part I have been copying kikuchipy/ @hakonanes for the documentation strategy.  Ideally most of the documentation would be handled through example notebooks or through small edits after this large push. 


**Checklist**
- [x] Add in landing page for documentation
- [x] Add in API references
- [x] Add in similar projects
- [ ] Add in list papers which cite pyxem 
- [ ] Add in Support for notebook --> .rst (I am going to have to adjust the formatting of some of the notebooks to get them to look nice on the webpage)
- [x] Add in contributing guide
- [ ] Add in github action to automatically check documentation
- [ ] Change pyxem website so it links to pyxem documentation

**What does this PR do? Please describe and/or link to an open issue.**
This is kind of the first step for #629.  Bringing our documentation more into line with hyperspy and kikuchipy I think will
help easy transition from one to the other.  There is also fair amount of documentation for pixstem I think @magnunor wanted to
bring over to pyxem eventually. 

**Are there any known issues? Do you need help?**
I would like to add in a couple of automatic checks for building the documentation. I am willing to add those in but I think I need additional privileges @pc494. 

Other than that any comments will be helpful.  If you are interested in building the documentation you should be able to run the make file to build it.  Otherwise I can commit my html build files. 