### PR TITLE
Hyperspy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -71,7 +72,7 @@ setup(
         "numba",
         "orix >= 0.3",
     ],
-    python_requires=">=3.0, <3.9",  # some dependencies do not currently support 3.9 (Jan 2020)
+    python_requires=">=3.7",
     package_data={
         "": ["LICENSE", "readme.rst"],
         "pyxem": ["*.py", "hyperspy_extension.yaml"],

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "scikit-image >= 0.17.0",
         "matplotlib >= 3.1.1",  # 3.1.0 failed
         "scikit-learn >= 0.19",  # reason unknown
-        "hyperspy == 1.6.2",  # significant improvements
+        "hyperspy >= 1.6.2",
         "diffsims >= 0.4.0,<0.5",
         "lmfit >= 0.9.12",
         "pyfai",


### PR DESCRIPTION
Following yesterday hyperspy 1.6.3 release, installing pyxem can cause dependencies incompatibilities. See an example of this [workflow](https://github.com/ericpre/hyperspy-extensions-list/runs/2801323244?check_suite_focus=true) where pyxem 10.1 is installed.

Instead of pinning to a specific version of hyperspy, a minimum requirement needs to be set. If you have concerns about breaking changes, then you should check regularly the integration test suite at https://github.com/hyperspy/hyperspy-extensions-list, which runs daily or add a daily job to this repository which runs the test suite against the development branches of hyperspy.