### PR TITLE
Patching cupy + dask issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ exec(open("pyxem/release_info.py").read())  # grab version info
 # tests. From setuptools:
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
 extra_feature_requirements = {
-    "tests": ["pytest>=5.0", "pytest-cov>=2.8.1", "coveralls>=1.10", "coverage>=5.0"]
+    "tests": ["pytest>=5.0", "pytest-cov>=2.8.1", "coveralls>=1.10", "coverage>=5.0"],
+    "gpu": ["cupy>=9.0.0"]
 }
 
 
@@ -64,7 +65,7 @@ setup(
         "scikit-image >= 0.17.0",
         "matplotlib >= 3.1.1",  # 3.1.0 failed
         "scikit-learn >= 0.19",  # reason unknown
-        "hyperspy == 1.6.2",  # significant improvements
+        "hyperspy >= 1.6.2",  # significant improvements
         "diffsims ~= 0.4",
         "lmfit >= 0.9.12",
         "pyfai",


### PR DESCRIPTION
---
name: Fixing dask + cupy workflows for fast template matching
about: This is a fix for #778 

---

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
Fixes #778 to prevent dask flooding the VRAM when it schedules all copying of the dataset to the GPU sequentially. Instead of doing `map_blocks(to_gpu)`, I call `to_gpu` and `as_numpy` explicitly at the beginning and end of the indexation function when dealing with the GPU. This ensures that the VRAM can only contain data up to the number of workers times the size of the blocks. However, it takes away scheduling flexibility and benchmarks show it performs in a suboptimal way compared to the `LocalCluster`.

In addition, I've made some minor modifications like trying to do a better job estimating the necessary number of workers.

**Describe alternatives you've considered**
Alternatively, one could move to the `dask.distributed` schedulers. I experimented with the `LocalCUDAcluster` and this worked just fine without running out of VRAM. Unfortunately this would require a lot of overhaul and an additional dependency for a single function. Better would be to make this a hyperspy thing in the `compute` function.

I've also thought about making the entire output lazy, such that compute does not need to be called inside the function at all. However, for this I need dask arrays to index into dask arrays, which is not supported. One might perhaps work around it with delayed but this yields very intransparant output. Basically, some developments in dask would be necessary for this to be possible.

In terms of coverage, tests with cupy in them will be skipped in the CI, so here is the coverage report from my computer (output from `pytest --cov=pyxem --runslow --pyargs pyxem` and `coverage report --show_missing`:

```
Name                                                                    Stmts   Miss     Cover   Missing
--------------------------------------------------------------------------------------------------------
pyxem/components/__init__.py                                                4      0   100.00%
pyxem/components/reduced_intensity_correction_component.py                 12      0   100.00%
pyxem/components/scattering_fit_component_lobato.py                        33      0   100.00%
pyxem/components/scattering_fit_component_xtables.py                       33      0   100.00%
pyxem/conftest.py                                                          23      0   100.00%
pyxem/detectors/__init__.py                                                 4      0   100.00%
pyxem/detectors/generic_flat_detector.py                                   10      0   100.00%
pyxem/detectors/medipix_256x256.py                                         12      0   100.00%
pyxem/detectors/medipix_515x515.py                                         18      0   100.00%
pyxem/dummy_data/__init__.py                                                3      0   100.00%
pyxem/dummy_data/dummy_data.py                                            238      0   100.00%
pyxem/dummy_data/make_diffraction_test_data.py                            389      0   100.00%
pyxem/generators/__init__.py                                               10      0   100.00%
pyxem/generators/calibration_generator.py                                 137      0   100.00%
pyxem/generators/displacement_gradient_tensor_generator.py                 16      0   100.00%
pyxem/generators/indexation_generator.py                                  177      0   100.00%
pyxem/generators/integration_generator.py                                  69      0   100.00%
pyxem/generators/pdf_generator1d.py                                        30      0   100.00%
pyxem/generators/red_intensity_generator1d.py                              56      0   100.00%
pyxem/generators/subpixelrefinement_generator.py                          101      0   100.00%
pyxem/generators/variance_generator.py                                     43      0   100.00%
pyxem/generators/virtual_image_generator.py                                72      0   100.00%
pyxem/libraries/__init__.py                                                 2      0   100.00%
pyxem/libraries/calibration_library.py                                     19      0   100.00%
pyxem/release_info.py                                                       9      0   100.00%
pyxem/signals/__init__.py                                                  22      0   100.00%
pyxem/signals/beam_shift.py                                                26      0   100.00%
pyxem/signals/common_diffraction.py                                        51      0   100.00%
pyxem/signals/correlation2d.py                                             37      0   100.00%
pyxem/signals/differential_phase_contrast.py                              235      0   100.00%
pyxem/signals/diffraction1d.py                                              9      0   100.00%
pyxem/signals/diffraction2d.py                                            560      1    99.82%   1370
pyxem/signals/diffraction_variance1d.py                                     5      0   100.00%
pyxem/signals/diffraction_variance2d.py                                     9      0   100.00%
pyxem/signals/diffraction_vectors.py                                      156      0   100.00%
pyxem/signals/electron_diffraction1d.py                                    37      0   100.00%
pyxem/signals/electron_diffraction2d.py                                    92      0   100.00%
pyxem/signals/indexation_results.py                                        75      0   100.00%
pyxem/signals/pair_distribution_function1d.py                               9      0   100.00%
pyxem/signals/polar_diffraction2d.py                                       51      0   100.00%
pyxem/signals/power2d.py                                                   30      0   100.00%
pyxem/signals/reduced_intensity1d.py                                       45      0   100.00%
pyxem/signals/segments.py                                                 177      0   100.00%
pyxem/signals/strain_map.py                                                39      0   100.00%
pyxem/signals/symmetry1d.py                                                23      0   100.00%
pyxem/signals/tensor_field.py                                              26      0   100.00%
pyxem/signals/virtual_dark_field_image.py                                  35      0   100.00%
pyxem/tests/__init__.py                                                     0      0   100.00%
pyxem/tests/components/__init__.py                                          0      0   100.00%
pyxem/tests/components/test_red_int_correction_component.py                 3      0   100.00%
pyxem/tests/components/test_scattering_fit_component_lobato.py             18      0   100.00%
pyxem/tests/components/test_scattering_fit_component_xtables.py            18      0   100.00%
pyxem/tests/conftest.py                                                    46      0   100.00%
pyxem/tests/detectors/__init__.py                                           0      0   100.00%
pyxem/tests/detectors/test_generic_flat_detector.py                         9      0   100.00%
pyxem/tests/detectors/test_medipix_256x256.py                               6      0   100.00%
pyxem/tests/detectors/test_medipix_515x515.py                              14      0   100.00%
pyxem/tests/dummy_data/__init__.py                                          0      0   100.00%
pyxem/tests/dummy_data/test_dummy_data.py                                  70      0   100.00%
pyxem/tests/dummy_data/test_make_diffraction_test_data.py                 613      0   100.00%
pyxem/tests/generators/__init__.py                                          0      0   100.00%
pyxem/tests/generators/test_calibration_generator.py                      128      0   100.00%
pyxem/tests/generators/test_displacement_gradient_tensor_generator.py      54      0   100.00%
pyxem/tests/generators/test_indexation_generator.py                        99      0   100.00%
pyxem/tests/generators/test_integration_generator.py                       37      0   100.00%
pyxem/tests/generators/test_pdf_generator.py                               51      0   100.00%
pyxem/tests/generators/test_red_intensity_generator.py                     69      0   100.00%
pyxem/tests/generators/test_subpixelrefinement_generator.py               102      0   100.00%
pyxem/tests/generators/test_variance_generator.py                          47      0   100.00%
pyxem/tests/generators/test_virtual_image_generator.py                    104      0   100.00%
pyxem/tests/library/__init__.py                                             0      0   100.00%
pyxem/tests/library/test_calibration_library.py                            29      0   100.00%
pyxem/tests/signals/__init__.py                                             0      0   100.00%
pyxem/tests/signals/test_beam_shift.py                                    130      0   100.00%
pyxem/tests/signals/test_correlation2d.py                                  77      0   100.00%
pyxem/tests/signals/test_differential_phase_contrast.py                   457      0   100.00%
pyxem/tests/signals/test_diffraction1d.py                                  84      0   100.00%
pyxem/tests/signals/test_diffraction2d.py                                1027      0   100.00%
pyxem/tests/signals/test_diffraction_variance1d.py                          8      0   100.00%
pyxem/tests/signals/test_diffraction_variance2d.py                         16      0   100.00%
pyxem/tests/signals/test_diffraction_vectors.py                           113      0   100.00%
pyxem/tests/signals/test_electron_diffraction1d.py                         61      0   100.00%
pyxem/tests/signals/test_electron_diffraction2d.py                        153      0   100.00%
pyxem/tests/signals/test_indexation_results.py                             59      0   100.00%
pyxem/tests/signals/test_lazy_diffraction1d.py                              7      0   100.00%
pyxem/tests/signals/test_lazy_diffraction2d.py                              7      0   100.00%
pyxem/tests/signals/test_lazy_electron_diffraction1d.py                     6      0   100.00%
pyxem/tests/signals/test_lazy_electron_diffraction2d.py                     6      0   100.00%
pyxem/tests/signals/test_metadata.py                                       10      0   100.00%
pyxem/tests/signals/test_pdf1d.py                                          10      0   100.00%
pyxem/tests/signals/test_pixelated_stem_class.py                          807      0   100.00%
pyxem/tests/signals/test_polar_diffraction2d.py                           120      0   100.00%
pyxem/tests/signals/test_power2d.py                                        67      0   100.00%
pyxem/tests/signals/test_reduced_intensity1d.py                            54      0   100.00%
pyxem/tests/signals/test_segments.py                                       94      0   100.00%
pyxem/tests/signals/test_strain_map.py                                     64      0   100.00%
pyxem/tests/signals/test_symmetry1d.py                                     14      0   100.00%
pyxem/tests/signals/test_tensor_field.py                                   22      0   100.00%
pyxem/tests/signals/test_virtual_dark_field_image.py                       42      0   100.00%
pyxem/tests/utils/__init__.py                                               0      0   100.00%
pyxem/tests/utils/test_big_data_utils.py                                   35      0   100.00%
pyxem/tests/utils/test_cluster_tools.py                                   332      0   100.00%
pyxem/tests/utils/test_correlation_utils.py                                56      0   100.00%
pyxem/tests/utils/test_cuda_utils.py                                       18      3    83.33%   30-32
pyxem/tests/utils/test_dask_tools.py                                     1134      0   100.00%
pyxem/tests/utils/test_dpc_signal_tools.py                                221      0   100.00%
pyxem/tests/utils/test_expt_utils.py                                      107      0   100.00%
pyxem/tests/utils/test_indexation_utils.py                                 27      0   100.00%
pyxem/tests/utils/test_io_utils.py                                         29      0   100.00%
pyxem/tests/utils/test_lazy_tools.py                                       92      0   100.00%
pyxem/tests/utils/test_marker_tools.py                                    161     10    93.79%   91-102
pyxem/tests/utils/test_pixelated_stem_tools.py                            323      0   100.00%
pyxem/tests/utils/test_plotting_utils.py                                   20      0   100.00%
pyxem/tests/utils/test_polar_transform_utils.py                            70      3    95.71%   29-31
pyxem/tests/utils/test_pyfai_utils.py                                      31      0   100.00%
pyxem/tests/utils/test_radial.py                                          220      0   100.00%
pyxem/tests/utils/test_ransac_ellipse_tools.py                            553      2    99.64%   296-297
pyxem/tests/utils/test_rotation_tempate_match.py                          269      3    98.88%   34-36
pyxem/tests/utils/test_segment_utils.py                                    26      0   100.00%
pyxem/tests/utils/test_signal_utils.py                                     11      0   100.00%
pyxem/tests/utils/test_tools.py                                            47      0   100.00%
pyxem/tests/utils/test_vector_utils.py                                     34      0   100.00%
pyxem/tests/utils/test_virtual_images.py                                   23      0   100.00%
pyxem/utils/big_data_utils.py                                              43      0   100.00%
pyxem/utils/cluster_tools.py                                              137      0   100.00%
pyxem/utils/correlation_utils.py                                           57      0   100.00%
pyxem/utils/cuda_utils.py                                                  46     21    54.35%   27-28, 36, 45, 60-64, 84-85, 106-107, 136-1
52
pyxem/utils/dask_tools.py                                                 431      0   100.00%
pyxem/utils/expt_utils.py                                                 171      4    97.66%   39-42
pyxem/utils/indexation_utils.py                                           415      5    98.80%   56-57, 956, 1617, 1769
pyxem/utils/lazy_tools.py                                                  69      0   100.00%
pyxem/utils/marker_tools.py                                               132      0   100.00%
pyxem/utils/pdf_utils.py                                                    4      0   100.00%
pyxem/utils/pixelated_stem_tools.py                                       215      0   100.00%
pyxem/utils/plotting_utils.py                                              21      1    95.24%   94
pyxem/utils/polar_transform_utils.py                                       94      6    93.62%   12-15, 111, 155
pyxem/utils/pyfai_utils.py                                                 56      0   100.00%
pyxem/utils/radial_utils.py                                               236      0   100.00%
pyxem/utils/ransac_ellipse_tools.py                                       140      0   100.00%
pyxem/utils/ri_utils.py                                                    32      0   100.00%
pyxem/utils/segment_utils.py                                               75      0   100.00%
pyxem/utils/signal.py                                                      31      0   100.00%
pyxem/utils/vector_utils.py                                                76      0   100.00%
pyxem/utils/virtual_images_utils.py                                        22      0   100.00%
--------------------------------------------------------------------------------------------------------
TOTAL                                                                   14643     59    99.60%
```
The lines that are missing coverage here are those with boilerplate, raising issues when cupy is not installed. There also is one failing test on something I didn't touch, which may be related to my version of hyperspy in my venv.

**Are there any known issues? Do you need help?**

**Work in progress?**
