### PR TITLE
Make pyxem work with improved version of HyperSpy's map

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1785,37 +1785,39 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             )
             + 1
         )
-        centre_x = centre_x.flatten()
-        centre_y = centre_y.flatten()
-        iterating_kwargs = [("centre_x", centre_x), ("centre_y", centre_y)]
-        if mask_array is not None:
-            #  This line flattens the mask array, except for the two
-            #  last dimensions. This to make the mask array work for the
-            #  _map_iterate function.
-            mask_flat = mask_array.reshape(-1, *mask_array.shape[-2:])
-            iterating_kwargs.append(("mask", mask_flat))
-
         if self._lazy:
             data = pst._radial_average_dask_array(
                 self.data,
                 return_sig_size=radial_array_size,
-                centre_x=centre_x,
-                centre_y=centre_y,
+                centre_x=centre_x.flatten(),
+                centre_y=centre_y.flatten(),
                 mask_array=mask_array,
                 normalize=normalize,
                 show_progressbar=show_progressbar,
             )
             s_radial = hs.signals.Signal1D(data)
         else:
-            s_radial = self._map_iterate(
+            if mask_array is not None:
+                mask_array = Signal2D(mask_array)
+            if self.data.ndim == centre_x.ndim:
+                centre_x = Signal2D(centre_x)
+                centre_y = Signal2D(centre_y)
+            else:
+                centre_x = BaseSignal(centre_x).T
+                centre_y = BaseSignal(centre_y).T
+
+            s_radial = self.map(
                 pst._get_radial_profile_of_diff_image,
                 normalize=normalize,
-                iterating_kwargs=iterating_kwargs,
+                centre_x=centre_x,
+                centre_y=centre_y,
+                mask=mask_array,
                 inplace=False,
                 ragged=False,
                 parallel=parallel,
                 radial_array_size=radial_array_size,
                 show_progressbar=show_progressbar,
+                lazy_result=False,
             )
             data = s_radial.data
         s_radial = hs.signals.Signal1D(data)

--- a/pyxem/signals/segments.py
+++ b/pyxem/signals/segments.py
@@ -238,6 +238,7 @@ class LearningSegment:
                 marker_radius=marker_radius,
                 threshold=threshold,
                 exclude_border=exclude_border,
+                ragged=True,
             ),
             dtype=object,
         )

--- a/pyxem/signals/virtual_dark_field_image.py
+++ b/pyxem/signals/virtual_dark_field_image.py
@@ -112,6 +112,7 @@ class VirtualDarkFieldImage(Signal2D):
                 marker_radius=marker_radius,
                 threshold=threshold,
                 exclude_border=exclude_border,
+                ragged=True,
             ),
             dtype=object,
         )

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -109,7 +109,7 @@ def diffraction_vectors_single(request):
     ]
 )
 def diffraction_vectors_map(request):
-    dvm = DiffractionVectors(request.param)
+    dvm = DiffractionVectors(request.param, ragged=True)
     dvm.axes_manager.set_signal_dimension(0)
     dvm.axes_manager[0].name = "x"
     dvm.axes_manager[1].name = "y"

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -115,13 +115,13 @@ def filter_vectors_ragged(z, min_magnitude, max_magnitude):
     """
     # Calculate norms
     norms = []
-    for i in z[0]:
+    for i in z:
         norms.append(np.linalg.norm(i))
     norms = np.asarray(norms)
     # Filter based on norms
     norms[norms < min_magnitude] = 0
     norms[norms > max_magnitude] = 0
-    filtered_vectors = z[0][np.where(norms)]
+    filtered_vectors = z[np.where(norms)]
 
     return filtered_vectors
 


### PR DESCRIPTION
Currently, processing large datasets in pyxem is done in two main ways: i) via HyperSpy's `signal._map_iterate` or `signal.map`, ii) pyxem's `_process_dask_array`.

I am currently working on a pull request in HyperSpy (https://github.com/hyperspy/hyperspy/pull/2703), which essentially generalize @CSSFrancis's pull request (https://github.com/hyperspy/hyperspy/pull/2617) from lazy signals, to non-lazy signals as well.

However, this pull request breaks some of pyxem's functions. This seems to mostly be due to various pyxem functions directly calling `_map_iterate`. At the time these functions were implemented, this made a lot of sense, since using HyperSpy's `signal.map` function didn't work very well for those use-cases. However, with the hyperspy/hyperspy#2703 pull request, this makes it impossible(?) to not break pyxem.

This pull request contains various changes necessary to make pyxem work with changes in HyperSpy's `map` and `_map_iterate, and must be released **after** the HyperSpy release which will contain https://github.com/hyperspy/hyperspy/pull/2703.

Due to this, the testing suite will fail, as it uses the most recent HyperSpy release. Thus, the tests must be checked manually.

**Work in progress**
- [ ] Fix the failing functions
- [ ] Make sure there are no issues in installing both the HyperSpy release with the new `signal.map`, and this version of pyxem

-----------
After this pull request has been completed, a bigger run-though of pyxem's functions will be done, streamlining the functions which require `signal.map` or `_process_dask_array`.