### PR TITLE
Make CI continue even after tests of docstring examples fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         shell: bash
         run: pip install -U -e .'[tests]'
       - name: Run docstring tests
+        continue-on-error: true
         run: pytest --doctest-modules --ignore=pyxem/tests pyxem
       - name: Run tests
         run: pytest --cov=pyxem --runslow --pyargs pyxem

--- a/pyxem/utils/segment_utils.py
+++ b/pyxem/utils/segment_utils.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from packaging.version import Version
-
 import matplotlib.pyplot as plt
 import numpy as np
 from numpy.ma import masked_where
@@ -27,13 +25,8 @@ from scipy.signal import convolve2d
 from skimage.feature import peak_local_max
 from skimage.filters import sobel, threshold_li
 from skimage.morphology import disk
+from skimage.segmentation import watershed
 from sklearn.cluster import DBSCAN
-
-from skimage import __version__ as skimage_version_str
-if Version(skimage_version_str) < Version("0.19"):
-    from skimage.morphology import watershed
-else:
-    from skimage.segmentation import watershed
 
 
 def norm_cross_corr(image, template):

--- a/pyxem/utils/segment_utils.py
+++ b/pyxem/utils/segment_utils.py
@@ -30,7 +30,7 @@ from skimage.morphology import disk
 from sklearn.cluster import DBSCAN
 
 from skimage import __version__ as skimage_version_str
-if Version(skimage_version_str) <= Version("0.19"):
+if Version(skimage_version_str) < Version("0.19"):
     from skimage.morphology import watershed
 else:
     from skimage.segmentation import watershed

--- a/pyxem/utils/segment_utils.py
+++ b/pyxem/utils/segment_utils.py
@@ -16,20 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-from numpy.ma import masked_where
+from packaging.version import Version
 
 import matplotlib.pyplot as plt
-
+import numpy as np
+from numpy.ma import masked_where
 from scipy.ndimage import distance_transform_edt, label, binary_erosion
 from scipy.spatial import distance_matrix
 from scipy.signal import convolve2d
-
 from skimage.feature import peak_local_max
 from skimage.filters import sobel, threshold_li
-from skimage.morphology import watershed, disk
-
+from skimage.morphology import disk
 from sklearn.cluster import DBSCAN
+
+from skimage import __version__ as skimage_version_str
+if Version(skimage_version_str) <= Version("0.19"):
+    from skimage.morphology import watershed
+else:
+    from skimage.segmentation import watershed
 
 
 def norm_cross_corr(image, template):


### PR DESCRIPTION
* CI steps continue even after tests of docstring examples fail since `continue-on-error: true` is added to this CI step.
* ~Check which scikit-image version is installed when importing `watershed()`, since it moved in v0.19. This check is done with `packaging.version.Version`.~ Unnecessary, since pyxem requires scikit-image >= 0.17, and the current location of `watershed()`, `skimage.segmentation.watershed`, has been available since 0.16. Solves one task in #786.

**Checklist**
- [n/a] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)