### PR TITLE
Add results_dict_to_crystal_map function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 - BeamShift class, which includes the `make_linear_plane` method for better correction of the beam shift when scanning large regions in STEM (#746)
 - Add unit testing of docstring examples (#766)
 - Add function for optimizing calibration of SPED data (#785)
+- Add function for creating a Orix CrystalMap from indexation results (#794)
 
 Removed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
 - BeamShift class, which includes the `make_linear_plane` method for better correction of the beam shift when scanning large regions in STEM (#746)
 - Add unit testing of docstring examples (#766)
 - Add function for optimizing calibration of SPED data (#785)
-- Add function for creating a Orix CrystalMap from indexation results (#794)
+- Add function for creating a orix CrystalMap from indexation results (#794)
 
 Removed
 ^^^^^^^

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -128,8 +128,8 @@ def results_dict_to_crystal_map(results, phase_key_dict, diffraction_library=Non
     """
     Exports an indexation result from index_dataset_with_template_rotation to
     crystal map with n_best rotations, score, mirrors and one phase_id per data point.
+    
     Parameters
-
     ----------
     results : dict
         Results dictionary obtained from index_dataset_with_template_rotation.

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -124,7 +124,7 @@ def _get_best_match(z):
     return z[np.argmax(z[:, -1]), :]
 
 
-def test_results_dict_to_crystal_map(results, phase_key_dict, diffraction_library=None):
+def results_dict_to_crystal_map(results, phase_key_dict, diffraction_library=None):
     """
     Exports an indexation result from index_dataset_with_template_rotation to
     crystal map with n_best rotations, score, mirrors and one phase_id per data point.

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -183,6 +183,7 @@ def results_dict_to_crystal_map(results, phase_key_dict, diffraction_library=Non
             prop = results[key]
         except KeyError:
             warn(f"Property '{key}' was expected but not found in `results`")
+            continue
 
         if n_phases > 1:
             prop = prop[:, :, 0].ravel()  # Keep best match only

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from warnings import warn
 import numpy as np
 from transforms3d.euler import mat2euler
+from warnings import warn
 
 import hyperspy.api as hs
 from hyperspy.signal import BaseSignal
-from orix.quaternion import Rotation
 from orix.crystal_map import CrystalMap, PhaseList
+from orix.quaternion import Rotation
 
 from pyxem.signals.diffraction_vectors import generate_marker_inputs_from_peaks
-from pyxem.utils.signal import transfer_navigation_axes
 from pyxem.utils.indexation_utils import get_nth_best_solution
+from pyxem.utils.signal import transfer_navigation_axes
 
 
 def crystal_from_vector_matching(z_matches):
@@ -125,67 +125,78 @@ def _get_best_match(z):
 
 
 def results_dict_to_crystal_map(results, phase_key_dict, diffraction_library=None):
-    """
-    Exports an indexation result from index_dataset_with_template_rotation to
-    crystal map with n_best rotations, score, mirrors and one phase_id per data point.
-    
+    """Export an indexation result from
+    :func:`index_dataset_with_template_rotation` to a crystal map with
+    `n_best` rotations, score, mirrors and one phase ID per data point.
+
     Parameters
     ----------
     results : dict
-        Results dictionary obtained from index_dataset_with_template_rotation.
+        Results dictionary obtained from
+        :func:`index_dataset_with_template_rotation`.
     phase_key_dict : dict
-        Phase_key_dict obtained from index_dataset_with_template_rotation.
-    diffraction_library : diffsims.libraries.DiffractionLibrary
-        Optional: Used for the structures to be passed to orix.crystal_map.PhaseList
+        Dictionary mapping phase ID to phase name, obtained from
+        :func:`index_dataset_with_template_rotation`.
+    diffraction_library : diffsims.libraries.DiffractionLibrary, optional
+        Used for the structures to be passed to
+        :class:`orix.crystal_map.PhaseList`.
 
     Returns
     -------
     orix.crystal_map.CrystalMap
+        Crystal map containing `results`. The map has multiple rotations
+        and properties ("correlation", "mirrored_template",
+        "template_index") per point only if `n_best` passed to
+        :func:`index_dataset_with_template_rotation` were more than one
+        and "phase_index" only has one phase.
+
+    Notes
+    -----
+    Phase's :attr:`~orix.crystal_map.Phase.point_group` must be set
+    manually to the correct :class:`~orix.quaternion.Symmetry` after
+    the crystal map is returned.
     """
+    nx, ny, n_best = results["phase_index"].shape
+    n_points = nx * ny
 
-    """ Gets properties """
-
-    shape = results["phase_index"].data.shape
-    datashape = shape[0] * shape[1], shape[2]
-
+    # Best matching phase
     phase_id = results["phase_index"][:, :, 0].ravel()
-    alpha = results["orientation"][:, :, :, 0].ravel()
-    beta = results["orientation"][:, :, :, 1].ravel()
-    gamma = results["orientation"][:, :, :, 2].ravel()
-    score = results["correlation"][:, :, :].ravel()
-    mirrors = results["mirrored_template"][:, :, :].ravel()
+    n_phases = np.unique(phase_id).size
 
-    if diffraction_library != None:
+    x, y = np.indices((nx, ny)).reshape((2, n_points))
+
+    if diffraction_library is not None:
         structures = diffraction_library.structures
     else:
         structures = None
-
-    """ Gets navigation placements """
-    xy = np.indices(shape[:2])
-    x = xy[1].ravel()
-    y = xy[0].ravel()
-
-    """ Tidies up so we can put these things into CrystalMap """
-    euler = np.column_stack((alpha, beta, gamma))
-    rotations = Rotation.from_euler(
-        np.deg2rad(euler), convention="bunge", direction="crystal2lab"
-    )
-
-    """ Reshape to fit proper rotations_per_point """
-    rotations = rotations.reshape(*datashape)
-    score = score.reshape(datashape)
-    mirrors = mirrors.reshape(datashape)
-
     phase_list = PhaseList(names=phase_key_dict, structures=structures)
 
-    properties = {"score": score, "mirrored_template": mirrors}
+    euler = np.deg2rad(results["orientation"].reshape((n_points, n_best, 3)))
+    if n_phases > 1:
+        euler = euler[:, 0]  # Keep best match only
+    euler = euler.squeeze()  # Remove singleton dimensions
+    rotations = Rotation.from_euler(euler, convention="bunge", direction="crystal2lab")
+
+    props = {}
+    for key in ("correlation", "mirrored_template", "template_index"):
+        try:
+            prop = results[key]
+        except KeyError:
+            warn(f"Property '{key}' was expected but not found in `results`")
+
+        if n_phases > 1:
+            prop = prop[:, :, 0].ravel()  # Keep best match only
+        else:
+            prop = prop.reshape((n_points, n_best))
+        props[key] = prop.squeeze()  # Remove singleton dimensions
+
     return CrystalMap(
         rotations=rotations,
         phase_id=phase_id,
         x=x,
         y=y,
         phase_list=phase_list,
-        prop=properties,
+        prop=props,
     )
 
 

--- a/pyxem/tests/conftest.py
+++ b/pyxem/tests/conftest.py
@@ -253,3 +253,24 @@ def test_library_phases():
         [np.array([(0, 0, 90), (0, 44, 90), (0, 54.735, 45)])],
     )
     return library_phases_test
+
+
+@pytest.fixture
+def test_library_phases_multi():
+
+    ni_structure = diffpy.structure.Structure(
+        atoms=[diffpy.structure.atom.Atom(atype="Ni", xyz=[0, 0, 0])], lattice=diffpy.structure.lattice.Lattice(3, 3, 3, 90, 90, 90)
+    )
+    al_structure = diffpy.structure.Structure(
+        atoms=[diffpy.structure.atom.Atom(atype="Al", xyz=[0, 0, 0])], lattice=diffpy.structure.lattice.Lattice(3, 4, 3, 90, 90, 90)
+    )
+    library_phases_test = StructureLibrary(
+        ["Ni", "Al"],
+        [ni_structure, al_structure],
+        [
+            np.array([(0, 0, 90), (0, 44, 90), (0, 54.735, 45)]),
+            np.array([(45, 45, 90), (45, 90, 45), (90, 45, 0)]),
+        ],
+    )
+    return library_phases_test
+

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -106,6 +106,26 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     np.testing.assert_allclose(
         xmap.phase_id.reshape(nav_shape), result["phase_index"][:, :, 0]
     )
+    
+    assert xmap.rotations_per_point == 1
+    assert xmap.phases.names == phase_names
+    assert (
+        xmap.phases.structures[0].lattice.abcABG()
+        == library_phases.structures[0].lattice.abcABG()
+    )
+
+    del result["correlation"]
+    with pytest.warns(UserWarning, match="Property 'correlation' was expected"):
+        xmap2 = results_dict_to_crystal_map(
+            result, phasedict, diffraction_library=diff_lib
+        )
+    assert list(xmap2.prop.keys()) == ["mirrored_template", "template_index"]
+
+    result["phase_index"][..., 0] = 0
+    xmap3 = results_dict_to_crystal_map(result, phasedict)
+    assert np.all(xmap3.phase_id == 0)
+    assert xmap3.phases.names[0] == phase_names[0]
+    assert xmap3.rotations_per_point == 3
 
 
 @pytest.fixture


### PR DESCRIPTION
---
Add results_dict_to_crystal_map function 
Adds a convenience function for putting template matching results dictionary into CrystalMap

---

**Checklist**
- [x] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
This a simple function modeled after the GenericMatchingResults.to_crystal_map to take the results dictionary from index_dataset_with_template_rotation and put them into a CrystalMap object in orix as mentioned in #777.

**Describe alternatives you've considered**
One question is whether or not this function should return 1 rotation per point or n_best rotations per point.  Orix.CrystalMap can not take multiple phase_ids per point but index_dataset_with_template_rotation returns however many n_best is.  However we can store the n_best rotations, scores and mirrors into the CrystalMap so that is how I have written but it could be changed to return only 1 rotation per point.  I also put the function in indexation_results.py but it could be moved to indexation_utils.py.

**Work in progress?**
If you know there is more to do, make a checklist here:
- [x] Tests
