### PR TITLE
Fix dt._peak_find_dog_single_frame unit test input parameters

### DIFF
--- a/pyxem/tests/utils/test_dask_tools.py
+++ b/pyxem/tests/utils/test_dask_tools.py
@@ -905,7 +905,7 @@ class TestPeakFindDog:
     def test_single_frame_one_peak(self, x, y):
         image = np.zeros(shape=(200, 100), dtype=np.float64)
         image[x, y] = 654
-        min_sigma, max_sigma, sigma_ratio = 2, 5, 5
+        min_sigma, max_sigma, sigma_ratio = 2, 5, 1.6
         threshold, overlap = 0.01, 1
         peaks = dt._peak_find_dog_single_frame(
             image,
@@ -922,7 +922,7 @@ class TestPeakFindDog:
         peak_list = [[120, 76], [23, 54], [32, 78], [10, 15]]
         for x, y in peak_list:
             image[x, y] = 654
-        min_sigma, max_sigma, sigma_ratio = 2, 5, 5
+        min_sigma, max_sigma, sigma_ratio = 2, 5, 1.6
         threshold, overlap = 0.01, 1
         peaks = dt._peak_find_dog_single_frame(
             image,
@@ -940,13 +940,13 @@ class TestPeakFindDog:
         image = np.zeros(shape=(200, 100), dtype=np.float64)
         image[54, 29] = 100
         image[123, 54] = 20
-        min_sigma, max_sigma, sigma_ratio, overlap = 2, 5, 5, 1
+        min_sigma, max_sigma, sigma_ratio, overlap = 2, 5, 1.6, 1
         peaks0 = dt._peak_find_dog_single_frame(
             image,
             min_sigma=min_sigma,
             max_sigma=max_sigma,
             sigma_ratio=sigma_ratio,
-            threshold=0.01,
+            threshold=0.005,
             overlap=overlap,
         )
         assert len(peaks0) == 2
@@ -955,7 +955,7 @@ class TestPeakFindDog:
             min_sigma=min_sigma,
             max_sigma=max_sigma,
             sigma_ratio=sigma_ratio,
-            threshold=0.05,
+            threshold=0.01,
             overlap=overlap,
         )
         assert len(peaks1) == 1


### PR DESCRIPTION
Due to changes in recent version (0.19) of `skimage.feature.blob_dog`: https://github.com/scikit-image/scikit-image/pull/5503