### PR TITLE
Allow getting CrystalMap with i out of n best matching data

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -19,8 +19,8 @@ The list of top modules:
 
 ....
 
-Detectors
-===============
+detectors
+=========
 
 .. automodule:: pyxem.detectors
 
@@ -37,8 +37,8 @@ Detectors
 
 ....
 
-Generators
-===========
+generators
+==========
 
 .. currentmodule:: pyxem.generators
 
@@ -65,7 +65,7 @@ Generators
 
 ....
 
-Libraries
+libraries
 =========
 
 .. automodule:: pyxem.libraries
@@ -74,8 +74,8 @@ Libraries
     CalibrationDataLibrary
 
 
-Signals
-==========
+signals
+=======
 
 .. automodule:: pyxem.signals
 
@@ -314,3 +314,14 @@ VirtualDarkFieldImage
 .. autoclass:: pyxem.signals.VirtualDarkFieldImage
     :members:
     :undoc-members:
+
+utils
+=====
+
+indexation_utils
+----------------
+
+.. automodule:: pyxem.utils.indexation_utils
+.. currentmodule:: pyxem.utils.indexation_utils
+
+.. autofunction:: results_dict_to_crystal_map

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -16,14 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-from transforms3d.euler import mat2euler
 from warnings import warn
 
 import hyperspy.api as hs
 from hyperspy.signal import BaseSignal
-from orix.crystal_map import CrystalMap, PhaseList
+import numpy as np
+from orix.crystal_map import CrystalMap
 from orix.quaternion import Rotation
+from transforms3d.euler import mat2euler
 
 from pyxem.signals.diffraction_vectors import generate_marker_inputs_from_peaks
 from pyxem.utils.indexation_utils import get_nth_best_solution
@@ -122,83 +122,6 @@ def _get_best_match(z):
 
     """
     return z[np.argmax(z[:, -1]), :]
-
-
-def results_dict_to_crystal_map(results, phase_key_dict, diffraction_library=None):
-    """Export an indexation result from
-    :func:`index_dataset_with_template_rotation` to a crystal map with
-    `n_best` rotations, score, mirrors and one phase ID per data point.
-
-    Parameters
-    ----------
-    results : dict
-        Results dictionary obtained from
-        :func:`index_dataset_with_template_rotation`.
-    phase_key_dict : dict
-        Dictionary mapping phase ID to phase name, obtained from
-        :func:`index_dataset_with_template_rotation`.
-    diffraction_library : diffsims.libraries.DiffractionLibrary, optional
-        Used for the structures to be passed to
-        :class:`orix.crystal_map.PhaseList`.
-
-    Returns
-    -------
-    orix.crystal_map.CrystalMap
-        Crystal map containing `results`. The map has multiple rotations
-        and properties ("correlation", "mirrored_template",
-        "template_index") per point only if `n_best` passed to
-        :func:`index_dataset_with_template_rotation` were more than one
-        and "phase_index" only has one phase.
-
-    Notes
-    -----
-    Phase's :attr:`~orix.crystal_map.Phase.point_group` must be set
-    manually to the correct :class:`~orix.quaternion.Symmetry` after
-    the crystal map is returned.
-    """
-    nx, ny, n_best = results["phase_index"].shape
-    n_points = nx * ny
-
-    # Best matching phase
-    phase_id = results["phase_index"][:, :, 0].ravel()
-    n_phases = np.unique(phase_id).size
-
-    x, y = np.indices((nx, ny)).reshape((2, n_points))
-
-    if diffraction_library is not None:
-        structures = diffraction_library.structures
-    else:
-        structures = None
-    phase_list = PhaseList(names=phase_key_dict, structures=structures)
-
-    euler = np.deg2rad(results["orientation"].reshape((n_points, n_best, 3)))
-    if n_phases > 1:
-        euler = euler[:, 0]  # Keep best match only
-    euler = euler.squeeze()  # Remove singleton dimensions
-    rotations = Rotation.from_euler(euler, convention="bunge", direction="crystal2lab")
-
-    props = {}
-    for key in ("correlation", "mirrored_template", "template_index"):
-        try:
-            prop = results[key]
-        except KeyError:
-            warn(f"Property '{key}' was expected but not found in `results`")
-            continue
-
-        if n_phases > 1:
-            prop = prop[:, :, 0].ravel()  # Keep best match only
-        else:
-            prop = prop.reshape((n_points, n_best))
-        props[key] = prop.squeeze()  # Remove singleton dimensions
-
-    return CrystalMap(
-        rotations=rotations,
-        phase_id=phase_id,
-        x=x,
-        y=y,
-        phase_list=phase_list,
-        prop=props,
-    )
 
 
 class GenericMatchingResults:

--- a/pyxem/tests/utils/test_indexation_utils.py
+++ b/pyxem/tests/utils/test_indexation_utils.py
@@ -16,14 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+from hyperspy.signals import Signal2D
 import numpy as np
-
-from diffsims.libraries.diffraction_library import DiffractionLibrary
+from orix.quaternion import Rotation
+import pytest
 
 from pyxem.utils.indexation_utils import (
     match_vectors,
     zero_mean_normalized_correlation,
     fast_correlation,
+)
+from pyxem.utils.indexation_utils import (
+    index_dataset_with_template_rotation, results_dict_to_crystal_map
 )
 
 
@@ -84,3 +88,98 @@ def test_match_vector_total_error_default(vector_match_peaks, vector_library):
     np.testing.assert_allclose(matches[0][4], 1.0)  # error mean
 
     assert len(rhkls) == 0
+
+
+def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
+    """Test getting a :class:`orix.crystal_map.CrystalMap` from returns
+    from :func:`index_dataset_with_template_rotation`.
+    """
+    # Map and signal shapes
+    nav_shape = (2, 3)
+    sig_shape = (80, 80)
+    test_set = np.zeros(nav_shape + sig_shape)
+
+    # Diffraction conditions
+    diff_lib = test_lib_gen.get_diffraction_library(
+        test_library_phases_multi,
+        calibration=0.015,
+        reciprocal_radius=1.18,
+        half_shape=tuple(np.array(sig_shape) // 2),
+        with_direct_beam=False,
+    )
+
+    # Simulate multi-phase results
+    phase_id = np.zeros(nav_shape, dtype=int)
+    phase_id[:, [0, 2]] = 1
+    phase_names = list(diff_lib.keys())
+
+    # Simulate patterns
+    sim_kwargs = dict(size=sig_shape[0], sigma=4)
+    for idx in np.ndindex(*nav_shape):
+        i = phase_id[idx]
+        j = int(idx[1] / 2)
+        test_pattern = diff_lib[phase_names[i]]["simulations"][j].\
+            get_diffraction_pattern(**sim_kwargs)
+        test_set[idx] = test_pattern
+
+    # Perform template matching
+    n_best = 3
+    results, phase_dict = index_dataset_with_template_rotation(
+        Signal2D(test_set), diff_lib, phases=phase_names, n_best=n_best,
+    )
+
+    # Extract various results once
+    phase_id = results["phase_index"].reshape((-1, n_best))
+    ori = np.deg2rad(results["orientation"].reshape((-1, n_best, 3)))
+
+    # Property names in `results`
+    prop_names = ["correlation", "mirrored_template", "template_index"]
+
+    # Only get the bast match when multiple phases match best to some
+    # patterns
+    xmap = results_dict_to_crystal_map(results, phase_dict, diffraction_library=diff_lib)
+    assert np.allclose(xmap.phase_id, phase_id[:, 0])
+    assert xmap.rotations_per_point == 1
+    assert xmap.phases.names == phase_names
+    assert (
+        xmap.phases.structures[0].lattice.abcABG()
+        == test_library_phases_multi.structures[0].lattice.abcABG()
+    )
+
+    # Raise warning when a property is not present as expected
+    del results[prop_names[0]]
+    with pytest.warns(UserWarning, match=f"Property '{prop_names[0]}' was expected"):
+        xmap2 = results_dict_to_crystal_map(
+            results, phase_dict, diffraction_library=diff_lib
+        )
+    assert list(xmap2.prop.keys()) == prop_names[1:]
+
+    # Raise error when trying to access a best match which isn't
+    # available
+    with pytest.raises(ValueError, match="`index` cannot be higher than 2"):
+        _ = results_dict_to_crystal_map(results, phase_dict, index=3)
+    # Get second best match
+    i = 1
+    xmap3 = results_dict_to_crystal_map(results, phase_dict, index=i)
+    assert xmap3.rotations_per_point == 1
+    assert np.allclose(xmap3.phase_id, phase_id[:, i])
+    assert np.allclose(xmap3.rotations.data, Rotation.from_euler(ori[:, i]).data)
+    assert np.allclose(
+        xmap3.prop[prop_names[1]], results[prop_names[1]][:, :, i].flatten()
+    )
+
+    # Make map single-phase and get all matches per point
+    results["phase_index"][..., 0] = 0
+    xmap4 = results_dict_to_crystal_map(results, phase_dict)
+    assert np.all(xmap4.phase_id == 0)
+    assert xmap4.phases.names[0] == phase_names[0]
+    assert xmap4.rotations_per_point == 3
+
+    # Get only best match even though map is single-phase
+    i = 0
+    xmap5 = results_dict_to_crystal_map(results, phase_dict, index=i)
+    assert xmap5.rotations_per_point == 1
+    assert np.allclose(xmap5.rotations.data, Rotation.from_euler(ori[:, i]).data)
+    assert np.allclose(
+        xmap5.prop[prop_names[1]], results[prop_names[1]][:, :, i].flatten()
+    )

--- a/pyxem/utils/__init__.py
+++ b/pyxem/utils/__init__.py
@@ -16,6 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Additional utility functions for processing signals
-"""
+"""Additional utility functions for processing signals."""

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -16,11 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Utilities for indexing electron diffraction spot patterns."""
 
+from collections import namedtuple
 from itertools import combinations
 from operator import attrgetter
+import warnings
 
+from dask.diagnostics import ProgressBar
+from numba import njit, prange
 import numpy as np
+from orix.crystal_map import CrystalMap, PhaseList
+from orix.quaternion import Rotation
+import psutil
 import scipy
 
 from pyxem.utils.expt_utils import _cart2polar
@@ -28,19 +36,11 @@ from pyxem.utils.vector_utils import get_rotation_matrix_between_vectors
 from pyxem.utils.vector_utils import get_angle_cartesian
 from pyxem.utils.cuda_utils import (
     is_cupy_array,
-    to_numpy,
     get_array_module,
     _correlate_polar_image_to_library_gpu,
     TPB,
 )
-
-from collections import namedtuple
-
 from pyxem.utils.dask_tools import _get_dask_array
-import psutil
-from dask.diagnostics import ProgressBar
-from numba import njit, float64, float32, int32, prange
-
 from pyxem.utils.polar_transform_utils import (
     _cartesian_positions_to_polar,
     get_polar_pattern_shape,
@@ -51,7 +51,6 @@ from pyxem.utils.polar_transform_utils import (
 
 try:
     import cupy as cp
-
     CUPY_INSTALLED = True
     import cupyx.scipy as spgpu
 except ImportError:
@@ -1726,3 +1725,113 @@ def index_dataset_with_template_rotation(
     result["correlation"] = res_index[:, :, :, 1]
     result["mirrored_template"] = res_index[:, :, :, 3] == -1
     return result, phase_key_dict
+
+
+def results_dict_to_crystal_map(
+    results, phase_key_dict, diffraction_library=None, index=None
+):
+    """Export an indexation result from
+    :func:`index_dataset_with_template_rotation` to a crystal map with
+    `n_best` rotations, score, mirrors and one phase ID per data point.
+
+    Parameters
+    ----------
+    results : dict
+        Results dictionary obtained from
+        :func:`index_dataset_with_template_rotation`.
+    phase_key_dict : dict
+        Dictionary mapping phase ID to phase name, obtained from
+        :func:`index_dataset_with_template_rotation`.
+    diffraction_library : diffsims.libraries.DiffractionLibrary, optional
+        Used for the structures to be passed to
+        :class:`orix.crystal_map.PhaseList`.
+    index : int, optional
+        Which of the `n_best` solutions (0-indexed) obtained from
+        :func:`index_dataset_with_template_rotation` to get a crystal
+        map from. Highest allowed value is `n_best` - 1. If not given,
+        all solutions are used if `n_best` was more than one and
+        `results["phase_index"]` only has one phase, otherwise, only the
+        best solution is used.
+
+    Returns
+    -------
+    orix.crystal_map.CrystalMap
+        Crystal map containing `results`. The map has multiple rotations
+        and properties ("correlation", "mirrored_template",
+        "template_index") per point only if `n_best` passed to
+        :func:`index_dataset_with_template_rotation` was more than one
+        and "phase_index" only has one phase.
+
+    Notes
+    -----
+    Phase's :attr:`~orix.crystal_map.Phase.point_group` must be set
+    manually to the correct :class:`~orix.quaternion.Symmetry` after
+    the crystal map is returned.
+
+    Examples
+    --------
+    After getting `results` and `phase_key_dict` from template matching
+
+    >>> xmap = results_dict_to_crystal_map(results, phase_key_dict)
+    >>> xmap.plot()  # Phase map
+
+    Getting the second best match if `n_best` passed to the template
+    matching function is greater than one
+
+    >>> xmap2 = results_dict_to_crystal_map(
+    ...     results, phase_key_dict, index=1
+    ... )
+    """
+    nx, ny, n_best = results["phase_index"].shape
+    if index is not None and index > n_best - 1:
+        raise ValueError(f"`index` cannot be higher than {n_best - 1} (`n_best` - 1)")
+
+    n_points = nx * ny
+
+    # Phase ID (only one per point is allowed, always)
+    if index is None:
+        phase_id = results["phase_index"][:, :, 0].ravel()
+    else:
+        phase_id = results["phase_index"][:, :, index].ravel()
+    n_phases = np.unique(phase_id).size
+
+    x, y = np.indices((nx, ny)).reshape((2, n_points))
+
+    if diffraction_library is not None:
+        structures = diffraction_library.structures
+    else:
+        structures = None
+    phase_list = PhaseList(names=phase_key_dict, structures=structures)
+
+    euler = np.deg2rad(results["orientation"].reshape((n_points, n_best, 3)))
+    if index is None and n_phases > 1:
+        euler = euler[:, 0]  # Best match only
+    elif index is not None:
+        euler = euler[:, index]  # Desired match only
+    euler = euler.squeeze()  # Remove singleton dimensions
+    rotations = Rotation.from_euler(euler, convention="bunge", direction="crystal2lab")
+
+    props = {}
+    for key in ("correlation", "mirrored_template", "template_index"):
+        try:
+            prop = results[key]
+        except KeyError:
+            warnings.warn(f"Property '{key}' was expected but not found in `results`")
+            continue
+
+        if index is None and n_phases > 1:
+            prop = prop[:, :, 0].ravel()  # Best match only
+        elif index is not None:
+            prop = prop[:, :, index].ravel()  # Desired match only
+        else:
+            prop = prop.reshape((n_points, n_best))  # All
+        props[key] = prop.squeeze()  # Remove singleton dimensions
+
+    return CrystalMap(
+        rotations=rotations,
+        phase_id=phase_id,
+        x=x,
+        y=y,
+        phase_list=phase_list,
+        prop=props,
+    )

--- a/setup.py
+++ b/setup.py
@@ -27,21 +27,21 @@ exec(open("pyxem/release_info.py").read())  # grab version info
 extra_feature_requirements = {
     "doc": [
         "furo",
-        "nbsphinx >= 0.7",
-        "sphinx >= 3.0.2, <= 4.0.2",
-        "sphinx-copybutton >= 0.2.5",
-        "sphinx-autodoc-typehints >= 1.10.3",
-        "sphinx-gallery >= 0.6",
-        "sphinxcontrib-bibtex >= 1.0",
+        "nbsphinx                   >= 0.7",
+        "sphinx                     >= 3.0.2, <= 4.0.2",
+        "sphinx-copybutton          >= 0.2.5",
+        "sphinx-autodoc-typehints   >= 1.10.3",
+        "sphinx-gallery             >= 0.6",
+        "sphinxcontrib-bibtex       >= 1.0",
     ],
-    "tests": ["pytest>=5.0",
-              "pytest-cov>=2.8.1",
-              "coveralls>=1.10",
-              "coverage>=5.0"],
-    "dev": ["black",
-            "pre-commit > =1.16"
-            ],
-    "gpu": ["cupy>=9.0.0"],
+    "tests": [
+        "pytest     >= 5.0",
+        "pytest-cov >= 2.8.1",
+        "coveralls  >= 1.10",
+        "coverage   >= 5.0"
+    ],
+    "dev": ["black", "pre-commit >=1.16"],
+    "gpu": ["cupy >= 9.0.0"],
 }
 
 
@@ -77,21 +77,25 @@ setup(
     packages=find_packages(),
     extras_require=extra_feature_requirements,
     install_requires=[
-        "scikit-image >= 0.17.0",
-        "matplotlib >= 3.1.1",  # 3.1.0 failed
-        "scikit-learn >= 0.19",  # reason unknown
-        "hyperspy >= 1.6.2",  # significant improvements
-        "diffsims ~= 0.4",
-        "lmfit >= 0.9.12",
-        "pyfai",
-        "psutil",
+        "dask",
+        "diffsims       ~= 0.4",
+        "hyperspy       >= 1.6.2",  # significant improvements
         "ipywidgets",
+        "lmfit          >= 0.9.12",
+        "matplotlib     >= 3.1.1",  # 3.1.0 failed
         "numba",
-        "orix >= 0.3",
+        "numpy",
+        "orix           >= 0.3",
+        "psutil",
+        "pyfai",
+        "scikit-image   >= 0.17.0",
+        "scikit-learn   >= 0.19",  # reason unknown
+        "scipy",
+        "transforms3d",
     ],
     python_requires=">=3.7",
     package_data={
-        "": ["LICENSE", "readme.rst"],
+        "": ["LICENSE", "README.rst"],
         "pyxem": ["*.py", "hyperspy_extension.yaml"],
     },
     entry_points={"hyperspy.extensions": ["pyxem = pyxem"]},


### PR DESCRIPTION
* Move `pyxem.signals.indexation_results.results_dict_to_crystal_map()` to `pyxem.utils.indexation_utils.results_dict_to_crystal_map()`, where it belongs. Move test accordingly.
* If `n_best` > 1 in `pyxem.utils.indexation_utils.index_dataset_with_template_rotation()`, `results_dict_to_crystal_map(..., index=1)` will return a crystal map with the second best match, `index=2` the third best match, etc. Note that [`orix.crystal_map.CrystalMap`](https://orix.readthedocs.io/en/stable/reference.html#crystalmap) allows for multiple *rotations* per point, but not phase IDs per point. Thus, if `index=None` (default) and `results["phase_index"][:, :, 0]` contains only one phase ID, all rotations per point are returned in the `CrystalMap`, as can be checked in `CrystalMap.rotations_per_point`.
* Add example to docstring of function, and add function to reference API. I couldn't build this locally, so let's hope Readthedocs builds the docs alright.
* Add missing requirements to setup.py

I made this change thanks to Aaron Chote who prompted me.

**Checklist**
- [n/a] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)