### PR TITLE
Fix to shape in results_dict_to_crystal_map

### DIFF
--- a/pyxem/tests/conftest.py
+++ b/pyxem/tests/conftest.py
@@ -233,20 +233,17 @@ def test_lib_gen():
         precession_angle=1,
         scattering_params="lobato",
         shape_factor_model="linear",
-        minimum_intensity=0.1,
+        minimum_intensity=0.05,
     )
-
     lib_gen = DiffractionLibraryGenerator(diff_gen)
     return lib_gen
 
 
 @pytest.fixture
 def test_library_phases():
-
     latt = diffpy.structure.lattice.Lattice(3, 3, 3, 90, 90, 90)
     atom = diffpy.structure.atom.Atom(atype="Ni", xyz=[0, 0, 0], lattice=latt)
     structure = diffpy.structure.Structure(atoms=[atom], lattice=latt)
-
     library_phases_test = StructureLibrary(
         ["Test"],
         [structure],
@@ -257,12 +254,13 @@ def test_library_phases():
 
 @pytest.fixture
 def test_library_phases_multi():
-
     ni_structure = diffpy.structure.Structure(
-        atoms=[diffpy.structure.atom.Atom(atype="Ni", xyz=[0, 0, 0])], lattice=diffpy.structure.lattice.Lattice(3, 3, 3, 90, 90, 90)
+        atoms=[diffpy.structure.atom.Atom(atype="Ni", xyz=[0, 0, 0])],
+        lattice=diffpy.structure.lattice.Lattice(3, 3, 3, 90, 90, 90)
     )
     al_structure = diffpy.structure.Structure(
-        atoms=[diffpy.structure.atom.Atom(atype="Al", xyz=[0, 0, 0])], lattice=diffpy.structure.lattice.Lattice(3, 4, 3, 90, 90, 90)
+        atoms=[diffpy.structure.atom.Atom(atype="Al", xyz=[0, 0, 0])],
+        lattice=diffpy.structure.lattice.Lattice(4, 4, 4, 90, 90, 90)
     )
     library_phases_test = StructureLibrary(
         ["Ni", "Al"],

--- a/pyxem/tests/utils/test_indexation_utils.py
+++ b/pyxem/tests/utils/test_indexation_utils.py
@@ -90,6 +90,7 @@ def test_match_vector_total_error_default(vector_match_peaks, vector_library):
     assert len(rhkls) == 0
 
 
+@pytest.mark.filterwarnings("ignore:Property 'correlation' was expected")
 def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     """Test getting a :class:`orix.crystal_map.CrystalMap` from returns
     from :func:`index_dataset_with_template_rotation`.
@@ -138,6 +139,7 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     # Only get the bast match when multiple phases match best to some
     # patterns
     xmap = results_dict_to_crystal_map(results, phase_dict, diffraction_library=diff_lib)
+    assert xmap.shape == nav_shape
     assert np.allclose(xmap.phase_id, phase_id[:, 0])
     assert xmap.rotations_per_point == 1
     assert xmap.phases.names == phase_names

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1508,8 +1508,8 @@ def index_dataset_with_template_rotation(
         the best matching orientations expressed in Bunge convention Euler angles.
         Correlation is the matching correlation indices. mirrored template represents
         whether the original template best fits (False) or the mirror image (True).
-        Each is a numpy array of shape (scan_x, scan_y, n_best) except orientation
-        is of shape (scan_x, scan_y, n_best, 3).
+        Each is a numpy array of shape (scan_y, scan_x, n_best) except orientation
+        is of shape (scan_y, scan_x, n_best, 3).
     phase_key_dict: dictionary
         A small dictionary to translate the integers in the phase_index array
         to phase names in the original template library.

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1782,7 +1782,7 @@ def results_dict_to_crystal_map(
     ...     results, phase_key_dict, index=1
     ... )  # doctest: +SKIP
     """
-    nx, ny, n_best = results["phase_index"].shape
+    ny, nx, n_best = results["phase_index"].shape
     if index is not None and index > n_best - 1:
         raise ValueError(f"`index` cannot be higher than {n_best - 1} (`n_best` - 1)")
 


### PR DESCRIPTION
---
name: Fix shape in results_dict_to_crystal_map
about: Simply swaps the x and y to be correct

---

**Checklist**
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
Single line fix because the shape is incorrect and will create crystal map incorrectly. + Correct docstring for index_dataset_with_template_rotation.
