### PR TITLE
Skipping failing tests using older Template matching

### DIFF
--- a/pyxem/tests/generators/test_indexation_generator.py
+++ b/pyxem/tests/generators/test_indexation_generator.py
@@ -229,6 +229,7 @@ def test_vector_indexation_generator_cartesian_check():
         vector_indexation_generator = VectorIndexationGenerator(vectors, vector_library)
 
 
+@pytest.mark.skip(reason="Failing test due to using an old version of template matching")
 def test_vector_indexation_generator_index_vectors(vector_match_peaks, vector_library):
     # vectors not used directly
     vectors = DiffractionVectors(np.array(vector_match_peaks[:, :2]))

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -39,6 +39,7 @@ def test_TemplateMatchingResults_to_crystal_map():
     return t.to_crystal_map()
 
 
+@pytest.mark.skip(reason="Failing test due to using an old version of template matching")
 def test_TemplateMatchingResults_plot_best_results_on_signal(
     diffraction_pattern, default_structure
 ):


### PR DESCRIPTION
Skipping failing tests using older Template matching
---
name: Skipping failing tests using older Template matching
about: 
This skips the failing tests as per @pc494. It gets testing back to passing with the new hyperspy version, although this should be fixed in later versions of pyxem.

---

**Checklist**
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)
