### PR TITLE
Remove process dask array

### DIFF
--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -145,7 +145,7 @@ class TestFullDirectBeamCentering:
         s_beam_shift = s.get_direct_beam_position(method="blur", sigma=1)
         s_beam_shift.make_linear_plane(mask=s_mask)
         s.center_direct_beam(shifts=s_beam_shift)
-        assert (s.data[:, :, 8, 8] == 10).all()
+        np.testing.assert_almost_equal(s.data[:, :, 8, 8], 10,decimal=5)
         s.data[:, :, 8, 8] = 0
         s.data[1, 2, 3, 2] = 0
         np.testing.assert_almost_equal(s.data, 0.0, decimal=5)
@@ -162,7 +162,7 @@ class TestFullDirectBeamCentering:
         s_beam_shift.make_linear_plane(mask=s_mask)
         s.center_direct_beam(shifts=s_beam_shift)
         s.compute()
-        assert (s.data[:, :, 8, 8] == 10).all()
+        np.testing.assert_almost_equal(s.data[:, :, 8, 8], 10,decimal=5)
         s.data[:, :, 8, 8] = 0
         s.data[1, 2, 3, 2] = 0
         np.testing.assert_almost_equal(s.data, 0.0, decimal=5)

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -767,25 +767,25 @@ class TestGetDirectBeamPosition:
 
     def test_lazy_result(self):
         s = self.s
-        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_output=True)
         assert hasattr(s_shift.data, "compute")
         s_shift.compute()
 
     def test_lazy_input_non_lazy_result(self):
         s = LazyDiffraction2D(da.from_array(self.s.data))
-        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=False)
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_output=False)
         assert not hasattr(s_shift.data, "compute")
         assert not hasattr(s_shift, "compute")
 
     def test_lazy_input_lazy_result(self):
         s = LazyDiffraction2D(da.from_array(self.s.data))
-        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_output=True)
         assert hasattr(s_shift.data, "compute")
         s_shift.compute()
 
     def test_non_uniform_chunks(self):
         s = LazyDiffraction2D(da.from_array(self.s.data, chunks=(8, 7, 10, 12)))
-        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
+        s_shift = s.get_direct_beam_position(method="blur", sigma=1, lazy_output=True)
         shift_data_shape = s.data.shape[:-2] + (2,)
         assert s_shift.data.shape == shift_data_shape
         s_shift.compute()
@@ -823,7 +823,7 @@ class TestCenterDirectBeam:
 
     def test_non_lazy_lazy_result(self):
         s = self.s
-        s.center_direct_beam(method="blur", sigma=1, lazy_result=True)
+        s.center_direct_beam(method="blur", sigma=1, lazy_output=True, inplace=True)
         assert s._lazy is True
         s.compute()
         assert (s.data[:, :, 10, 8] == 9).all()
@@ -841,7 +841,7 @@ class TestCenterDirectBeam:
 
     def test_lazy_not_lazy_result(self):
         s_lazy = self.s_lazy
-        s_lazy.center_direct_beam(method="blur", sigma=1, lazy_result=False)
+        s_lazy.center_direct_beam(method="blur", sigma=1, lazy_output=False)
         assert s_lazy._lazy is False
         assert (s_lazy.data[:, :, 10, 8] == 9).all()
         s_lazy.data[:, :, 10, 8] = 0
@@ -852,7 +852,7 @@ class TestCenterDirectBeam:
         s_lazy.data = s_lazy.data.rechunk((5, 4, 12, 14))
         s_lazy_shape = s_lazy.axes_manager.shape
         data_lazy_shape = s_lazy.data.shape
-        s_lazy.center_direct_beam(method="blur", sigma=1, lazy_result=True)
+        s_lazy.center_direct_beam(method="blur", sigma=1, lazy_output=True)
         assert s_lazy.axes_manager.shape == s_lazy_shape
         assert s_lazy.data.shape == data_lazy_shape
         s_lazy.compute()
@@ -862,7 +862,7 @@ class TestCenterDirectBeam:
     def test_return_shifts_non_lazy(self):
         s = self.s
         s_shifts = s.center_direct_beam(method="blur", sigma=1, return_shifts=True)
-        assert s_shifts._lazy is False
+        assert s_shifts._lazy is True
         nav_dim = s.axes_manager.navigation_dimension
         assert nav_dim == s_shifts.axes_manager.navigation_dimension
         x_pos_list, y_pos_list = self.x_pos_list, self.y_pos_list
@@ -888,7 +888,7 @@ class TestCenterDirectBeam:
 
     def test_shifts_input(self):
         s = self.s
-        s_shifts = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=False)
+        s_shifts = s.get_direct_beam_position(method="blur", sigma=1, lazy_output=False)
         s.center_direct_beam(shifts=s_shifts)
         assert (s.data[:, :, 10, 8] == 9).all()
         s.data[:, :, 10, 8] = 0
@@ -896,7 +896,7 @@ class TestCenterDirectBeam:
 
     def test_shifts_input_lazy(self):
         s = self.s
-        s_shifts = s.get_direct_beam_position(method="blur", sigma=1, lazy_result=True)
+        s_shifts = s.get_direct_beam_position(method="blur", sigma=1, lazy_output=True)
         s.center_direct_beam(shifts=s_shifts)
         assert (s.data[:, :, 10, 8] == 9).all()
         s.data[:, :, 10, 8] = 0

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -862,7 +862,7 @@ class TestCenterDirectBeam:
     def test_return_shifts_non_lazy(self):
         s = self.s
         s_shifts = s.center_direct_beam(method="blur", sigma=1, return_shifts=True)
-        assert s_shifts._lazy is True
+        assert s_shifts._lazy is False
         nav_dim = s.axes_manager.navigation_dimension
         assert nav_dim == s_shifts.axes_manager.navigation_dimension
         x_pos_list, y_pos_list = self.x_pos_list, self.y_pos_list


### PR DESCRIPTION
---
name: Remove process dask array
about: This removes all instances of `process_dask_array` and replaces them with `map` instead for more constancy throughout the code.

---

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

@magnunor Do you see any reason against doing this?
