### PR TITLE
Remove setting axes unnecessarily and simplify code, part 2

### DIFF
--- a/pyxem/signals/correlation1d.py
+++ b/pyxem/signals/correlation1d.py
@@ -83,9 +83,10 @@ class Correlation1D(Signal1D):
         if normalize:
             signals = np.divide(signals, num_angles)
 
-        signals.axes_manager[-1].name = "Symmetry Order"
-        signals.axes_manager.navigation_axes[0].scale = 1
-        signals.axes_manager.navigation_axes[0].name = "Symmetry"
-        signals.axes_manager.navigation_axes[0].offset = 0
+        signals.axes_manager.signal_axes[-1].name = "Symmetry Order"
+        signals.axes_manager.signal_axes[0].scale = 1
+        signals.axes_manager.signal_axes[0].name = "Symmetry"
+        signals.axes_manager.signal_axes[0].unit = "a.u."
+        signals.axes_manager.signal_axes[0].offset = 0
         
         return signals

--- a/pyxem/signals/correlation2d.py
+++ b/pyxem/signals/correlation2d.py
@@ -30,19 +30,6 @@ class Correlation2D(Signal2D, CommonDiffraction):
     """
     _signal_type = "correlation"
 
-    def __init__(self, *args, **kwargs):
-        """Create a PolarDiffraction2D object from a numpy.ndarray.
-
-        Parameters
-        ----------
-        *args :
-            Passed to the __init__ of Signal2D. The first arg should be
-            a numpy.ndarray
-        **kwargs :
-            Passed to the __init__ of Signal2D
-        """
-        super().__init__(*args, **kwargs)
-
     def get_angular_power(self, inplace=False, **kwargs):
         """Returns the power spectrum of the angular auto-correlation function
         in the form of a Signal2D class.
@@ -68,15 +55,14 @@ class Correlation2D(Signal2D, CommonDiffraction):
             The power spectrum of the Signal2D
         """
         power = self.map(corr_to_power, inplace=inplace, **kwargs)
-        if inplace:
-            self.set_signal_type("power")
-            fourier_axis = self.axes_manager.signal_axes[0]
-        else:
-            power.set_signal_type("power")
-            fourier_axis = self.axes_manager.signal_axes[0]
+
+        s = self if inplace else power
+
+        s.set_signal_type("power")
+        fourier_axis = s.axes_manager.signal_axes[0]
+
         fourier_axis.name = "Fourier Coefficient"
         fourier_axis.units = "a.u"
-        fourier_axis.offset = 0.5
         fourier_axis.scale = 1
         return power
 
@@ -96,15 +82,14 @@ class Correlation2D(Signal2D, CommonDiffraction):
             The power spectrum of summed angular correlation
         """
         power = self.nansum().map(corr_to_power, inplace=inplace, **kwargs)
-        if inplace:
-            self.set_signal_type("power")
-            fourier_axis = self.axes_manager.signal_axes[0]
-        else:
-            power.set_signal_type("power")
-            fourier_axis = self.axes_manager.signal_axes[0]
+
+        s = self if inplace else power
+
+        s.set_signal_type("power")
+        fourier_axis = s.axes_manager.signal_axes[0]
+
         fourier_axis.name = "Fourier Coefficient"
         fourier_axis.units = "a.u"
-        fourier_axis.offset = 0.5
         fourier_axis.scale = 1
         return power
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -2154,6 +2154,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         t_axis = s.axes_manager.signal_axes[0]
         k_axis = s.axes_manager.signal_axes[1]
         t_axis.name = "Radians"
+        t_axis.units = "Rad"
         
         if azimuth_range is None:
             t_axis.scale = np.pi * 2 / npt_azim

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -124,11 +124,13 @@ class PolarDiffraction2D(Signal2D):
         Parameters
         ----------
         mask: Numpy array
-            A bool mask of values to ignore of shape equal to the signal shape. True for
-            elements masked, False for elements unmasked
-        krange: tuple
-            The range of k values in corresponding unit for segment correlation (None if use
-            the entire pattern). Not compatible with ``inplace=True``.
+            A bool mask of values to ignore of shape equal to the signal shape.
+            True for elements masked, False for elements unmasked
+        krange: tuple of int or float
+            The range of k values for segment correlation. If type is ``int``,
+            the value is taken as the axis index. If type is ``float`` the
+            value is in corresponding unit.
+            If None (default), use the entire pattern .
         inplace: bool
             From hyperspy.signal.map(). inplace=True means the signal is
             overwritten.
@@ -139,30 +141,32 @@ class PolarDiffraction2D(Signal2D):
             The pearson rotational correlation when inplace is False, otherwise
             return None
         """
-        if krange is None:
-            correlation = self.map(_pearson_correlation, mask=mask, inplace=inplace, **kwargs)
-        else:
+        # placeholder to handle inplace playing well with cropping and mapping
+        s_ = self
+        if krange is not None:
             if inplace:
-                raise ValueError("`krange` is not compatible with `inplace=True`")
-            k_range_slice = self.isig[:, krange[0]:krange[1]]
-            if mask is not None:
-                mask_signal = Signal2D(mask)
-                mask_signal.axes_manager.signal_axes[1].scale = self.axes_manager[-1].scale
-                mask_signal.axes_manager.signal_axes[1].offset = self.axes_manager[-1].offset
-                mask_slice = mask_signal.isig[:, krange[0]:krange[1]]
-                correlation = k_range_slice.map(_pearson_correlation,
-                                                mask=mask_slice,
-                                                inplace=inplace,
-                                                **kwargs)
+                s_.crop(-1, start=krange[0], end=krange[1])
             else:
-                correlation = k_range_slice.map(_pearson_correlation,
-                                                inplace=inplace,
-                                                **kwargs)
+                s_ = self.isig[:, krange[0]:krange[1]]
 
-        s = self if inplace else correlation
+            if mask is not None:
+                mask = Signal2D(mask)
+                # When float krange are used, axis calibration is required
+                mask.axes_manager[-1].scale = self.axes_manager[-1].scale
+                mask.axes_manager[-1].offset = self.axes_manager[-1].offset
+                mask.crop(-1, start=krange[0], end=krange[1])
+
+        correlation = s_.map(
+            _pearson_correlation,
+            mask=mask,
+            inplace=inplace,
+            **kwargs
+            )
+
+        s = s_ if inplace else correlation
         s.set_signal_type("correlation")
+        
         rho_axis = s.axes_manager.signal_axes[0]
-
         rho_axis.name = "Radians"
         rho_axis.units = 'rad'
         rho_axis.scale = self.axes_manager[-2].scale

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -28,7 +28,6 @@ class PolarDiffraction2D(Signal2D):
 
     _signal_type = "polar_diffraction"
 
-
     def get_angular_correlation(
         self, mask=None, normalize=True, inplace=False, **kwargs
     ):
@@ -73,9 +72,12 @@ class PolarDiffraction2D(Signal2D):
             **kwargs
         )
         s = self if inplace else correlation
-        s.set_signal_type("correlation")
-        s.axes_manager.signal_axes[0].name = "Angular Correlation, $/phi$"   
+        theta_axis = s.axes_manager.signal_axes[0]
 
+        theta_axis.name = "Angular Correlation, $ \Delta \Theta$"
+        theta_axis.offset = 0
+
+        s.set_signal_type("correlation")
         return correlation
 
     def get_angular_power(self, mask=None, normalize=True, inplace=False, **kwargs):
@@ -113,7 +115,6 @@ class PolarDiffraction2D(Signal2D):
 
         fourier_axis.name = "Fourier Coefficient"
         fourier_axis.units = "a.u"
-        fourier_axis.offset = 0.5
         fourier_axis.scale = 1
 
         return power
@@ -167,7 +168,8 @@ class PolarDiffraction2D(Signal2D):
         s.set_signal_type("correlation")
         
         rho_axis = s.axes_manager.signal_axes[0]
-        rho_axis.name = "Radians"
+        rho_axis.name = "Pearson Correlation, $ \Delta \Theta$"
+        rho_axis.offset = 0
         rho_axis.units = 'rad'
         rho_axis.scale = self.axes_manager[-2].scale
         

--- a/pyxem/tests/signals/test_polar_diffraction2d.py
+++ b/pyxem/tests/signals/test_polar_diffraction2d.py
@@ -155,24 +155,32 @@ class TestPearsonCorrelation:
         pd.axes_manager.signal_axes[1].name = "k"
         return pd
 
-    @pytest.mark.parametrize("krange", [None, (0, 4), (1., 5.)])
+    @pytest.mark.parametrize("krange", [None, (0, 4), (1., 4.9)])
     def test_pearson_correlation_signal(self, flat_pattern, krange):
         rho = flat_pattern.get_pearson_correlation(krange=krange)
         assert isinstance(rho, Signal1D)
 
-    @pytest.mark.parametrize("krange", [None, (0, 30), (1., 5.)])
-    def test_pearson_correlation_results(self, flat_pattern, krange):
-        rho = flat_pattern.get_pearson_correlation(krange=krange)
-        np.testing.assert_allclose(np.zeros((2, 2, 14)), rho.data[:, :, 1:], atol=0.1)
+    @pytest.mark.parametrize('inplace', (True, False))
+    @pytest.mark.parametrize("krange", [None, (0, 30), (1., 4.9)])
+    def test_pearson_correlation_results(self, flat_pattern, krange, inplace):
+        out = flat_pattern.get_pearson_correlation(
+            krange=krange,
+            inplace=inplace,
+            )
+        if inplace:
+            assert out is None
+            out = flat_pattern
+        else:
+            # check the original signal is not changed
+            assert flat_pattern.axes_manager[-1].size == 50
+
+        assert isinstance(out, Correlation1D)
+        np.testing.assert_allclose(np.zeros((2, 2, 14)), out.data[..., 1:], atol=0.1)
 
     def test_pearson_correlation_inplace(self, flat_pattern):
         rho = flat_pattern.get_pearson_correlation(inplace=True)
         assert rho is None
         assert isinstance(flat_pattern, Correlation1D)
-
-    def test_pearson_correlation_inplace_error(self, flat_pattern):
-        with pytest.raises(ValueError):
-            flat_pattern.get_pearson_correlation(inplace=True, krange=[0, 30])
 
     def test_axes_transfer(self, flat_pattern):
         rho = flat_pattern.get_pearson_correlation()
@@ -181,9 +189,7 @@ class TestPearsonCorrelation:
             == flat_pattern.axes_manager.signal_axes[0].scale
         )
 
-    @pytest.mark.parametrize(
-        "mask", [None, np.zeros(shape=(50, 15))]
-    )
+    @pytest.mark.parametrize( "mask", [None, np.zeros(shape=(50, 15))])
     def test_masking_pearson_correlation(self, flat_pattern, mask):
         rho_0 = flat_pattern.get_pearson_correlation(mask=mask)
         assert isinstance(rho_0, Correlation1D)


### PR DESCRIPTION
Follow up of #825 to re-introduce inplace support in `get_pearson_correlation` method.