### PR TITLE
Allow manual trigger of PyPI publish action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,8 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    workflow: "*"
 
 jobs:
   deploy:


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

I see that the [publish action](https://github.com/pyxem/pyxem/runs/6228595319?check_suite_focus=true) failed due to invalid authentication. I had [similar issues](https://github.com/pyxem/orix/pull/283) with a previous orix release, and ended up adding the possibility to manually run the publish action, instead of it having to be run only when a new tagged annotated release was published (as it is in pyxem at the moment).

I think the PyPI authentication has to be updated, see https://github.com/pyxem/orix/pull/293.