### PR TITLE
Add center-of-mass algorithm to get_direct_beam_position

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
+Added
+-----
+- Center-of-mass algorithm added to get_direct_beam_position (#845)
+
 2022-29-04 - version 0.14.1
 ===========================
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -616,10 +616,17 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         method : str,
             Must be one of "cross_correlate", "blur", "interpolate" or "center_of_mass".
 
-           "cross_correlate": Center finding using cross-correlation of circles of `radius_start` to `radius_finish`.
-           "blur": Center finding by blurring each frame with a Gaussian kernel with standard deviation `sigma` and finding the maximum.
-           "interpolate": Finding the center by summing along X/Y and finding the peak for each axis independently. Data is blurred first using a Gaussian kernel with standard deviation "sigma".
-           "center_of_mass": The center is found using a calculation of the center of mass. Optionally a `mask` can be applied to focus on just the center of some dataset.
+           "cross_correlate": Center finding using cross-correlation of circles of 
+                `radius_start` to `radius_finish`.
+           "blur": Center finding by blurring each frame with a Gaussian kernel with 
+                standard deviation `sigma` and finding the maximum.
+           "interpolate": Finding the center by summing along X/Y and finding the peak 
+                for each axis independently. Data is blurred first using a Gaussian kernel 
+                with standard deviation "sigma".
+           "center_of_mass": The center is found using a calculation of the center of mass. 
+                Optionally a `mask` can be applied to focus on just the center of some 
+                dataset. A threshold value can also be given to suppress contrast from 
+                weaker diffraction features.
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
@@ -781,6 +788,16 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 # fails if non-square dp
                 max_index = int(origin_coordinates[0] + half_square_width)
                 temp_signal = temp_signal.isig[min_index:max_index, min_index:max_index]
+                if method == "center_of_mass" and "mask" in kwargs:
+                    # correct mask coordinates
+                    center_of_mass_mask = kwargs["mask"]
+                    center_of_mass_mask = (
+                        center_of_mass_mask[0] - min_index, 
+                        center_of_mass_mask[1] - min_index, 
+                        center_of_mass_mask[2],
+                    )
+                    kwargs["mask"] = center_of_mass_mask
+            
             shifts = temp_signal.get_direct_beam_position(
                 method=method,
                 lazy_output=lazy_output,

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -704,7 +704,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Parameters
         ----------
-        method : str {'cross_correlate', 'blur', 'interpolate'}
+        method : str {'cross_correlate', 'blur', 'interpolate', 'center_of_mass'}
             Method used to estimate the direct beam position. The direct
             beam position can also be passed directly with the shifts parameter.
         half_square_width : int

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -615,6 +615,11 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         ----------
         method : str,
             Must be one of "cross_correlate", "blur", "interpolate" or "center_of_mass".
+
+           "cross_correlate": Center finding using cross-correlation of circles of `radius_start` to `radius_finish`.
+           "blur": Center finding by blurring each frame with a Gaussian kernel with standard deviation `sigma` and finding the maximum.
+           "interpolate": Finding the center by summing along X/Y and finding the peak for each axis independently. Data is blurred first using a Gaussian kernel with standard deviation "sigma".
+           "center_of_mass": The center is found using a calculation of the center of mass. Optionally a `mask` can be applied to focus on just the center of some dataset.
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
@@ -677,6 +682,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             shifts = -centers + origin_coordinates
         elif method == "center_of_mass":
             centers = self.center_of_mass(lazy_result=lazy_output,
+                                          show_progressbar=False,
                                           **kwargs,
                                           )
             shifts = -centers.T + origin_coordinates

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -614,7 +614,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         Parameters
         ----------
         method : str,
-            Must be one of "cross_correlate", "blur" or "interpolate"
+            Must be one of "cross_correlate", "blur", "interpolate" or "center_of_mass".
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
@@ -643,6 +643,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             "cross_correlate": find_beam_offset_cross_correlation,
             "blur": find_beam_center_blur,
             "interpolate": find_beam_center_interpolate,
+            "center_of_mass": None,
         }
 
         method_function = select_method_from_method_dict(method, method_dict,
@@ -674,6 +675,11 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                                **kwargs,
                                )
             shifts = -centers + origin_coordinates
+        elif method == "center_of_mass":
+            centers = self.center_of_mass(lazy_result=lazy_output,
+                                          **kwargs,
+                                          )
+            shifts = -centers.T + origin_coordinates
 
         shifts.set_signal_type("beam_shift")
 

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -975,6 +975,10 @@ class TestCenterDirectBeam:
         s = self.s
         s.center_direct_beam(method="cross_correlate", radius_start=0, radius_finish=2)
 
+    def test_method_center_of_mass(self):
+        s = self.s
+        s.center_direct_beam(method="center_of_mass")
+
     def test_parameter_both_method_and_shifts(self):
         s = self.s
         with pytest.raises(ValueError):

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -756,6 +756,16 @@ class TestGetDirectBeamPosition:
             method="cross_correlate", radius_start=0, radius_finish=1
         )
 
+    def test_center_of_mass(self):
+        dx, dy = self.dx, self.dy
+        s, x_pos_list, y_pos_list = self.s, self.x_pos_list, self.y_pos_list
+        s_shift = s.get_direct_beam_position(
+            method="center_of_mass"
+        )
+        assert s.axes_manager.navigation_shape == s_shift.axes_manager.navigation_shape
+        assert (-(x_pos_list - dx / 2) == s_shift.isig[0].data[0]).all()
+        assert (-(y_pos_list - dy / 2) == s_shift.isig[1].data[:, 0]).all()
+
     def test_lazy_result_none_non_lazy_signal(self):
         s = self.s
         s_shift = s.get_direct_beam_position(method="blur", sigma=1)


### PR DESCRIPTION
---
name: Center-of-mass in get_direct_beam_position
about: Adds center-of-mass algorithm to get_direct_beam_position for Diffraction2D

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
This adds the center-of-mass algorithm to get_direct_beam_position in Diffraction2D. 
It reuses the center_of_mass method in Diffraction2D, then adjusts the result to comply with the existing get_direct_beam_position return values.
Also adds a test for the functionality.

**Describe alternatives you've considered**
To reimplement center-of-mass or use a method outside the class. However, it is more efficient to reuse existing functionality.

**Are there any known issues? Do you need help?**

**Work in progress?**
If you know there is more to do, make a checklist here:
