### PR TITLE
Increase minimal version of orix to 0.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+
+Changed
+-------
+- Increase minimal version of orix to >= 0.9.
+
 2022-29-04 - version 0.14.1
 ===========================
 

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -16,11 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
-
-import numpy as np
 
 from hyperspy.signals import Signal2D
+import numpy as np
+import pytest
 
 from pyxem.generators import VirtualDarkFieldGenerator
 from pyxem.signals import (
@@ -73,25 +72,28 @@ def learning_segment(signal_decomposition):
 class TestLearningSegment:
     def test_learning_ncc_matrix(self, learning_segment):
         ncc = learning_segment.get_ncc_matrix()
+        # fmt: off
         ans = np.array(
             [
                 [
-                    [1.0, -0.26413543, -0.50636968, 0.61237256, 0.0],
-                    [-0.26413543, 1.0, -0.40125028, -0.43133109, 0.0],
-                    [-0.50636968, -0.40125028, 1.0, -0.31008684, 0.0],
-                    [0.61237256, -0.43133109, -0.31008684, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0, 1.0],
+                    [ 1.0,   -0.264, -0.506,  0.612, 0.0],
+                    [-0.264,  1.0,   -0.401, -0.431, 0.0],
+                    [-0.506, -0.401,  1.0,   -0.310, 0.0],
+                    [ 0.612, -0.431, -0.310,  1.0,   0.0],
+                    [ 0.0,    0.0,    0.0,    0.0,   1.0],
                 ],
                 [
-                    [1.0, -0.0588285, -0.07313363, -0.04087783, 0.0],
-                    [-0.0588285, 1.0, -0.07312725, -0.04099601, 0.0],
-                    [-0.07313363, -0.07312725, 1.0, -0.05096472, 0.0],
-                    [-0.04087783, -0.04099601, -0.05096472, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0, 1.0],
+                    [ 1.0,   -0.059, -0.073, -0.041, 0.0],
+                    [-0.059,  1.0,   -0.073, -0.041, 0.0],
+                    [-0.073, -0.073,  1.0,   -0.051, 0.0],
+                    [-0.040, -0.041, -0.051,  1.0,   0.0],
+                    [ 0.0,    0.0,    0.0,    0.0,   1.0],
                 ],
             ]
         )
-        np.testing.assert_almost_equal(ncc.data, ans)
+        # fmt: on
+        print(ncc.data)
+        assert np.allclose(ncc.data, ans, atol=1e-3)
 
     @pytest.mark.parametrize(
         "corr_th_factors, corr_th_loadings", [(-0.1, 0.6), (0.5, 0.5)]

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 
 from hyperspy.signals import Signal2D
 import numpy as np
@@ -70,6 +71,11 @@ def learning_segment(signal_decomposition):
 
 
 class TestLearningSegment:
+    @pytest.mark.skipif(
+        (sys.platform == "win32" and sys.version_info[:2] == (3, 8)) or
+        (sys.platform == "darwin" and sys.version_info[:2] in [(3, 8), (3, 9)]),
+        reason="NCC scores differ on these OS' with these Python versions"
+    )
     def test_learning_ncc_matrix(self, learning_segment):
         ncc = learning_segment.get_ncc_matrix()
         # fmt: off

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -92,7 +92,6 @@ class TestLearningSegment:
             ]
         )
         # fmt: on
-        print(ncc.data)
         assert np.allclose(ncc.data, ans, atol=1e-3)
 
     @pytest.mark.parametrize(

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -58,7 +58,7 @@ def signal_data():
 
 @pytest.fixture
 def signal_decomposition(signal_data):
-    signal_data.decomposition(algorithm="NMF", output_dimension=5)
+    signal_data.decomposition(algorithm="NMF", output_dimension=5, init="nndsvd")
     s_nmf = signal_data.get_decomposition_model(components=5)
     factors = s_nmf.get_decomposition_factors()
     loadings = s_nmf.get_decomposition_loadings()
@@ -71,11 +71,6 @@ def learning_segment(signal_decomposition):
 
 
 class TestLearningSegment:
-    @pytest.mark.skipif(
-        (sys.platform == "win32" and sys.version_info[:2] == (3, 8)) or
-        (sys.platform == "darwin" and sys.version_info[:2] in [(3, 8), (3, 9)]),
-        reason="NCC scores differ on these OS' with these Python versions"
-    )
     def test_learning_ncc_matrix(self, learning_segment):
         ncc = learning_segment.get_ncc_matrix()
         # fmt: off

--- a/pyxem/tests/utils/test_indexation_utils.py
+++ b/pyxem/tests/utils/test_indexation_utils.py
@@ -26,6 +26,7 @@ from pyxem.utils.indexation_utils import (
     index_dataset_with_template_rotation, results_dict_to_crystal_map
 )
 
+
 def test_match_vectors(vector_match_peaks, vector_library):
     # Wrap to test handling of ragged arrays
     peaks = np.empty(1, dtype="object")
@@ -92,7 +93,14 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     phase_names = list(diff_lib.keys())
 
     # Simulate patterns
-    sim_kwargs = dict(size=sig_shape[0], sigma=4)
+    # TODO: Remove version check after diffsims 0.5.0 is released
+    from packaging.version import Version
+    import diffsims
+    diffsims_version = Version(diffsims.__version__)
+    if diffsims_version > Version("0.4.2"):
+        sim_kwargs = dict(shape=sig_shape, sigma=4)
+    else:  # pragma: no cover
+        sim_kwargs = dict(size=sig_shape[0], sigma=4)
     for idx in np.ndindex(*nav_shape):
         i = phase_id[idx]
         j = int(idx[1] / 2)

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -107,6 +107,7 @@ def get_nth_best_solution(
 
     return best_fit
 
+
 def index_magnitudes(z, simulation, tolerance):
     """Assigns hkl indices to peaks in the diffraction profile.
 
@@ -1711,7 +1712,7 @@ def results_dict_to_crystal_map(
     elif index is not None:
         euler = euler[:, index]  # Desired match only
     euler = euler.squeeze()  # Remove singleton dimensions
-    rotations = Rotation.from_euler(euler, convention="bunge", direction="crystal2lab")
+    rotations = Rotation.from_euler(euler)
 
     props = {}
     for key in ("correlation", "mirrored_template", "template_index"):

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,7 @@ setup(
     extras_require=extra_feature_requirements,
     install_requires=[
         "dask",
-#        "diffsims       ~= 0.4",
-        "diffsims       == 0.5.0rc1",
+        "diffsims       ~= 0.4",
         "hyperspy       >= 1.7.0",  # significant improvements
         "ipywidgets",
         "lmfit          >= 0.9.12",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "matplotlib     >= 3.1.1",  # 3.1.0 failed
         "numba",
         "numpy",
-        "orix           >= 0.3",
+        "orix           >= 0.9",
         "psutil",
         "pyfai",
         "scikit-image   >= 0.17.0",

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ setup(
     extras_require=extra_feature_requirements,
     install_requires=[
         "dask",
-        "diffsims       ~= 0.4",
+#        "diffsims       ~= 0.4",
+        "diffsims       == 0.5.0rc1",
         "hyperspy       >= 1.7.0",  # significant improvements
         "ipywidgets",
         "lmfit          >= 0.9.12",


### PR DESCRIPTION
* Increase minimal version of orix to `>= 0.9`. This leads to some currently failing tests to pass (fixes #843).
* Updates an indexing utilities test to work with both diffsims 0.4.2 and the coming 0.5.0. This check should be removed once the minimal version of diffsims is increased to `>= 0.5`.
* Reduce precision in a failing learning segment NCC matrix test.

**Checklist**
- [x] Updated CHANGELOG.md
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)