### PR TITLE
Fix bug in `get_DisplacementGradientMap`, due to changes in HyperSpy map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changed
 -------
 - Increase minimal version of orix to >= 0.9.
 
+Fixed
+-----
+- Fix bug in `get_DisplacementGradientMap` (#852)
+
 2022-29-04 - version 0.14.1
 ===========================
 

--- a/pyxem/generators/displacement_gradient_tensor_generator.py
+++ b/pyxem/generators/displacement_gradient_tensor_generator.py
@@ -65,6 +65,8 @@ def get_DisplacementGradientMap(strained_vectors, unstrained_vectors, weights=No
         Vu=unstrained_vectors,
         weights=weights,
         inplace=False,
+        output_signal_size=(3, 3),
+        output_dtype=np.float64,
     )
 
     return DisplacementGradientMap(D)
@@ -102,6 +104,9 @@ def get_single_DisplacementGradientTensor(Vs, Vu=None, weights=None):
     get_DisplacementGradientMap()
 
     """
+    if Vu is not None:
+        if Vu.dtype == object:
+            Vu = Vu[()]
     if weights is not None:
         # see https://stackoverflow.com/questions/27128688
         weights = np.asarray(weights)

--- a/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
@@ -132,3 +132,28 @@ def test_weight_function_behaviour():
     np.testing.assert_almost_equal(
         strain_map.inav[0].isig[0, 0].data[0], -1.0166666 + 1, decimal=2
     )
+
+
+class TestLazyNotLazy:
+
+    def setup_method(self):
+        data = np.empty((4, 2), dtype=object)
+        for iy, ix in np.ndindex(data.shape):
+            data[iy, ix] = np.array([[5, 10], [10, 5]])
+        self.vs = hs.signals.BaseSignal(data, ragged=True)
+
+    def test_not_lazy(self):
+        vs = self.vs
+        vs_ref = vs.inav[0, 0]
+        D = get_DisplacementGradientMap(vs, vs_ref)
+        assert D.axes_manager.navigation_shape == (2, 4)
+        assert D.axes_manager.signal_shape == (3, 3)
+        strain_map = D.get_strain_maps()
+
+    def test_lazy(self):
+        vs = self.vs.as_lazy()
+        vs_ref = vs.inav[0, 0]
+        D = get_DisplacementGradientMap(vs, vs_ref)
+        assert D.axes_manager.navigation_shape == (2, 4)
+        assert D.axes_manager.signal_shape == (3, 3)
+        strain_map = D.get_strain_maps()


### PR DESCRIPTION
Currently `get_DisplacementGradientMap` is not working correctly in some cases, partly due to changes in `s.map`.

Working in progress, will extend the text here soonish.

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Add unit test