### PR TITLE
BugFix: list--> Tuple in correlation_utils.py for numpy 1.23

### DIFF
--- a/pyxem/utils/correlation_utils.py
+++ b/pyxem/utils/correlation_utils.py
@@ -31,7 +31,7 @@ def _correlation(z, axis=0, mask=None, wrap=True, normalize=True):
         padder[axis] = (pad, pad)
         slicer = [
             slice(None),
-        ] * len(z_shape)
+                 ] * len(z_shape)
         slicer[axis] = slice(0, -2 * pad)  # creating the proper slices
         if mask is None:
             mask = np.zeros(shape=np.shape(z))
@@ -71,8 +71,7 @@ def _correlation(z, axis=0, mask=None, wrap=True, normalize=True):
         a = np.divide(np.subtract(a, row_mean), row_mean)
 
     if wrap is False:
-        print(slicer)
-        a = a[slicer]
+        a = a[tuple(slicer)]
     return a
 
 


### PR DESCRIPTION
name: BugFix: list--> Tuple in correlation_utils.py for numpy 1.23
about: Fixes #863 

Fixes test failing from changing to numpy 1.23.  Lists of slices are no longer accepted to index numpy arrays.  Cast from list to tuple.
