### PR TITLE
Deprecation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-2022-29-04 - version 0.14.0
+2022-29-04 - version 0.14.1
 ===========================
 
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 Added
 -----
 - Added damp_extrapolate_to_zero to ReducedIntensity1D
+- Addded in deprecation wrapper class to wrap deprecated functions in pyxem.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Unreleased
 Added
 -----
 - Added damp_extrapolate_to_zero to ReducedIntensity1D
-- Addded in deprecation wrapper class to wrap deprecated functions in pyxem.
+- Added in deprecation wrapper class to wrap deprecated functions in pyxem.
 
 Changed
 -------

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -153,8 +153,8 @@ Tips for writing Jupyter notebooks that are meant to be converted to reST text f
   must be added to the gallery in the README.rst to be included in the
   documentation pages.
 
-Deprecations:
-=============
+Deprecations
+============
 We attempt to adhere to semantic versioning as best we can. This means that as little,
 ideally no, functionality should break between minor releases. Deprecation warnings
 are raised whenever possible and feasible for functions/methods/properties/arguments,

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -153,6 +153,25 @@ Tips for writing Jupyter notebooks that are meant to be converted to reST text f
   must be added to the gallery in the README.rst to be included in the
   documentation pages.
 
+Deprecations:
+=============
+We attempt to adhere to semantic versioning as best we can. This means that as little,
+ideally no, functionality should break between minor releases. Deprecation warnings
+are raised whenever possible and feasible for functions/methods/properties/arguments,
+so that users get a heads-up one (minor) release before something is removed or changes,
+with a possible alternative to be used.
+
+The decorator should be placed right above the object signature to be deprecated::
+
+    @deprecate(since=0.8, removal=0.9, alternative="bar")
+    def foo(self, n):
+        return n + 1
+
+    @property
+    @deprecate(since=0.9, removal=0.10, alternative="another", is_function=True)
+    def this_property(self):
+        return 2
+
 Running and writing tests
 =========================
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -37,8 +37,13 @@ from pyxem.utils.signal import (
     select_method_from_method_dict,
     transfer_navigation_axes,
 )
+from pyxem.utils._deprecated import deprecated
 
 
+@deprecated(since="0.14",
+            alternative="pyxem.generators.AcceleratedIndexationGenerator or pyxem.generators.VectorIndexationGenerator",
+            alternative_is_function=True,
+            removal="1.0.0", )
 class IndexationGenerator:
     """Generates an indexer for data using a number of methods.
 
@@ -63,6 +68,10 @@ class IndexationGenerator:
         )
 
 
+@deprecated(since="0.14",
+            alternative="pyxem.generators.AcceleratedIndexationGenerator or pyxem.generators.VectorIndexationGenerator",
+            alternative_is_function=True,
+            removal="1.0.0", )
 class TemplateIndexationGenerator:
     """Generates an indexer for data using a number of methods.
 

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -40,10 +40,6 @@ from pyxem.utils.signal import (
 from pyxem.utils._deprecated import deprecated
 
 
-@deprecated(since="0.14",
-            alternative="pyxem.generators.AcceleratedIndexationGenerator or pyxem.generators.VectorIndexationGenerator",
-            alternative_is_function=True,
-            removal="1.0.0", )
 class IndexationGenerator:
     """Generates an indexer for data using a number of methods.
 
@@ -68,10 +64,6 @@ class IndexationGenerator:
         )
 
 
-@deprecated(since="0.14",
-            alternative="pyxem.generators.AcceleratedIndexationGenerator or pyxem.generators.VectorIndexationGenerator",
-            alternative_is_function=True,
-            removal="1.0.0", )
 class TemplateIndexationGenerator:
     """Generates an indexer for data using a number of methods.
 
@@ -131,10 +123,7 @@ class AcceleratedIndexationGenerator:
         self.library = diffraction_library
 
     def correlate(
-        self,
-        n_largest=5,
-        include_phases=None,
-        **kwargs,
+        self, n_largest=5, include_phases=None, **kwargs,
     ):
         """
         Correlates the library of simulated diffraction patterns with the

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -37,7 +37,6 @@ from pyxem.utils.signal import (
     select_method_from_method_dict,
     transfer_navigation_axes,
 )
-from pyxem.utils._deprecated import deprecated
 
 
 class IndexationGenerator:

--- a/pyxem/generators/pdf_generator1d.py
+++ b/pyxem/generators/pdf_generator1d.py
@@ -34,16 +34,20 @@ class PDFGenerator1D:
     signal : ReducedIntensity1D
         A reduced intensity radial profile.
     """
-    @deprecated(since="0.15",
-                alternative="diffraction2d.get_pdf",
-                alternative_is_function=True,
-                removal="1.0.0", )
+
+    @deprecated(
+        since="0.15",
+        alternative="pyxem.signals.diffraction2d.get_pdf",
+        removal="1.0.0",
+    )
     def __init__(self, signal, *args, **kwargs):
         self.signal = signal
-    @deprecated(since="0.15",
-                alternative="diffraction2d.get_pdf",
-                alternative_is_function=True,
-                removal="1.0.0", )
+
+    @deprecated(
+        since="0.15",
+        alternative="pyxem.signals.diffraction2d.get_pdf",
+        removal="1.0.0",
+    )
     def get_pdf(self, s_min, s_max=None, r_min=0, r_max=20, r_increment=0.01):
         """Calculates the pdf from the reduced intensity signal.
 

--- a/pyxem/generators/pdf_generator1d.py
+++ b/pyxem/generators/pdf_generator1d.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from pyxem.signals import PairDistributionFunction1D
 from pyxem.utils.signal import transfer_navigation_axes
+from pyxem.utils._deprecated import deprecated
 
 
 class PDFGenerator1D:
@@ -33,10 +34,16 @@ class PDFGenerator1D:
     signal : ReducedIntensity1D
         A reduced intensity radial profile.
     """
-
+    @deprecated(since="0.15",
+                alternative="diffraction2d.get_pdf",
+                alternative_is_function=True,
+                removal="1.0.0", )
     def __init__(self, signal, *args, **kwargs):
         self.signal = signal
-
+    @deprecated(since="0.15",
+                alternative="diffraction2d.get_pdf",
+                alternative_is_function=True,
+                removal="1.0.0", )
     def get_pdf(self, s_min, s_max=None, r_min=0, r_max=20, r_increment=0.01):
         """Calculates the pdf from the reduced intensity signal.
 

--- a/pyxem/generators/variance_generator.py
+++ b/pyxem/generators/variance_generator.py
@@ -27,6 +27,7 @@ from pyxem.utils.signal import (
     transfer_navigation_axes_to_signal_axes,
     transfer_signal_axes,
 )
+from pyxem.utils._deprecated import deprecated
 
 
 class VarianceGenerator:
@@ -40,12 +41,20 @@ class VarianceGenerator:
 
     """
 
+    @deprecated(since="0.15",
+                alternative="diffraction2d.get_variance",
+                alternative_is_function=True,
+                removal="1.0.0", )
     def __init__(self, signal, *args, **kwargs):
         self.signal = signal
         self.thickness_filter = None
 
-        # add a check for calibration
 
+        # add a check for calibration
+    @deprecated(since="0.15",
+                alternative="diffraction2d.get_variance",
+                alternative_is_function=True,
+                removal="1.0.0", )
     def get_diffraction_variance(self, dqe, set_data_type=None):
         """Calculates the variance in scattered intensity as a function of
         scattering vector.
@@ -92,7 +101,10 @@ class VarianceGenerator:
         dv = transfer_signal_axes(dv, self.signal)
 
         return dv
-
+    @deprecated(since="0.15",
+                alternative="diffraction2d.get_variance",
+                alternative_is_function=True,
+                removal="1.0.0", )
     def get_image_variance(self, dqe):
         """Calculates the variance in scattered intensity as a function of
         scattering vector. The calculated variance is normalised by the mean

--- a/pyxem/generators/variance_generator.py
+++ b/pyxem/generators/variance_generator.py
@@ -41,20 +41,22 @@ class VarianceGenerator:
 
     """
 
-    @deprecated(since="0.15",
-                alternative="diffraction2d.get_variance",
-                alternative_is_function=True,
-                removal="1.0.0", )
+    @deprecated(
+        since="0.15",
+        alternative="pyxem.signals.diffraction2d.get_variance",
+        removal="1.0.0",
+    )
     def __init__(self, signal, *args, **kwargs):
         self.signal = signal
         self.thickness_filter = None
 
-
         # add a check for calibration
-    @deprecated(since="0.15",
-                alternative="diffraction2d.get_variance",
-                alternative_is_function=True,
-                removal="1.0.0", )
+
+    @deprecated(
+        since="0.15",
+        alternative="pyxem.signals.diffraction2d.get_variance",
+        removal="1.0.0",
+    )
     def get_diffraction_variance(self, dqe, set_data_type=None):
         """Calculates the variance in scattered intensity as a function of
         scattering vector.
@@ -101,10 +103,12 @@ class VarianceGenerator:
         dv = transfer_signal_axes(dv, self.signal)
 
         return dv
-    @deprecated(since="0.15",
-                alternative="diffraction2d.get_variance",
-                alternative_is_function=True,
-                removal="1.0.0", )
+
+    @deprecated(
+        since="0.15",
+        alternative="pyxem.signals.diffraction2d.get_variance",
+        removal="1.0.0",
+    )
     def get_image_variance(self, dqe):
         """Calculates the variance in scattered intensity as a function of
         scattering vector. The calculated variance is normalised by the mean

--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -1,5 +1,5 @@
 name = "pyxem"
-version = "0.14.0"
+version = "0.14.1"
 author = "Duncan Johnstone, Phillip Crout, Magnus Nord"
 copyright = "Copyright 2016-2022, The pyxem developers"
 # Contributors listed by original commiter, maintainers, then other

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -75,6 +75,7 @@ import pyxem.utils.pixelated_stem_tools as pst
 import pyxem.utils.dask_tools as dt
 import pyxem.utils.marker_tools as mt
 import pyxem.utils.ransac_ellipse_tools as ret
+from pyxem.utils._deprecated import deprecated
 
 
 class Diffraction2D(Signal2D, CommonDiffraction):
@@ -1092,7 +1093,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             s = LazyDiffraction2D(output_array)
         pst._copy_signal_all_axes_metadata(self, s)
         return s
-
+    @deprecated(since="0.14",
+                alternative="find_peaks",
+                alternative_is_function=True,
+                removal="1.0.0",)
     def find_peaks_lazy(
         self, method="dog", lazy_result=True, show_progressbar=True, **kwargs
     ):
@@ -1584,10 +1588,16 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return variance
 
     """ Methods associated with radial integration, not pyFAI based """
-
+    @deprecated(since="0.14",
+                alternative="get_azimuthal_integral1d",
+                alternative_is_function=True,
+                removal="1.0.0",)
     def radial_integration(self):
         raise Exception("radial_integration has been renamed radial_average")
-
+    @deprecated(since="0.14",
+                alternative="get_azimuthal_integral1d",
+                alternative_is_function=True,
+                removal="1.0.0",)
     def radial_average(
         self,
         centre_x=None,

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -778,9 +778,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 max_index = int(origin_coordinates[0] + half_square_width)
                 temp_signal = temp_signal.isig[min_index:max_index, min_index:max_index]
             shifts = temp_signal.get_direct_beam_position(
-                method=method,
-                lazy_output=lazy_output,
-                **kwargs,
+                method=method, lazy_output=lazy_output, **kwargs,
             )
 
         if not "order" in align_kwargs:
@@ -1093,10 +1091,12 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             s = LazyDiffraction2D(output_array)
         pst._copy_signal_all_axes_metadata(self, s)
         return s
-    @deprecated(since="0.14",
-                alternative="find_peaks",
-                alternative_is_function=True,
-                removal="1.0.0",)
+
+    @deprecated(
+        since="0.14",
+        alternative="hyperspy.signals.signal2d.find_peaks",
+        removal="1.0.0",
+    )
     def find_peaks_lazy(
         self, method="dog", lazy_result=True, show_progressbar=True, **kwargs
     ):
@@ -1588,16 +1588,20 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return variance
 
     """ Methods associated with radial integration, not pyFAI based """
-    @deprecated(since="0.14",
-                alternative="get_azimuthal_integral1d",
-                alternative_is_function=True,
-                removal="1.0.0",)
+
+    @deprecated(
+        since="0.14",
+        alternative="pyxem.signals.diffraction2d.get_azimuthal_integral1d",
+        removal="1.0.0",
+    )
     def radial_integration(self):
         raise Exception("radial_integration has been renamed radial_average")
-    @deprecated(since="0.14",
-                alternative="get_azimuthal_integral1d",
-                alternative_is_function=True,
-                removal="1.0.0",)
+
+    @deprecated(
+        since="0.14",
+        alternative="pyxem.signals.diffraction2d.get_azimuthal_integral1d",
+        removal="1.0.0",
+    )
     def radial_average(
         self,
         centre_x=None,

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1093,7 +1093,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return s
 
     @deprecated(
-        since="0.14",
+        since="0.15",
         alternative="hyperspy.signals.signal2d.find_peaks",
         removal="1.0.0",
     )
@@ -1590,7 +1590,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
     """ Methods associated with radial integration, not pyFAI based """
 
     @deprecated(
-        since="0.14",
+        since="0.15",
         alternative="pyxem.signals.diffraction2d.get_azimuthal_integral1d",
         removal="1.0.0",
     )
@@ -1598,7 +1598,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         raise Exception("radial_integration has been renamed radial_average")
 
     @deprecated(
-        since="0.14",
+        since="0.15",
         alternative="pyxem.signals.diffraction2d.get_azimuthal_integral1d",
         removal="1.0.0",
     )

--- a/pyxem/tests/utils/test_deprecation.py
+++ b/pyxem/tests/utils/test_deprecation.py
@@ -1,0 +1,115 @@
+import warnings
+
+import numpy as np
+import pytest
+
+from pyxem.utils._deprecated import deprecated, deprecated_argument
+
+
+class TestDeprecationWarning:
+    def test_deprecation_since(self):
+        """Ensure functions decorated with the custom deprecated
+        decorator returns desired output, raises a desired warning, and
+        gets the desired additions to their docstring.
+        """
+
+        @deprecated(since=0.7, alternative="bar", removal=0.8)
+        def foo(n):
+            """Some docstring."""
+            return n + 1
+
+        with pytest.warns(np.VisibleDeprecationWarning) as record:
+            assert foo(4) == 5
+        desired_msg = (
+            "Function `foo()` is deprecated and will be removed in version 0.8. Use "
+            "`bar()` instead."
+        )
+        assert str(record[0].message) == desired_msg
+        assert foo.__doc__ == (
+            "[*Deprecated*] Some docstring.\n\n"
+            "Notes\n-----\n"
+            ".. deprecated:: 0.7\n"
+            f"   {desired_msg}"
+        )
+
+        @deprecated(since=1.9)
+        def foo2(n):
+            """Another docstring.
+            Notes
+            -----
+            Some existing notes.
+            """
+            return n + 2
+
+        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+            assert foo2(4) == 6
+        desired_msg2 = "Function `foo2()` is deprecated."
+        assert str(record2[0].message) == desired_msg2
+        assert foo2.__doc__ == (
+            "[*Deprecated*] Another docstring."
+            "\nNotes\n-----\n"
+            "Some existing notes.\n\n"
+            ".. deprecated:: 1.9\n"
+            f"   {desired_msg2}"
+        )
+
+    def test_deprecation_no_old_doc(self):
+        @deprecated(since=0.7, alternative="bar", removal=0.8)
+        def foo(n):
+            return n + 1
+
+        with pytest.warns(np.VisibleDeprecationWarning) as record:
+            assert foo(4) == 5
+        desired_msg = (
+            "Function `foo()` is deprecated and will be removed in version 0.8. Use "
+            "`bar()` instead."
+        )
+        assert str(record[0].message) == desired_msg
+        assert foo.__doc__ == (
+            "[*Deprecated*] \n"
+            "\nNotes\n-----\n"
+            ".. deprecated:: 0.7\n"
+            f"   {desired_msg}"
+        )
+
+
+class TestDeprecateArgument:
+    def test_deprecate_argument(self):
+        """Functions decorated with the custom `deprecated_argument`
+        decorator returns desired output and raises a desired warning
+        only if the argument is passed.
+        """
+
+        class Foo:
+            @deprecated_argument(name="a", since="1.3", removal="1.4")
+            def bar_arg(self, **kwargs):
+                return kwargs
+
+            @deprecated_argument(name="a", since="1.3", removal="1.4", alternative="b")
+            def bar_arg_alt(self, **kwargs):
+                return kwargs
+
+        my_foo = Foo()
+
+        # Does not warn
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert my_foo.bar_arg(b=1) == {"b": 1}
+
+        # Warns
+        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+            assert my_foo.bar_arg(a=2) == {"a": 2}
+        assert str(record2[0].message) == (
+            r"Argument `a` is deprecated and will be removed in version 1.4. "
+            r"To avoid this warning, please do not use `a`. See the documentation of "
+            r"`bar_arg()` for more details."
+        )
+
+        # Warns with alternative
+        with pytest.warns(np.VisibleDeprecationWarning) as record3:
+            assert my_foo.bar_arg_alt(a=3) == {"a": 3}
+        assert str(record3[0].message) == (
+            r"Argument `a` is deprecated and will be removed in version 1.4. "
+            r"To avoid this warning, please do not use `a`. Use `b` instead. See the "
+            r"documentation of `bar_arg_alt()` for more details."
+        )

--- a/pyxem/tests/utils/test_deprecation.py
+++ b/pyxem/tests/utils/test_deprecation.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2022 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
 import warnings
 
 import numpy as np

--- a/pyxem/utils/_deprecated.py
+++ b/pyxem/utils/_deprecated.py
@@ -40,7 +40,7 @@ class deprecated:
     `scikit-image
     <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py>`_
     and `matplotlib
-    <https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_api/deprecation.py#L122>`_.
+    <https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_api/deprecation.py>`_.
     """
 
     def __init__(
@@ -50,6 +50,7 @@ class deprecated:
         alternative_is_function: bool = True,
         removal: Union[str, int, float, None] = None,
     ):
+
         """Visible deprecation warning.
         Parameters
         ----------
@@ -116,7 +117,7 @@ class deprecated_argument:
     """Decorator to remove an argument from a function or method's
     signature.
     Adapted from `scikit-image
-    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L115>`_.
+    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py>`_.
     """
 
     def __init__(self, name, since, removal, alternative=None):

--- a/pyxem/utils/_deprecated.py
+++ b/pyxem/utils/_deprecated.py
@@ -1,5 +1,23 @@
-"""Helper functions and classes for managing kikuchipy.
-This module and documentation is only relevant for kikuchipy developers,
+# -*- coding: utf-8 -*-
+# Copyright 2016-2022 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helper functions and classes for managing pyxem.
+This module and documentation is only relevant for pyxem developers,
 not for users.
 .. warning:
     This module and its submodules are for internal use only.  Do not
@@ -20,7 +38,7 @@ class deprecated:
     warning.
     Adapted from
     `scikit-image
-    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L297>`_
+    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py>`_
     and `matplotlib
     <https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_api/deprecation.py#L122>`_.
     """

--- a/pyxem/utils/_deprecated.py
+++ b/pyxem/utils/_deprecated.py
@@ -1,0 +1,134 @@
+"""Helper functions and classes for managing kikuchipy.
+This module and documentation is only relevant for kikuchipy developers,
+not for users.
+.. warning:
+    This module and its submodules are for internal use only.  Do not
+    use them in your own code. We may change the API at any time with no
+    warning.
+"""
+
+import functools
+import inspect
+from typing import Callable, Optional, Union
+import warnings
+
+import numpy as np
+
+
+class deprecated:
+    """Decorator to mark deprecated functions with an informative
+    warning.
+    Adapted from
+    `scikit-image
+    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L297>`_
+    and `matplotlib
+    <https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_api/deprecation.py#L122>`_.
+    """
+
+    def __init__(
+        self,
+        since: Union[str, int, float],
+        alternative: Optional[str] = None,
+        alternative_is_function: bool = True,
+        removal: Union[str, int, float, None] = None,
+    ):
+        """Visible deprecation warning.
+        Parameters
+        ----------
+        since
+            The release at which this API became deprecated.
+        alternative
+            An alternative API that the user may use in place of the
+            deprecated API.
+        alternative_is_function
+            Whether the alternative is a function. Default is ``True``.
+        removal
+            The expected removal version.
+        """
+        self.since = since
+        self.alternative = alternative
+        self.alternative_is_function = alternative_is_function
+        self.removal = removal
+
+    def __call__(self, func: Callable):
+        # Wrap function to raise warning when called, and add warning to
+        # docstring
+        if self.alternative is not None:
+            if self.alternative_is_function:
+                alt_msg = f" Use `{self.alternative}()` instead."
+            else:
+                alt_msg = f" Use `{self.alternative}` instead."
+        else:
+            alt_msg = ""
+        if self.removal is not None:
+            rm_msg = f" and will be removed in version {self.removal}"
+        else:
+            rm_msg = ""
+        msg = f"Function `{func.__name__}()` is deprecated{rm_msg}.{alt_msg}"
+
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            warnings.simplefilter(
+                action="always", category=np.VisibleDeprecationWarning, append=True
+            )
+            func_code = func.__code__
+            warnings.warn_explicit(
+                message=msg,
+                category=np.VisibleDeprecationWarning,
+                filename=func_code.co_filename,
+                lineno=func_code.co_firstlineno + 1,
+            )
+            return func(*args, **kwargs)
+
+        # Modify docstring to display deprecation warning
+        old_doc = inspect.cleandoc(func.__doc__ or "").strip("\n")
+        notes_header = "\nNotes\n-----"
+        new_doc = (
+            f"[*Deprecated*] {old_doc}\n"
+            f"{notes_header if notes_header not in old_doc else ''}\n"
+            f".. deprecated:: {self.since}\n"
+            f"   {msg.strip()}"  # Matplotlib uses three spaces
+        )
+        wrapped.__doc__ = new_doc
+
+        return wrapped
+
+
+class deprecated_argument:
+    """Decorator to remove an argument from a function or method's
+    signature.
+    Adapted from `scikit-image
+    <https://github.com/scikit-image/scikit-image/blob/main/skimage/_shared/utils.py#L115>`_.
+    """
+
+    def __init__(self, name, since, removal, alternative=None):
+        self.name = name
+        self.since = since
+        self.removal = removal
+        self.alternative = alternative
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            if self.name in kwargs.keys():
+                msg = (
+                    f"Argument `{self.name}` is deprecated and will be removed in "
+                    f"version {self.removal}. To avoid this warning, please do not use "
+                    f"`{self.name}`. "
+                )
+                if self.alternative is not None:
+                    msg += f"Use `{self.alternative}` instead. "
+                msg += f"See the documentation of `{func.__name__}()` for more details."
+                warnings.simplefilter(
+                    action="always", category=np.VisibleDeprecationWarning
+                )
+                func_code = func.__code__
+                warnings.warn_explicit(
+                    message=msg,
+                    category=np.VisibleDeprecationWarning,
+                    filename=func_code.co_filename,
+                    lineno=func_code.co_firstlineno + 1,
+                )
+            return func(*args, **kwargs)
+
+        return wrapped


### PR DESCRIPTION
---
Name: Adding in a Deprecation wrapper
About: This copies some of how kikuchipy does their deprecation (Which copies matplotlib and nump)

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Added in deprecate decorator
- [x] Added in tests for deprecation
- [x] Added deprecation for known functions in Diffraction2D
- [x] Added deprecation for known Generators


**What does this PR do? Please describe and/or link to an open issue.**
I think this is a good start for 0.15.  We can start to deprecate functions as they are changed before 1.0 and then remove them after that. 

**Describe alternatives you've considered**
I think that we could also increase the amount of info/warnings that are output.  That could be a separate PR

**Are there any known issues? Do you need help?**
@hakonanes Let me know if you have any other ideas etc. 
