### PR TITLE
Change axes_manager.set_signal_dimension to transpose

### DIFF
--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -163,7 +163,7 @@ class DiffractionVectors(BaseSignal):
         )
 
         vectors = cls(gvectors)
-        vectors.axes_manager.set_signal_dimension(0)
+        vectors = vectors.transpose(signal_axes=0)
 
         return vectors
 
@@ -262,7 +262,7 @@ class DiffractionVectors(BaseSignal):
                 )
             else:
                 peaks = DiffractionVectors(cores)
-                peaks.axes_manager.set_signal_dimension(1)
+                peaks = peaks.transpose(signal_axes=1)
                 # Since this original number of vectors can be huge, we
                 # find a reduced number of vectors that should be plotted, by
                 # running a new clustering on all the vectors not considered
@@ -355,7 +355,7 @@ class DiffractionVectors(BaseSignal):
         # Otherwise easier to calculate.
         else:
             magnitudes = BaseSignal(calculate_norms(self))
-            magnitudes.axes_manager.set_signal_dimension(0)
+            magnitudes = magnitudes.transpose(signal_axes=0)
 
         return magnitudes
 
@@ -524,7 +524,7 @@ class DiffractionVectors(BaseSignal):
         # Manipulate into DiffractionVectors class
         if unique_peaks.size > 0:
             unique_peaks = DiffractionVectors(unique_peaks)
-            unique_peaks.axes_manager.set_signal_dimension(1)
+            unique_peaks = unique_peaks.transpose(signal_axes=1)
         if return_clusters and method == "DBSCAN":
             return unique_peaks, clusters
         else:
@@ -563,7 +563,7 @@ class DiffractionVectors(BaseSignal):
             )
             # Type assignment to DiffractionVectors for return
             filtered_vectors = DiffractionVectors(filtered_vectors)
-            filtered_vectors.axes_manager.set_signal_dimension(0)
+            filtered_vectors = filtered_vectors.transpose(signal_axes=0)
         # Otherwise easier to calculate.
         else:
             magnitudes = self.get_magnitudes()
@@ -618,7 +618,7 @@ class DiffractionVectors(BaseSignal):
             )
             # Type assignment to DiffractionVectors for return
             filtered_vectors = DiffractionVectors(filtered_vectors)
-            filtered_vectors.axes_manager.set_signal_dimension(0)
+            filtered_vectors = filtered_vectors.transpose(signal_axes=0)
         # Otherwise easier to calculate.
         else:
             x_inbounds = (
@@ -628,7 +628,7 @@ class DiffractionVectors(BaseSignal):
             filtered_vectors = self.data[np.logical_and(x_inbounds, y_inbounds)]
             # Type assignment to DiffractionVectors for return
             filtered_vectors = DiffractionVectors(filtered_vectors)
-            filtered_vectors.axes_manager.set_signal_dimension(1)
+            filtered_vectors = filtered_vectors.transpose(signal_axes=1)
 
         transfer_navigation_axes(filtered_vectors, self)
 
@@ -714,4 +714,4 @@ class DiffractionVectors2D(DiffractionVectors):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         if self.axes_manager.signal_dimension != 2:
-            self.axes_manager.set_signal_dimension(2)
+            self.transpose(signal_axes=2)

--- a/pyxem/signals/tensor_field.py
+++ b/pyxem/signals/tensor_field.py
@@ -102,7 +102,7 @@ class DisplacementGradientMap(Signal2D):
         e21 = U.isig[1, 0].T
         e22 = -U.isig[1, 1].T + 1
         theta = R.map(_get_rotation_angle, inplace=False)
-        theta = theat.transpose(signal_axes=2)
+        theta = theta.transpose(signal_axes=2)
 
         strain_results = stack([e11, e22, e12, theta])
 

--- a/pyxem/signals/tensor_field.py
+++ b/pyxem/signals/tensor_field.py
@@ -102,7 +102,7 @@ class DisplacementGradientMap(Signal2D):
         e21 = U.isig[1, 0].T
         e22 = -U.isig[1, 1].T + 1
         theta = R.map(_get_rotation_angle, inplace=False)
-        theta.axes_manager.set_signal_dimension(2)
+        theta = theat.transpose(signal_axes=2)
 
         strain_results = stack([e11, e22, e12, theta])
 

--- a/pyxem/signals/virtual_dark_field_image.py
+++ b/pyxem/signals/virtual_dark_field_image.py
@@ -150,7 +150,7 @@ class VirtualDarkFieldImage(Signal2D):
         n = vdfsegs.segments.axes_manager.navigation_axes[0]
         n.name = "n"
         n.units = "number"
-        vdfsegs.vectors_of_segments.axes_manager.set_signal_dimension(1)
+        vdfsegs.vectors_of_segments = vdfsegs.vectors_of_segments.transpose(signal_axes=1)
         vdfsegs.vectors_of_segments = transfer_signal_axes(
             vdfsegs.vectors_of_segments, self.vectors
         )

--- a/pyxem/tests/generators/test_subpixelrefinement_generator.py
+++ b/pyxem/tests/generators/test_subpixelrefinement_generator.py
@@ -81,8 +81,8 @@ class Test_init_xfails:
         """Tests that navigation dimensions must be appropriate too."""
         dp = ElectronDiffraction2D(np.zeros((2, 2, 8, 8)))
         vectors = DiffractionVectors(np.zeros((1, 2)))
-        dp.axes_manager.set_signal_dimension(2)
-        vectors.axes_manager.set_signal_dimension(0)
+        dp = dp.transpose(signal_axes=2)
+        vectors = vectors.transpose(signal_axes=0)
 
         # Note - uses regex via re.search()
         with pytest.raises(
@@ -119,7 +119,7 @@ class set_up_for_subpixelpeakfinders:
         v1 = np.array([[90 - 64, 30 - 64]])
         v2 = np.array([[90 - 64, 30 - 64], [100 - 64, 60 - 64]])
         vectors = DiffractionVectors(np.array([[v1, v1], [v2, v2]]))
-        vectors.axes_manager.set_signal_dimension(0)
+        vectors = vectors.transpose(signal_axes=0)
         return vectors
 
 

--- a/pyxem/tests/generators/test_virtual_image_generator.py
+++ b/pyxem/tests/generators/test_virtual_image_generator.py
@@ -32,7 +32,7 @@ from pyxem.signals import (
 @pytest.fixture(params=[np.array([[1, 1], [2, 2]])])
 def diffraction_vectors(request):
     dvec = DiffractionVectors(request.param)
-    dvec.axes_manager.set_signal_dimension(1)
+    dvec = dvec.transpose(signal_axes=1)
     return dvec
 
 
@@ -55,7 +55,7 @@ class TestVirtualDarkFieldGenerator:
                 dtype=object,
             )
         )
-        dvm.axes_manager.set_signal_dimension(0)
+        dvm = dvm.transpose(signal_axes=0)
 
         vdfgen = VirtualDarkFieldGenerator(diffraction_pattern, dvm)
         assert isinstance(vdfgen.signal, ElectronDiffraction2D)
@@ -126,7 +126,7 @@ def test_vdf_generator_from_map(diffraction_pattern):
             dtype=object,
         )
     )
-    dvm.axes_manager.set_signal_dimension(0)
+    dvm = dvm.transpose(signal_axes=0)
 
     vdfgen = VirtualImageGenerator(diffraction_pattern, dvm)
     assert isinstance(vdfgen, VirtualImageGenerator)

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -47,7 +47,7 @@ from pyxem.signals import DiffractionVectors
 )
 def diffraction_vectors_single(request):
     dvs = DiffractionVectors(request.param)
-    dvs.axes_manager.set_signal_dimension(1)
+    dvs = dvs.transpose(signal_axes=1)
     return dvs
 
 
@@ -110,7 +110,7 @@ def diffraction_vectors_single(request):
 )
 def diffraction_vectors_map(request):
     dvm = DiffractionVectors(request.param)
-    dvm.axes_manager.set_signal_dimension(0)
+    dvm = dvm.transpose(signal_axes=0)
     dvm.axes_manager[0].name = "x"
     dvm.axes_manager[1].name = "y"
     return dvm

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -161,7 +161,7 @@ class TestLearningSegment:
 )
 def unique_vectors(request):
     uv = DiffractionVectors(request.param)
-    uv.axes_manager.set_signal_dimension(0)
+    uv = uv.transpose(signal_axes=0)
     return uv
 
 

--- a/pyxem/tests/signals/test_virtual_dark_field_image.py
+++ b/pyxem/tests/signals/test_virtual_dark_field_image.py
@@ -44,7 +44,7 @@ from pyxem.signals import ElectronDiffraction2D, DiffractionVectors, VDFSegment
 )
 def unique_vectors(request):
     uv = DiffractionVectors(request.param)
-    uv.axes_manager.set_signal_dimension(0)
+    uv = uv.transpose(signal_axes=0)
     return uv
 
 

--- a/pyxem/tests/utils/test_io_utils.py
+++ b/pyxem/tests/utils/test_io_utils.py
@@ -48,9 +48,9 @@ def test_load_function_core(class_to_test, meta_string):
     to_save = class_to_test(np.zeros((2, 2, 2, 2)))
     to_save.metadata.Signal.tracker = meta_string
     if class_to_test is DiffractionVectors:
-        to_save.axes_manager.set_signal_dimension(0)
+        to_save = to_save.transpose(signal_axes=0)
     if class_to_test is DiffractionVectors2D:
-        to_save.axes_manager.set_signal_dimension(2)
+        to_save = to_save.transpose(signal_axes=2)
     to_save.save("tempfile_for_load_and_save.hspy", overwrite=True)
     from_save = hs.load("tempfile_for_load_and_save.hspy")
     assert isinstance(from_save, class_to_test)


### PR DESCRIPTION
This change was introduced to hyperspy in 2016 (commit [7aed14c](https://github.com/hyperspy/hyperspy/commit/7aed14c84a6c51c7b4e78e9a084a7b057bc2fc14))

Signed-off-by: akalankag <boney.ag@gmail.com>

---
name: Pull request 
about: change API invocation set_signal_dimension to transpose

---

**Checklist**
- [ ] Updated CHANGELOG.md

**What does this PR do? Please describe and/or link to an open issue.**
Change `x.axes_manager.set_signal_dimension(x)` to x = `x.transpose(singal_axes=x)`

**Describe alternatives you've considered**
No alternatives considered

**Are there any known issues? Do you need help?**
No

**Work in progress?**
No
