### PR TITLE
BugFix: Change related to numpy strict type checking ragged arrays

### DIFF
--- a/pyxem/tests/utils/test_vector_utils.py
+++ b/pyxem/tests/utils/test_vector_utils.py
@@ -35,7 +35,7 @@ def test_calculate_norms():
 
 
 def test_calculate_norms_ragged():
-    norms = calculate_norms_ragged(np.array([[3], [6, 8]]))
+    norms = calculate_norms_ragged(np.array([[3], [6, 8]], dtype=object))
     assert np.allclose(norms, [3, 10])
 
 

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -137,7 +137,7 @@ def index_magnitudes(z, simulation, tolerance):
         diffs = diff[np.where(diff < tolerance)]
 
         indices = np.array((hkls, diffs))
-        indexation[i] = np.array((mags.data[i], indices))
+        indexation[i] = np.array((mags.data[i], indices), dtype=object)
 
     return indexation
 


### PR DESCRIPTION
Fixes changes Related to #880.  Dtype needs to be explicitly set for ragged arrays. 
