### PR TITLE
BugFix: Affine Correction With multiple Affine Corrections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 Fixed
 -----
 - Fixed a factor of 1/2 missing in ScatteringFitComponentXTables
+- Fixed error related to `DiffractionSignal2D.apply_affine_transformation` when multiple affine transformations are given. (#870)
 - Bugfix related to Numpy 1.24.0. Strict array creation with dtype=object is needed
   for ragged arrays. (#880 & #881)
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -122,9 +122,21 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 convert_affine_to_transform, shape=shape, inplace=False
             )
 
+        if not keep_dtype:
+            out_dtype = float
+        else:
+            out_dtype = self.data.dtype
+
+        if "output_shape" in kwargs:
+            output_shape = kwargs["output_shape"]
+        else:
+            output_shape= shape
+
         return self.map(
             apply_transformation,
             transformation=transformation,
+            output_dtype=out_dtype,
+            output_signal_size=output_shape,
             order=order,
             keep_dtype=keep_dtype,
             inplace=inplace,

--- a/pyxem/tests/signals/test_electron_diffraction2d.py
+++ b/pyxem/tests/signals/test_electron_diffraction2d.py
@@ -78,7 +78,15 @@ class TestSimpleMaps:
         )
         assert isinstance(diffraction_pattern, ElectronDiffraction2D)
 
-    @pytest.mark.skip(reason="Dynamic version is broken downstream in scikit image, issue pyxem/#870")
+    def test_apply_affine_transformation_upsample(self, diffraction_pattern):
+        old_data = diffraction_pattern.data
+        diffraction_pattern.apply_affine_transformation(
+            D=np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]), output_shape=(8, 8)
+        )
+        assert isinstance(diffraction_pattern, ElectronDiffraction2D)
+        assert diffraction_pattern.axes_manager.signal_shape == (8, 8)
+        np.testing.assert_almost_equal(old_data, diffraction_pattern.data)
+
     def test_apply_affine_transforms_paths(self, diffraction_pattern):
         D = np.array([[1.0, 0.9, 0.0], [1.1, 1.0, 0.0], [0.0, 0.0, 1.0]])
         s = Signal2D(np.asarray([[D, D], [D, D]]))


### PR DESCRIPTION
@pc494  This fixes #870. It is kind of a workaround due to the `map` function not properly handling passing functions as iterating arguments.  I can fix this upstream but it is better to just strictly set the shape and dtype for the output.