### PR TITLE
Center direct beam refactor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,14 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 Unreleased
-===========================
+==========
 
 Added
 -----
 - Added damp_extrapolate_to_zero to ReducedIntensity1D
 - Added in deprecation wrapper class to wrap deprecated functions in pyxem.
+- Center-of-mass algorithm added to get_direct_beam_position (#845)
+
 
 Changed
 -------
@@ -73,13 +75,6 @@ Deprecated
 Changed
 ^^^^^^^
 - For developers: HyperSpy's `.map` function will now be used to process big datasets, instead of pyXem's `process_dask_array`
-
-2022-29-04 - version 0.14.0
-===========================
-
-The code contained in this version is identical to 0.14.1, the release was 
-recreated to fix an error with the Zenodo files.
-
 
 2021-04-14 - version 0.13.2
 ===========================

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -624,10 +624,17 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         method : str,
             Must be one of "cross_correlate", "blur", "interpolate" or "center_of_mass".
 
-           "cross_correlate": Center finding using cross-correlation of circles of `radius_start` to `radius_finish`.
-           "blur": Center finding by blurring each frame with a Gaussian kernel with standard deviation `sigma` and finding the maximum.
-           "interpolate": Finding the center by summing along X/Y and finding the peak for each axis independently. Data is blurred first using a Gaussian kernel with standard deviation "sigma".
-           "center_of_mass": The center is found using a calculation of the center of mass. Optionally a `mask` can be applied to focus on just the center of some dataset.
+           "cross_correlate": Center finding using cross-correlation of circles of 
+                `radius_start` to `radius_finish`.
+           "blur": Center finding by blurring each frame with a Gaussian kernel with 
+                standard deviation `sigma` and finding the maximum.
+           "interpolate": Finding the center by summing along X/Y and finding the peak 
+                for each axis independently. Data is blurred first using a Gaussian kernel 
+                with standard deviation "sigma".
+           "center_of_mass": The center is found using a calculation of the center of mass. 
+                Optionally a `mask` can be applied to focus on just the center of some 
+                dataset. A threshold value can also be given to suppress contrast from 
+                weaker diffraction features.
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
@@ -797,6 +804,16 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 # fails if non-square dp
                 max_index = int(origin_coordinates[0] + half_square_width)
                 temp_signal = temp_signal.isig[min_index:max_index, min_index:max_index]
+                if method == "center_of_mass" and "mask" in kwargs:
+                    # correct mask coordinates
+                    center_of_mass_mask = kwargs["mask"]
+                    center_of_mass_mask = (
+                        center_of_mass_mask[0] - min_index, 
+                        center_of_mass_mask[1] - min_index, 
+                        center_of_mass_mask[2],
+                    )
+                    kwargs["mask"] = center_of_mass_mask
+            
             shifts = temp_signal.get_direct_beam_position(
                 method=method, lazy_output=lazy_output, **kwargs,
             )

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -623,6 +623,11 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         ----------
         method : str,
             Must be one of "cross_correlate", "blur", "interpolate" or "center_of_mass".
+
+           "cross_correlate": Center finding using cross-correlation of circles of `radius_start` to `radius_finish`.
+           "blur": Center finding by blurring each frame with a Gaussian kernel with standard deviation `sigma` and finding the maximum.
+           "interpolate": Finding the center by summing along X/Y and finding the peak for each axis independently. Data is blurred first using a Gaussian kernel with standard deviation "sigma".
+           "center_of_mass": The center is found using a calculation of the center of mass. Optionally a `mask` can be applied to focus on just the center of some dataset.
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
@@ -691,6 +696,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             shifts = -centers + origin_coordinates
         elif method == "center_of_mass":
             centers = self.center_of_mass(lazy_result=lazy_output,
+                                          show_progressbar=False,
                                           **kwargs,
                                           )
             shifts = -centers.T + origin_coordinates

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -718,7 +718,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         Parameters
         ----------
-        method : str {'cross_correlate', 'blur', 'interpolate'}
+        method : str {'cross_correlate', 'blur', 'interpolate', 'center_of_mass'}
             Method used to estimate the direct beam position. The direct
             beam position can also be passed directly with the shifts parameter.
         half_square_width : int

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -622,7 +622,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         Parameters
         ----------
         method : str,
-            Must be one of "cross_correlate", "blur" or "interpolate"
+            Must be one of "cross_correlate", "blur", "interpolate" or "center_of_mass".
         lazy_result : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
@@ -653,6 +653,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             "cross_correlate": find_beam_offset_cross_correlation,
             "blur": find_beam_center_blur,
             "interpolate": find_beam_center_interpolate,
+            "center_of_mass": None,
         }
 
         method_function = select_method_from_method_dict(
@@ -688,6 +689,11 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 **kwargs,
             )
             shifts = -centers + origin_coordinates
+        elif method == "center_of_mass":
+            centers = self.center_of_mass(lazy_result=lazy_output,
+                                          **kwargs,
+                                          )
+            shifts = -centers.T + origin_coordinates
 
         shifts.set_signal_type("beam_shift")
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -75,7 +75,7 @@ import pyxem.utils.pixelated_stem_tools as pst
 import pyxem.utils.dask_tools as dt
 import pyxem.utils.marker_tools as mt
 import pyxem.utils.ransac_ellipse_tools as ret
-from pyxem.utils._deprecated import deprecated
+from pyxem.utils._deprecated import deprecated, deprecated_argument
 
 
 class Diffraction2D(Signal2D, CommonDiffraction):
@@ -635,7 +635,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 Optionally a `mask` can be applied to focus on just the center of some 
                 dataset. A threshold value can also be given to suppress contrast from 
                 weaker diffraction features.
-        lazy_result : optional
+        lazy_output : optional
             If True, s_shifts will be a lazy signal. If False, a non-lazy signal.
             By default, if the signal is (non-)lazy, the result will also be (non-)lazy.
         **kwargs:
@@ -891,11 +891,13 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         )
         return s_out
 
+    @deprecated_argument(since="0.15.0", name="lazy_result", alternative="lazy_output", removal="1.00.0")
     def center_of_mass(
         self,
         threshold=None,
         mask=None,
-        lazy_result=False,
+        lazy_result=None,
+        lazy_output=False,
         show_progressbar=True,
         chunk_calculations=None,
     ):

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -938,6 +938,10 @@ class TestCenterDirectBeam:
         s = self.s
         s.center_direct_beam(method="cross_correlate", radius_start=0, radius_finish=2)
 
+    def test_method_center_of_mass(self):
+        s = self.s
+        s.center_direct_beam(method="center_of_mass")
+
     def test_parameter_both_method_and_shifts(self):
         s = self.s
         with pytest.raises(ValueError):

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -719,6 +719,16 @@ class TestGetDirectBeamPosition:
             method="cross_correlate", radius_start=0, radius_finish=1
         )
 
+    def test_center_of_mass(self):
+        dx, dy = self.dx, self.dy
+        s, x_pos_list, y_pos_list = self.s, self.x_pos_list, self.y_pos_list
+        s_shift = s.get_direct_beam_position(
+            method="center_of_mass"
+        )
+        assert s.axes_manager.navigation_shape == s_shift.axes_manager.navigation_shape
+        assert (-(x_pos_list - dx / 2) == s_shift.isig[0].data[0]).all()
+        assert (-(y_pos_list - dy / 2) == s_shift.isig[1].data[:, 0]).all()
+
     def test_lazy_result_none_non_lazy_signal(self):
         s = self.s
         s_shift = s.get_direct_beam_position(method="blur", sigma=1)


### PR DESCRIPTION
---
name: Center direct beam refactor
about: Adds some simplification the Center Direct Beam Functions

---

**Checklist**
- [ ] Updated CHANGELOG.md
- [x] Moved code for slicing data before finding the direct beam
- [x] Added tests for slicing data before finding the direct beam 
- [x] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
This PR simplifies some of the find direct beam code and allows for slightly more flexiblity in selecting only the direct beam.

It also refactors some of the tests to improve coverage. 