### PR TITLE
Bugfix for Strain Mapping Code

### DIFF
--- a/pyxem/generators/displacement_gradient_tensor_generator.py
+++ b/pyxem/generators/displacement_gradient_tensor_generator.py
@@ -104,6 +104,10 @@ def get_single_DisplacementGradientTensor(Vs, Vu=None, weights=None):
     get_DisplacementGradientMap()
 
     """
+    is_row_nan = np.logical_not(np.any(np.isnan(Vs), axis=1))
+    Vs = Vs[is_row_nan]
+    Vu = Vu[is_row_nan]
+
     if Vu is not None:
         if Vu.dtype == object:
             Vu = Vu[()]
@@ -111,12 +115,15 @@ def get_single_DisplacementGradientTensor(Vs, Vu=None, weights=None):
         # see https://stackoverflow.com/questions/27128688
         weights = np.asarray(weights)
         # Need vectors normalized to the unstrained region otherwise the weighting breaks down
-        Vs = (
-            np.divide(Vs, np.linalg.norm(Vu, axis=0)) * np.sqrt(weights)
-        ).T  # transpose for conventions
-        Vu = (np.divide(Vu, np.linalg.norm(Vu, axis=0)) * np.sqrt(weights)).T
+        norm = np.linalg.norm(Vu, axis=1)
+        Vs = (np.divide(Vs.T,
+                        np.linalg.norm(Vu, axis=1)) *
+              np.sqrt(weights)).T
+        Vu = (np.divide(Vu.T,
+                        np.linalg.norm(Vu, axis=1)) *
+              np.sqrt(weights)).T
     else:
-        Vs, Vu = Vs.T, Vu.T
+        Vs, Vu = Vs, Vu
 
     L = np.linalg.lstsq(Vu, Vs, rcond=-1)[
         0

--- a/pyxem/generators/displacement_gradient_tensor_generator.py
+++ b/pyxem/generators/displacement_gradient_tensor_generator.py
@@ -44,6 +44,11 @@ def get_DisplacementGradientMap(strained_vectors, unstrained_vectors, weights=No
         basis vectors, V and U, defined as row vectors.
     weights : list
         of weights to be passed to the least squares optimiser, not used for n=2
+    return_residuals: Bool
+        If the residuals for the least squares optimiser should be returned.
+    kwargs: dict
+        Any additional keyword arguments passed to the `hyperspy.signals.BaseSignal.map`
+        function.
 
     Returns
     -------
@@ -67,7 +72,7 @@ def get_DisplacementGradientMap(strained_vectors, unstrained_vectors, weights=No
         weights=weights,
         inplace=False,
         output_signal_size=(3, 3),
-        output_dtype=np.float64,
+        output_dtype=np.float64,**kwargs
     )
 
     if return_residuals:
@@ -77,7 +82,7 @@ def get_DisplacementGradientMap(strained_vectors, unstrained_vectors, weights=No
             weights=weights,
             inplace=False,
             output_dtype=np.float64,
-            return_residuals=True
+            return_residuals=True, **kwargs
         )
         return DisplacementGradientMap(D), R
     else:
@@ -102,10 +107,14 @@ def get_single_DisplacementGradientTensor(Vs, Vu=None, weights=None, return_resi
         basis vectors, V and U, defined as row vectors.
     weights : list
         of weights to be passed to the least squares optimiser
+    return_residuals: Bool
+        If the residuals for the least squares optimiser should be returned.
     Returns
     -------
     D : numpy.array
         A 3 x 3 displacement gradient tensor (measured in reciprocal space).
+    residuals : numpy.array
+        The residuals for the least squares fitting.
 
     Notes
     -----

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -560,7 +560,7 @@ class DiffractionVectors(BaseSignal):
         kwargs["ragged"] = ragged
         if not ragged:
             kwargs["output_signal_size"] = np.shape(basis)
-            kwargs["output_dtype"]= float
+            kwargs["output_dtype"] = float
 
         filtered_vectors = self.map(filter_vectors_near_basis,  basis=basis,
                                     distance=distance, **kwargs)

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -39,6 +39,7 @@ from pyxem.utils.vector_utils import (
     get_npeaks,
     filter_vectors_ragged,
     filter_vectors_edge_ragged,
+    filter_vectors_near_basis
 )
 from pyxem.utils.expt_utils import peaks_as_gvectors
 
@@ -163,7 +164,6 @@ class DiffractionVectors(BaseSignal):
         )
 
         vectors = cls(gvectors)
-        vectors.axes_manager.set_signal_dimension(0)
 
         return vectors
 
@@ -529,6 +529,42 @@ class DiffractionVectors(BaseSignal):
             return unique_peaks, clusters
         else:
             return unique_peaks
+
+    def filter_basis(self, basis, distance=0.5, **kwargs):
+        """
+        Filter vectors to only the set of vectors which is close
+        to a basis set of vectors. If there is no vector within the `distance`
+        parameter of the vector np.`nan` will be returned.
+
+        Parameters
+        ----------
+        basis: array-like or BaseSignal
+            The set of vectors to be compared.
+        distance: float
+            The distance between vectors and basis which detemine if the vector
+            is associated with the basis vector. If no vector is inside the
+            distance np.nan will be returned.
+        kwargs: dict
+            Any other parameters passed to the `hyperspy.BaseSignal.Map` function.
+        Returns
+        -------
+        vectors: DiffractionVectors or DiffractionVectors2D
+            The filtered list of diffraction vectors.  If basis is
+            an instance of hyperspy.Signals.BaseSignal and instance of the
+            DiffractionVectors class will be returned otherwise an instance
+            of the DiffractionVectors2D class will be returned.
+        """
+        ragged = (isinstance(basis, BaseSignal) and
+                  (basis.axes_manager.navigation_shape ==
+                   self.axes_manager.navigation_shape))
+        kwargs["ragged"] = ragged
+        if not ragged:
+            kwargs["output_signal_size"] = np.shape(basis)
+            kwargs["output_dtype"]= float
+
+        filtered_vectors = self.map(filter_vectors_near_basis,  basis=basis,
+                                    distance=distance, **kwargs)
+        return filtered_vectors
 
     def filter_magnitude(self, min_magnitude, max_magnitude, *args, **kwargs):
         """Filter the diffraction vectors to accept only those with a magnitude

--- a/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
@@ -17,6 +17,7 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyxem.generators import get_DisplacementGradientMap
+from pyxem.signals.tensor_field import DisplacementGradientMap, StrainMap
 import hyperspy.api as hs
 import pytest
 import numpy as np
@@ -38,9 +39,10 @@ def vector_operation(z, M):
         Output vectors
     """
     v_transformed = []
-    for i in np.arange(0, z.shape[1]):
-        v_transformed.append(np.matmul(M, z[:, i]))
-    return np.asarray(v_transformed).T
+    print(z.shape[0])
+    for i in np.arange(0, z.shape[0]):
+        v_transformed.append(np.matmul(M, z[i, :]))
+    return np.asarray(v_transformed)
 
 
 def rotation(z):
@@ -67,71 +69,91 @@ def generate_test_vectors(v):
     return np.asarray([[v, rotation(v)], [uniform_expansion(v), stretch_in_x(v)]])
 
 
-def generate_strain_map(vectors):
+def generate_displacment_map(vectors):
     deformed = hs.signals.Signal2D(generate_test_vectors(vectors))
-    return get_DisplacementGradientMap(deformed, vectors).get_strain_maps()
+    return get_DisplacementGradientMap(deformed, vectors)
 
 
-@pytest.fixture()
-def xy_vectors():
-    xy = np.asarray([[1, 0], [0, 1]])
-    return generate_strain_map(xy)
+def generate_strain_map(vectors):
+    return generate_displacment_map(vectors).get_strain_maps()
 
 
-@pytest.fixture()
-def left_handed():
-    not_xy = np.asarray(([1, 1], [1, -1.2]))
-    return generate_strain_map(not_xy)
+class TestDisplacementGradientMap:
 
+    four_vectors = np.asarray([[1, 0],
+                               [0, 1],
+                               [1, -1],
+                               [1, 1]])
+    left_handed = np.asarray(([1, 1], [1, -1.2]))
+    xy_vectors = np.asarray([[1, 0], [0, 1]])
 
-@pytest.fixture()
-def multi_vector():
-    four_vectors = np.asarray([[1, 0, 1, 1], [0, 1, -1, 1]])
-    return generate_strain_map(four_vectors)
+    def setup(self):
+        # reinitalizing to use inside functions...
+        self.left_handed = np.asarray(([1, 1], [1, -1.2]))
+        self.xy_vectors = np.asarray([[1, 0], [0, 1]])
+        self.four_vectors = np.asarray([[1, 0],
+                               [0, 1],
+                               [1, -1],
+                               [1, 1]])
+
+    @pytest.mark.parametrize("four_vectors", (four_vectors,))
+    def test_generate_test_vectors(self, four_vectors):
+        test_vectors = generate_test_vectors(four_vectors)
+        assert np.shape(test_vectors) == (2, 2, 4, 2)
+        assert np.shape(test_vectors[0, 0]) == four_vectors.shape
+        assert np.shape(test_vectors[0, 1]) == four_vectors.shape
+
+    @pytest.mark.parametrize("vectors", (four_vectors, xy_vectors, left_handed))
+    def test_generate_displacement_map(self, vectors):
+        dis_map = generate_displacment_map(vectors)
+        assert isinstance(dis_map, DisplacementGradientMap)
+
+    @pytest.mark.parametrize("vectors", (four_vectors, xy_vectors, left_handed))
+    def test_generate_strain_map(self, vectors):
+        dis_map = generate_strain_map(vectors)
+        assert isinstance(dis_map, StrainMap)
+
+    def test_results_returned_correctly_in_same_basis(self):
+        """ Basic test of the summary statement for this section """
+        xy = generate_strain_map(self.xy_vectors)
+        lh = generate_strain_map(self.left_handed)
+        fv = generate_strain_map(self.four_vectors)
+        np.testing.assert_almost_equal(xy.data, lh.data, decimal=2)
+        np.testing.assert_almost_equal(xy.data, fv.data, decimal=2)
+
+    def test_trivial_weight_function_case(self):
+        """ If weights are [1,1,1,1] the result should be the same as weights=None"""
+        weights = [1, 1, 1, 1]
+        xy = generate_strain_map(self.xy_vectors)
+        deformed = hs.signals.Signal2D(generate_test_vectors(self.four_vectors))
+        weight_strain_map = get_DisplacementGradientMap(
+            deformed, self.four_vectors, weights=weights
+        ).get_strain_maps()
+        np.testing.assert_almost_equal(xy.data, weight_strain_map.data, decimal=2)
+
+    def test_weight_function_behaviour(self):
+        """ Confirms that  a weight function [1,1,2,2] on [a,a,b,b] gives (2a+4b)/6 as the strain"""
+        multi_vector_array = self.four_vectors
+        strained_by_1pc_in_x = vector_operation(
+            multi_vector_array, np.asarray([[1.01, 0], [0, 1]])
+        )  # first  2
+        strained_by_2pc_in_x = vector_operation(
+            multi_vector_array, np.asarray([[1.02, 0], [0, 1]])
+        )  # second 2
+        weights = [1, 1, 2, 2]  # ((0.1*2 + 0.2*4)/6) = 0.166666
+        vectors = np.concatenate(
+            (strained_by_1pc_in_x[:, :2], strained_by_2pc_in_x[:, 2:]), axis=1
+        )
+        deformed = hs.signals.Signal2D(np.asarray([[vectors, vectors], [vectors, vectors]]))
+        strain_map = get_DisplacementGradientMap(
+            deformed, multi_vector_array, weights=weights
+        ).get_strain_maps()
+        np.testing.assert_almost_equal(
+            strain_map.inav[0].isig[0, 0].data[0], -1.0166666 + 1, decimal=2
+        )
 
 
 """ Each of these basis should return the same results, in an xy basis"""
-
-
-def test_results_returned_correctly_in_same_basis(
-    xy_vectors, left_handed, multi_vector
-):
-    """ Basic test of the summary statement for this section """
-    np.testing.assert_almost_equal(xy_vectors.data, left_handed.data, decimal=2)
-    np.testing.assert_almost_equal(xy_vectors.data, multi_vector.data, decimal=2)
-
-
-def test_trivial_weight_function_case(xy_vectors):
-    """ If weights are [1,1,1,1] the result should be the same as weights=None"""
-    weights = [1, 1, 1, 1]
-    four_vectors = np.asarray([[1, 0, 1, 1], [0, 1, -1, 1]])
-    deformed = hs.signals.Signal2D(generate_test_vectors(four_vectors))
-    weight_strain_map = get_DisplacementGradientMap(
-        deformed, four_vectors, weights=weights
-    ).get_strain_maps()
-    np.testing.assert_almost_equal(xy_vectors.data, weight_strain_map.data, decimal=2)
-
-
-def test_weight_function_behaviour():
-    """ Confirms that  a weight function [1,1,2,2] on [a,a,b,b] gives (2a+4b)/6 as the strain"""
-    multi_vector_array = np.asarray([[1, 0, 1, 1], [0, 1, -1, 1]])
-    strained_by_1pc_in_x = vector_operation(
-        multi_vector_array, np.asarray([[1.01, 0], [0, 1]])
-    )  # first  2
-    strained_by_2pc_in_x = vector_operation(
-        multi_vector_array, np.asarray([[1.02, 0], [0, 1]])
-    )  # second 2
-    weights = [1, 1, 2, 2]  # ((0.1*2 + 0.2*4)/6) = 0.166666
-    vectors = np.concatenate(
-        (strained_by_1pc_in_x[:, :2], strained_by_2pc_in_x[:, 2:]), axis=1
-    )
-    deformed = hs.signals.Signal2D(np.asarray([[vectors, vectors], [vectors, vectors]]))
-    strain_map = get_DisplacementGradientMap(
-        deformed, multi_vector_array, weights=weights
-    ).get_strain_maps()
-    np.testing.assert_almost_equal(
-        strain_map.inav[0].isig[0, 0].data[0], -1.0166666 + 1, decimal=2
-    )
 
 
 class TestLazyNotLazy:
@@ -143,7 +165,7 @@ class TestLazyNotLazy:
 
     def test_not_lazy(self):
         vs = self.vs
-        vs_ref = vs.inav[0, 0]
+        vs_ref = vs.data[0, 0]
         D = get_DisplacementGradientMap(vs, vs_ref)
         assert D.axes_manager.navigation_shape == (2, 4)
         assert D.axes_manager.signal_shape == (3, 3)
@@ -151,7 +173,7 @@ class TestLazyNotLazy:
 
     def test_lazy(self):
         vs = self.vs.as_lazy()
-        vs_ref = vs.inav[0, 0]
+        vs_ref = vs.data[0, 0]
         D = get_DisplacementGradientMap(vs, vs_ref)
         assert D.axes_manager.navigation_shape == (2, 4)
         assert D.axes_manager.signal_shape == (3, 3)

--- a/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
@@ -39,7 +39,6 @@ def vector_operation(z, M):
         Output vectors
     """
     v_transformed = []
-    print(z.shape[0])
     for i in np.arange(0, z.shape[0]):
         v_transformed.append(np.matmul(M, z[i, :]))
     return np.asarray(v_transformed)
@@ -69,9 +68,10 @@ def generate_test_vectors(v):
     return np.asarray([[v, rotation(v)], [uniform_expansion(v), stretch_in_x(v)]])
 
 
-def generate_displacment_map(vectors):
+def generate_displacment_map(vectors, return_residuals=False):
     deformed = hs.signals.Signal2D(generate_test_vectors(vectors))
-    return get_DisplacementGradientMap(deformed, vectors)
+    return get_DisplacementGradientMap(deformed, vectors,
+                                       return_residuals=return_residuals)
 
 
 def generate_strain_map(vectors):
@@ -103,9 +103,13 @@ class TestDisplacementGradientMap:
         assert np.shape(test_vectors[0, 0]) == four_vectors.shape
         assert np.shape(test_vectors[0, 1]) == four_vectors.shape
 
+    @pytest.mark.parametrize("residuals", (True,False))
     @pytest.mark.parametrize("vectors", (four_vectors, xy_vectors, left_handed))
-    def test_generate_displacement_map(self, vectors):
-        dis_map = generate_displacment_map(vectors)
+    def test_generate_displacement_map(self, vectors, residuals):
+        if residuals:
+            dis_map, r = generate_displacment_map(vectors, return_residuals=residuals)
+        else:
+            dis_map = generate_displacment_map(vectors, return_residuals=residuals)
         assert isinstance(dis_map, DisplacementGradientMap)
 
     @pytest.mark.parametrize("vectors", (four_vectors, xy_vectors, left_handed))

--- a/pyxem/tests/utils/test_expt_utils.py
+++ b/pyxem/tests/utils/test_expt_utils.py
@@ -105,19 +105,18 @@ def test_polar2cart(r, theta, x, y):
 
 
 @pytest.mark.parametrize(
-    "z, center, calibration, g",
+    "z, center, calibration",
     [
         (
             np.array([[100, 100], [200, 200], [150, -150]]),
             np.array((127.5, 127.5)),
-            0.0039,
-            np.array([-0.10725, -0.10725]),
-        ),
+            0.0039,),
     ],
 )
-def test_peaks_as_gvectors(z, center, calibration, g):
+def test_peaks_as_gvectors(z, center, calibration):
     gc = peaks_as_gvectors(z=z, center=center, calibration=calibration)
-    np.testing.assert_almost_equal(gc, g)
+    ans = (z - 127.5) *calibration
+    np.testing.assert_almost_equal(gc, ans)
 
 
 def test_remove_dead_pixels(dp_single):

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -673,7 +673,7 @@ def peaks_as_gvectors(z, center, calibration):
 
     """
     g = (z - center) * calibration
-    return np.array([g[0].T[1], g[0].T[0]]).T
+    return g
 
 
 def investigate_dog_background_removal_interactive(

--- a/pyxem/utils/vector_utils.py
+++ b/pyxem/utils/vector_utils.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 import math
-
+from scipy.spatial.distance import cdist
 from transforms3d.axangles import axangle2mat
 
 
@@ -314,3 +314,35 @@ def get_angle_cartesian(a, b):
     if denom == 0:
         return 0.0
     return math.acos(max(-1.0, min(1.0, np.dot(a, b) / denom)))
+
+
+def filter_vectors_near_basis(vectors, basis, distance=None):
+    """
+    Filter an array of vectors to only the list of closest vectors
+    to some set of basis vectors.  Only vectors within some `distance`
+    are considered.  If no vector is within the `distance` np.nan is
+    returned for that vector.
+
+    Parameters
+    ----------
+    vectors: array-like
+        A two dimensional array of vectors where each row identifies a new vector
+
+    basis: array-like
+        A two dimensional array of vectors where each row identifies a vector.
+
+    Returns
+    -------
+    closest_vectors: array-like
+        An array of vectors which are the closest to the basis considered.
+    """
+    distance_mat = cdist(vectors, basis)
+    closest_index = np.argmin(distance_mat, axis=0)
+    min_distance = distance_mat[closest_index, np.arange(len(basis), dtype=int)]
+    closest_vectors = vectors[closest_index]
+    if distance is not None:
+        if closest_vectors.dtype == int:
+            closest_vectors = closest_vectors.astype(float)
+
+        closest_vectors[min_distance > distance, :] = np.nan
+    return closest_vectors


### PR DESCRIPTION
---
name: Bugfix for Strain Mapping Code
about: This code fixes the broken strain mapping code and simplifies the workflow

---

For a more complete example of how this works look at:
https://github.com/pyxem/pyxem-demos/pull/80

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] (if finished) Requested a review (from pc494 if you are unsure who is most suitable)

**What does this PR do? Please describe and/or link to an open issue.**
Simplifies the work flow:

1. Filter data/ subtract background etc.
2. Find peaks in the data
3. Refine positions (need to add subpixel refinement code)
4. Determine unstrained basis
5. Get displacementGradientTensor
6. Get Strain Map

If you have time to get around to this @pc494 this largely fixes #892 