### PR TITLE
fixed orientation bug in index_dataset_with_template_rotation function

### DIFF
--- a/pyxem/tests/utils/test_indexation_utils.py
+++ b/pyxem/tests/utils/test_indexation_utils.py
@@ -97,6 +97,7 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     # TODO: Remove version check after diffsims 0.5.0 is released
     from packaging.version import Version
     import diffsims
+    from scipy.ndimage import rotate
 
     diffsims_version = Version(diffsims.__version__)
     if diffsims_version > Version("0.4.2"):
@@ -111,6 +112,7 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
         ].get_diffraction_pattern(**sim_kwargs)
         test_set[idx] = test_pattern
 
+    test_set[0, 0] = rotate(test_set[0, 0], -30, reshape=False)
     # Perform template matching
     n_best = 3
     results, phase_dict = index_dataset_with_template_rotation(
@@ -123,6 +125,7 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     # Extract various results once
     phase_id = results["phase_index"].reshape((-1, n_best))
     ori = np.deg2rad(results["orientation"].reshape((-1, n_best, 3)))
+    assert abs(results["orientation"][0, 0, 0, 0] - 30) < 1  # rotation is within 1 deg
 
     # Property names in `results`
     prop_names = ["correlation", "mirrored_template", "template_index"]

--- a/pyxem/tests/utils/test_indexation_utils.py
+++ b/pyxem/tests/utils/test_indexation_utils.py
@@ -125,7 +125,8 @@ def test_results_dict_to_crystal_map(test_library_phases_multi, test_lib_gen):
     # Extract various results once
     phase_id = results["phase_index"].reshape((-1, n_best))
     ori = np.deg2rad(results["orientation"].reshape((-1, n_best, 3)))
-    assert abs(results["orientation"][0, 0, 0, 0] - 30) < 1  # rotation is within 1 deg
+    assert (abs(results["orientation"][0, 0, 0, 0] - 30) < 1 or
+            abs(results["orientation"][0, 0, 0, 0] - 165) < 1)
 
     # Property names in `results`
     prop_names = ["correlation", "mirrored_template", "template_index"]

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1630,7 +1630,7 @@ def index_dataset_with_template_rotation(
         )  # multiply by the sign
         orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta* phasemask
         # add to orients, there should be no overlap on pixels or N
-    orients = orients + orimap
+orients = orients + orimap
     result["orientation"] = orients
     result["correlation"] = res_index[:, :, :, 1]
     result["mirrored_template"] = res_index[:, :, :, 3] == -1

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1628,7 +1628,7 @@ def index_dataset_with_template_rotation(
         orimap[:, :, :, 2] = (
             orimap[:, :, :, 2] * res_index[:, :, :, 3]
         )  # multiply by the sign
-        orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta
+        orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta* phasemask
         # add to orients, there should be no overlap on pixels or N
     orients = orients + orimap
     result["orientation"] = orients

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1630,7 +1630,7 @@ def index_dataset_with_template_rotation(
         )  # multiply by the sign
         orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta* phasemask
         # add to orients, there should be no overlap on pixels or N
-    orients = orients + orimap
+        orients = orients + orimap
     result["orientation"] = orients
     result["correlation"] = res_index[:, :, :, 1]
     result["mirrored_template"] = res_index[:, :, :, 3] == -1

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1630,7 +1630,7 @@ def index_dataset_with_template_rotation(
         )  # multiply by the sign
         orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta
         # add to orients, there should be no overlap on pixels or N
-        orients = orients + orimap
+    orients = orients + orimap
     result["orientation"] = orients
     result["correlation"] = res_index[:, :, :, 1]
     result["mirrored_template"] = res_index[:, :, :, 3] == -1

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -1630,7 +1630,7 @@ def index_dataset_with_template_rotation(
         )  # multiply by the sign
         orimap[:, :, :, 0] = res_index[:, :, :, 2] * delta_theta* phasemask
         # add to orients, there should be no overlap on pixels or N
-orients = orients + orimap
+    orients = orients + orimap
     result["orientation"] = orients
     result["correlation"] = res_index[:, :, :, 1]
     result["mirrored_template"] = res_index[:, :, :, 3] == -1


### PR DESCRIPTION
---
name: Fixed minor orientation bug
about: A pull request that fixes a bug with the index_dataset_with_template_rotation function for template matching.

---

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
The index_dataset_with_template_rotation function returns the wrong in plane rotation when more than one phase is included in the template library (An issue exists for this: #853). The bug originates from an operation being performed in a loop when it should be performed outside it. The result is that the collected in plane angle is multiplied by the number of phases present in the template library. The original code produce the results below for three different spots in a small SPED dataset:

Returned in-plane rotation: 543
<img src = "https://user-images.githubusercontent.com/104507376/220907563-c0bc5e4e-ed7a-4216-9866-f972918ce494.png" width ="50%" height="50%" >

Returned in-plane rotation: 990
<img src = "https://user-images.githubusercontent.com/104507376/220907564-0b3e1ff3-33d1-43c6-b200-c226ed7dea2b.png" width ="50%" height="50%" > 

Returned in-plane rotation: 321 
<img src = "https://user-images.githubusercontent.com/104507376/220907570-3a70ead2-119b-4985-b834-6b4fd265da4b.png" width ="50%" height="50%" >

Implementing the changes to index_dataset_with_template_rotation proposed here the same locations produce the following results where no in plane rotation is above 360 degrees and it can be seen that the in-plane orientation is one third of the previous ones due to there being three phases in the template bank for this case.

Returned in-plane rotation: 181
<img src = "https://user-images.githubusercontent.com/104507376/220908777-95dcc960-787e-4798-bd30-611036b56df6.png" width ="50%" height="50%" >

Returned in-plane rotation: 330
<img src = "https://user-images.githubusercontent.com/104507376/220908779-690a1f3f-c0d3-41f1-8f7b-b716e6b61b17.png" width ="50%" height="50%" >

Returned-plane rotation: 107
<img src = "https://user-images.githubusercontent.com/104507376/220908774-ab01ecaa-dd6e-433c-84fb-98387fb9657f.png" width ="50%" height="50%" >