### PR TITLE
Update CI with test run of with minimal dep. versions ++

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: 3.7
-            DEPENDENCIES: diffsims==0.5.0 hyperspy==1.7.0 lmfit==0.9.12 matplotlib==3.1.1 orix==0.9.0 scikit-image==0.19.0 scikit-learn==1.0.0
+            DEPENDENCIES: diffsims==0.5.0 hyperspy==1.7.0 lmfit==0.9.12 matplotlib==3.3 orix==0.9.0 scikit-image==0.19.0 scikit-learn==1.0.0
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: psf/black@stable
-        continue-on-error: true
 
   build-with-pip:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
         include:
           - os: ubuntu-latest
             python-version: 3.7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,37 +6,70 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  MPLBACKEND: agg
+
 jobs:
+  code:
+    name: code style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: psf/black@stable
+
   build-with-pip:
-    name: ${{ matrix.os }}/py${{ matrix.python-version }}/pip
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    env:
-      MPLBACKEND: agg
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10']
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+            DEPENDENCIES: diffsims==0.5.0 hyperspy==1.7.0 lmfit==0.9.12 matplotlib==3.1.1 orix==0.9.0 scikit-image==0.19.0 scikit-learn==1.0.0
+            LABEL: -oldest
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Display versions
-        run: python -V; pip -V
+
       - name: Install dependencies and package
         shell: bash
-        run: pip install -U -e .'[tests]'
+        run: |
+          pip install -U -e .'[tests]'
+
+      - name: Install oldest supported versions
+        if: contains(matrix.LABEL, 'oldest')
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
+
+      - name: Display Python, pip and package versions
+        run: |
+          python -V
+          pip -V
+          pip list
+
       - name: Run docstring tests
         continue-on-error: true
-        run: pytest --doctest-modules --ignore=pyxem/tests pyxem
+        run: |
+          pytest --doctest-modules --doctest-continue-on-failure --ignore-glob=pyxem/tests pyxem
+
       - name: Run tests
-        run: pytest --cov=pyxem --runslow --pyargs pyxem
+        run: |
+          pytest -n 2 --cov=pyxem --runslow --pyargs pyxem
+
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: coverage report --show-missing
+        run: |
+          coverage report --show-missing
+
       - name: Upload coverage to Coveralls
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: psf/black@stable
+        continue-on-error: true
 
   build-with-pip:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.LABEL }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Changed
 - Fixed bugs resulting from API change in hyperspy/hyperspy#3045. Markers explicitly initialized
 - DiffractionVectors.get_diffraction_pixels_map returns a ragged signal
 - VirtualDarkFieldImage.get_vdf_segment changed to properly handle setting of axes
-- Minimal version of scikit-image increased to 0.19.0
+- Increased minimal version of scikit-image to >= 0.19.0
+- Increased minimal version of Matplotlib to >= 3.3
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 - Fixed bugs resulting from API change in hyperspy/hyperspy#3045. Markers explicitly initialized
 - DiffractionVectors.get_diffraction_pixels_map returns a ragged signal
 - VirtualDarkFieldImage.get_vdf_segment changed to properly handle setting of axes
+- Minimal version of scikit-image increased to 0.19.0
 
 Fixed
 -----

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,4 +1,3 @@
-# .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -14,13 +13,19 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
+# Set the version of Python and other tools
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
-python:
-   version: 3.7
-   install:
-      - method: pip
-        path: .
-        extra_requirements:
-           - doc
 submodules:
   include: all
+
+# Python environment for building the docs
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ extra_feature_requirements = {
     "tests": [
         "pytest     >= 5.0",
         "pytest-cov >= 2.8.1",
+        "pytest-xdist",
         "coveralls  >= 1.10",
         "coverage   >= 5.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "hyperspy       >= 1.7.0",  # significant improvements
         "ipywidgets",
         "lmfit          >= 0.9.12",
-        "matplotlib     >= 3.1.1",  # 3.1.0 failed
+        "matplotlib     >= 3.3",
         "numba",
         "numpy",
         "orix           >= 0.9",


### PR DESCRIPTION
This PR updates our CI with:
* Additional run on Python 3.7 with minimal versions of dependencies listed in setup.py
* Adds check of Black code style
* Make pytest distribute tests on two threads to reduce test time (with pytest-xdist)
* Drop testing with Python 3.8 (keep only 3.9 and 3.10)
* Increase minimal Matplotlib version to 3.3 since diffsims 0.9 has this minimal dependency

Other changes:
* Added a changelog entry describing that the minimal version of scikit-image increased to 0.19.0.
* Updated the Read The Docs (RTD) doc build to use Python 3.10 