### PR TITLE
Fix dtype mask in watershed with scikit-image 0.21.rc1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,16 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased
 ==========
 
+Fixed
+-----
+- Fixed type error in ``separate_watershed`` with scikit-image 0.21 (#921)
+
+
+
+2023-04-06 - version 0.15.0
+===========================
+
+
 Added
 -----
 - Added damp_extrapolate_to_zero to ReducedIntensity1D

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,8 @@ Fixed
 - Fixed type error in ``separate_watershed`` with scikit-image 0.21 (#921)
 
 
-
 2023-04-06 - version 0.15.0
 ===========================
-
 
 Added
 -----
@@ -54,7 +52,7 @@ Fixed
 - Bug fix for passing vector attributes when signal is copied or changed.
 
 
-2022-15-06 - version 0.14.2
+2022-06-15 - version 0.14.2
 ===========================
 
 Changed
@@ -67,7 +65,7 @@ Fixed
 - Fix bug in `get_DisplacementGradientMap` (#852)
 - Fix template matching bugs (originally fixed in #771 but omitted from 0.14 series by accident)
 
-2022-29-04 - version 0.14.1
+2022-04-29 - version 0.14.1
 ===========================
 
 Added
@@ -101,10 +99,10 @@ Changed
 ^^^^^^^
 - For developers: HyperSpy's `.map` function will now be used to process big datasets, instead of pyXem's `process_dask_array`
 
-2022-29-04 - version 0.14.0
+2022-04-29 - version 0.14.0
 ===========================
 
-The code contained in this version is identical to 0.14.1, the release was 
+The code contained in this version is identical to 0.14.1, the release was
 recreated to fix an error with the Zenodo files.
 
 

--- a/pyxem/utils/segment_utils.py
+++ b/pyxem/utils/segment_utils.py
@@ -125,8 +125,7 @@ def separate_watershed(
     # Create a mask from the input VDF image.
     if threshold:
         th = threshold_li(vdf_temp)
-        mask = np.zeros_like(vdf_temp)
-        mask[vdf_temp > th] = True
+        mask = vdf_temp > th
     else:
         mask = vdf_temp.astype("bool")
 


### PR DESCRIPTION
**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**

From https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/4684576528/jobs/8300866659:
```
_________ test_separate_watershed[3-1-inf-inf-0-True-sep_shape_expt5] __________

vdf_image = array([[0., 0., 0., 0., 0., 0.],
       [1., 1., 0., 0., 3., 3.],
       [1., 2., 2., 0., 3., 3.],
       [0., 2., 2., 0., 0., 0.],
       [0., 2., 2., 0., 4., 4.],
       [0., 0., 0., 0., 0., 0.],
       [5., 5., 5., 5., 5., 5.]])
min_distance = 3, min_size = 1, max_size = inf, max_number_of_grains = inf
exclude_border = 0, threshold = True, sep_shape_expt = (1, 6, 7)

    @pytest.mark.parametrize(
        "min_distance, min_size, max_size, "
        "max_number_of_grains, exclude_border, threshold, "
        "sep_shape_expt",
        [
            (1, 1, np.inf, np.inf, 0, True, (4, 6, 7)),
            (1, 1, np.inf, np.inf, 1, False, (1, 6, 7)),
            (1, 5, np.inf, np.inf, 0, True, (2, 6, 7)),
            (1, 1, np.inf, 4, 0, True, (3, 6, 7)),
            (1, 1, 3, np.inf, 0, True, (1, 6, 7)),
            (3, 1, np.inf, np.inf, 0, True, (1, 6, 7)),
        ],
    )
    def test_separate_watershed(
        vdf_image,
        min_distance,
        min_size,
        max_size,
        max_number_of_grains,
        exclude_border,
        threshold,
        sep_shape_expt,
    ):
>       sep = separate_watershed(
            vdf_image,
            min_distance=min_distance,
            min_size=min_size,
            max_size=max_size,
            max_number_of_grains=max_number_of_grains,
            exclude_border=exclude_border,
            threshold=threshold,
        )

/usr/share/miniconda3/lib/python3.10/site-packages/pyxem/tests/utils/test_segment_utils.py:93: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/share/miniconda3/lib/python3.10/site-packages/pyxem/utils/segment_utils.py:214: in separate_watershed
    labels = watershed(elevation, markers=markers, mask=mask)
/usr/share/miniconda3/lib/python3.10/site-packages/skimage/segmentation/_watershed.py:215: in watershed
    _watershed_cy.watershed_raveled(image.ravel(),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   TypeError: No matching signature found

_watershed_cy.pyx:70: TypeError
```