### PR TITLE
Reversing Vectors for VDF Creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 Fixed
 -----
 - Fixed type error in ``separate_watershed`` with scikit-image 0.21 (#921)
+- Fixed VDF creation from peaks using generators.VirtualDarkFieldGenerator.get_virtual_dark_field_images (#926)
 
 
 2023-04-06 - version 0.15.0

--- a/pyxem/generators/virtual_image_generator.py
+++ b/pyxem/generators/virtual_image_generator.py
@@ -303,7 +303,7 @@ class VirtualDarkFieldGenerator(VirtualImageGenerator):
             VirtualDarkFieldImage object containing virtual dark field images
             for all unique vectors.
         """
-        roi_args_list = [(v[0], v[1], radius, 0) for v in self.vectors.data]
+        roi_args_list = [(v[1], v[0], radius, 0) for v in self.vectors.data]
         new_axis_dict = {"name": "Vector index"}
         vdfim = self._get_virtual_images(
             roi_args_list,

--- a/pyxem/tests/generators/test_virtual_image_generator.py
+++ b/pyxem/tests/generators/test_virtual_image_generator.py
@@ -64,7 +64,7 @@ class TestVirtualDarkFieldGenerator:
 
         data[object2, 4, 7] = 10
 
-        self.vectors = DiffractionVectors2D([[7, 6], [3, 2], [4, 1], [7, 4]])
+        self.vectors = DiffractionVectors2D([[6, 7], [2, 3], [1, 4], [4, 7]])
 
         self.data = Diffraction2D(data)
 

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -197,7 +197,7 @@ class TestVDFSegment:
         data[object2, 1, 4] = 9
         data[object2, 4, 7] = 10
 
-        self.vectors = DiffractionVectors2D([[7, 6], [3, 2], [4, 1], [7, 4]])
+        self.vectors = DiffractionVectors2D([[6, 7], [2, 3], [1, 4], [4, 7]])
 
         self.data = Diffraction2D(data)
 
@@ -212,7 +212,6 @@ class TestVDFSegment:
         np.testing.assert_array_almost_equal(ncc.data[:2, :2], np.ones((2, 2)))
         np.testing.assert_array_almost_equal(ncc.data[2:, 2:], np.ones((2, 2)))
 
-        print(ncc.data)
 
     @pytest.mark.parametrize(
         "corr_threshold, vector_threshold," "segment_threshold",

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -212,7 +212,6 @@ class TestVDFSegment:
         np.testing.assert_array_almost_equal(ncc.data[:2, :2], np.ones((2, 2)))
         np.testing.assert_array_almost_equal(ncc.data[2:, 2:], np.ones((2, 2)))
 
-
     @pytest.mark.parametrize(
         "corr_threshold, vector_threshold," "segment_threshold",
         [(0.1, 1, 1), (0.9, 3, 2)],

--- a/pyxem/utils/segment_utils.py
+++ b/pyxem/utils/segment_utils.py
@@ -123,7 +123,9 @@ def separate_watershed(
     """
 
     # Create a mask from the input VDF image.
-    if threshold:
+    if not isinstance(threshold, bool):
+        mask = vdf_temp > np.max(vdf_temp) * threshold
+    elif threshold:
         th = threshold_li(vdf_temp)
         mask = vdf_temp > th
     else:


### PR DESCRIPTION
---
name: Reversing Vectors for VDF Creation

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**

It seems like there is a small bug related to the x,y indexes being reversed at some point resulting in the VDF's being created from the wrong location. 