### PR TITLE
Some updates after 0.15.1 release

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,60 @@
+How to make a new release of pyxem
+==================================
+
+pyxem versioning tries its best to adhere to `Semantic Versioning
+<https://semver.org/spec/v2.0.0.html>`__.
+See the `Python Enhancement Proposal (PEP) 440 <https://peps.python.org/pep-0440/>`__
+for supported version identifiers.
+
+Preparation
+-----------
+- Locally, create release branch from the ``main`` branch.
+
+- Run tutorial notebooks and examples in the documentation locally and confirm that they
+  produce the expected results.
+  From time to time, check the documentation links (``make linkchecker``) and fix any
+  broken ones.
+
+- Review the contributor list ``credits`` in ``pyxem/release_info.py`` to ensure all
+  contributors are included and sorted correctly.
+  Do the same for the Zenodo contributors file ``.zenodo.json``.
+
+- Increment the version number in ``pyxem/release_info.py``.
+  Review and clean up ``CHANGELOG.rst`` as per Keep a Changelog.
+
+- Make a PR of the release branch to ``main``.
+  Discuss the changelog with others, and make any changes *directly* to the release
+  branch.
+  Merge the branch into ``main``.
+
+Tag and release
+---------------
+- Make a tagged release on GitHub.
+  The tag target is the ``main`` branch.
+  If ``version`` is now "0.16.0", the release name is "pyxem 0.16.0".
+  The tag name is "v0.16.0".
+  The release body should contain a description of what has changed and a link to the
+  changelog.
+
+- Monitor the publish workflow to ensure the release is successfully uploaded to PyPI.
+  If the upload fails, the upload workflow can be re-run.
+
+Post-release action
+-------------------
+- Monitor the `documentation build <https://readthedocs.org/projects/pyxem/builds>`__
+  to ensure that the new stable documentation is successfully built from the release.
+
+- Ensure that `Zenodo <https://doi.org/10.5281/zenodo.2649351>`__ displays the new
+  release.
+
+- Make a new PR to ``main``, update ``version`` in ``pyxem/release_info.py`` and make
+  any updates to this guide if necessary.
+
+- Tidy up GitHub issues and close the corresponding milestone.
+
+- A PR to the conda-forge feedstock will be created by the conda-forge bot.
+  Follow the relevant instructions from the conda-forge documentation on updating
+  packages, as well as the instructions in the PR.
+  Merge after checks pass.
+  Monitor the Azure pipeline CI to ensure the release is successfully published to
+  conda-forge.

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -3,7 +3,7 @@ Related projects
 ================
 
 This is a non-exhaustive list of related, open-source projects.  Each project has
-strengths/weaknesses so it is important to see what project is best for your use case.
+strengths/weaknesses, so it is important to see what project is best for your use case.
 
 In the HyperSpy ecosystem
 -------------------------
@@ -31,3 +31,5 @@ Other projects
 - `LiberTEM <https://libertem.github.io/LiberTEM/>`_: Python library for high-throughput
   distributed processing of large-scale binary data sets using a simplified MapReduce
   programming model.
+- `STEMDIFF <https://mirekslouf.github.io/stemdiff/docs/>`_: Python library for
+  converting a 4D-STEM dataset to a 2D-powder diffractogram.

--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -1,5 +1,5 @@
 name = "pyxem"
-version = "0.15.1"
+version = "0.16.dev0"
 author = "Duncan Johnstone, Phillip Crout, Magnus Nord"
 copyright = "Copyright 2016-2023, The pyxem developers"
 # Contributors listed by original commiter, maintainers, then other

--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -39,7 +39,7 @@ credits = [
     "Rob Tovey",
     "Sivert Dagenborg",
 ]
-license = "GPLv3"
+license = "GPLv3+"
 maintainer = "Duncan Johnstone, Phillip Crout, Magnus Nord, Carter Francis"
 email = "pyxem.team@gmail.com"
 status = "development"

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "dask",
         "diffsims       >= 0.5",
         "hyperspy       >= 1.7.0",  # significant improvements
+        "h5py",
         "ipywidgets",
         "lmfit          >= 0.9.12",
         "matplotlib     >= 3.3",
@@ -93,6 +94,8 @@ setup(
         "scikit-image   >= 0.19.0",
         "scikit-learn   >= 1.0",
         "scipy",
+        "tqdm",
+        "traits",
         "transforms3d",
     ],
     python_requires=">=3.7",


### PR DESCRIPTION
* Bump version to 0.16.dev0
* Add "+" to license identifier (GPLv3+), signifying GPL v3 or later (corresponds to the current license text)
* Add missing dependencies (h5py, tqdm, traits)
* Add [STEMDIFF](https://mirekslouf.github.io/stemdiff/docs/) to related projects. I talked to @mirekslouf during this week's [EMAS workshop](https://www.microbeamanalysis.eu/events/event/60-emas-2023-17th-european-workshop-on-modern-developments-and-applications-in-microbeam-analysis) in Kraków, where he presented STEMDIFF. The package focuses on creating a powder diffractogram from 4D-STEM (nanobeam) patterns. I think it can be useful to users of pyxem, hence I added it to the list.
* Add a release guide

Is there interest in changing the doc theme from Furo to the PyData Sphinx Theme? If so, I can do this quickly, either in a separate PR (ignore this branch's name).