### PR TITLE
Add nd-filtering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Fixed
 - Set skimage != to version 0.21.0 because of regression
 - Do not reverse the y-axis of diffraction patterns when template matching (#925)
 
+Added
+-----
+- Add n-d and 2-d filters #935 for filtering datasets
 
 2023-05-08 - version 0.15.1
 ===========================

--- a/examples/processing/filtering_data.py
+++ b/examples/processing/filtering_data.py
@@ -15,17 +15,20 @@ import numpy as np
 
 s = pxm.data.mgo_nanocrystals(allow_download=True)  # MgO nanocrystals dataset
 
-s_filtered = s.filter(gaussian_filter,
-                      sigma=1.0,
-                      inplace=False)  # Gaussian filter with sigma=1.0
+s_filtered = s.filter(
+    gaussian_filter, sigma=1.0, inplace=False
+)  # Gaussian filter with sigma=1.0
 
-s_filtered2 = s.filter(gaussian_filter,
-                       sigma=(1.0, 1.0, 0, 0),
-                       inplace=False)  # Only filter in real space
+s_filtered2 = s.filter(
+    gaussian_filter, sigma=(1.0, 1.0, 0, 0), inplace=False
+)  # Only filter in real space
 
-hs.plot.plot_images([s.inav[10,10], s_filtered.inav[10,10], s_filtered2.inav[10,10]],
-                    label=['Original', 'GaussFilt(all)', 'GaussFilt(real space)'],
-                    tight_layout=True, vmax="99th")
+hs.plot.plot_images(
+    [s.inav[10, 10], s_filtered.inav[10, 10], s_filtered2.inav[10, 10]],
+    label=["Original", "GaussFilt(all)", "GaussFilt(real space)"],
+    tight_layout=True,
+    vmax="99th",
+)
 
 # %%
 """
@@ -39,12 +42,14 @@ def custom_filter(array):
     return filtered - np.mean(filtered)
 
 
-s_filtered3 = s.filter(custom_filter,
-                       inplace=False)  # Custom filter
+s_filtered3 = s.filter(custom_filter, inplace=False)  # Custom filter
 
-hs.plot.plot_images([s.inav[10,10], s_filtered3.inav[10,10]],
-                    label=['Original', 'GaussFilt(Custom)'],
-                    tight_layout=True, vmax="99th")
+hs.plot.plot_images(
+    [s.inav[10, 10], s_filtered3.inav[10, 10]],
+    label=["Original", "GaussFilt(Custom)"],
+    tight_layout=True,
+    vmax="99th",
+)
 # %%
 
 """
@@ -54,11 +59,14 @@ version which operates on dask arrays.
 """
 
 s = s.as_lazy()  # Convert to lazy dataset
-s_filtered4 = s.filter(dask_gaussian_filter,
-                       sigma=1.0,
-                       inplace=False)  # Gaussian filter with sigma=1.0
+s_filtered4 = s.filter(
+    dask_gaussian_filter, sigma=1.0, inplace=False
+)  # Gaussian filter with sigma=1.0
 
-hs.plot.plot_images([s_filtered.inav[10,10], s_filtered4.inav[10,10]],
-                    label=['GaussFilt', 'GaussFilt(Lazy)'],
-                    tight_layout=True, vmax="99th")
+hs.plot.plot_images(
+    [s_filtered.inav[10, 10], s_filtered4.inav[10, 10]],
+    label=["GaussFilt", "GaussFilt(Lazy)"],
+    tight_layout=True,
+    vmax="99th",
+)
 # %%

--- a/examples/processing/filtering_data.py
+++ b/examples/processing/filtering_data.py
@@ -1,0 +1,64 @@
+"""
+Filtering Data
+==============
+
+If you have a low number of counts in your data, you may want to filter the data
+to remove noise. This can be done using the `filter` function which applies some
+function to the entire dataset and returns a filtered dataset of the same shape.
+"""
+
+from scipy.ndimage import gaussian_filter
+from dask_image.ndfilters import gaussian_filter as dask_gaussian_filter
+import pyxem as pxm
+import hyperspy.api as hs
+import numpy as np
+
+s = pxm.data.mgo_nanocrystals(allow_download=True)  # MgO nanocrystals dataset
+
+s_filtered = s.filter(gaussian_filter,
+                      sigma=1.0,
+                      inplace=False)  # Gaussian filter with sigma=1.0
+
+s_filtered2 = s.filter(gaussian_filter,
+                       sigma=(1.0, 1.0, 0, 0),
+                       inplace=False)  # Only filter in real space
+
+hs.plot.plot_images([s.inav[10,10], s_filtered.inav[10,10], s_filtered2.inav[10,10]],
+                    label=['Original', 'GaussFilt(all)', 'GaussFilt(real space)'],
+                    tight_layout=True, vmax="99th")
+
+# %%
+"""
+The `filter` function can also be used with a custom function as long as the function
+takes a numpy array as input and returns a numpy array of the same shape.
+"""
+
+
+def custom_filter(array):
+    filtered = gaussian_filter(array, sigma=1.0)
+    return filtered - np.mean(filtered)
+
+
+s_filtered3 = s.filter(custom_filter,
+                       inplace=False)  # Custom filter
+
+hs.plot.plot_images([s.inav[10,10], s_filtered3.inav[10,10]],
+                    label=['Original', 'GaussFilt(Custom)'],
+                    tight_layout=True, vmax="99th")
+# %%
+
+"""
+For lazy datasets, functions which operate on dask arrays can be used. For example,
+the `gaussian_filter` function from `scipy.ndimage` is replaced with the `dask_image`
+version which operates on dask arrays.
+"""
+
+s = s.as_lazy()  # Convert to lazy dataset
+s_filtered4 = s.filter(dask_gaussian_filter,
+                       sigma=1.0,
+                       inplace=False)  # Gaussian filter with sigma=1.0
+
+hs.plot.plot_images([s_filtered.inav[10,10], s_filtered4.inav[10,10]],
+                    label=['GaussFilt', 'GaussFilt(Lazy)'],
+                    tight_layout=True, vmax="99th")
+# %%

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1122,10 +1122,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             normalize_template_match, template=ring, inplace=inplace, **kwargs
         )
 
-    def filter(self,
-               func,
-               inplace=False,
-               **kwargs):
+    def filter(self, func, inplace=False, **kwargs):
         """Filters the entire dataset given some function applied to the data.
 
         The function must take a numpy or dask array as input and return a
@@ -1155,8 +1152,9 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         new_data = func(self.data, **kwargs)
 
         if new_data.shape != self.data.shape:
-            raise ValueError("The function must return an array with "
-                             "the same shape as the input.")
+            raise ValueError(
+                "The function must return an array with " "the same shape as the input."
+            )
         if inplace:
             self.data = new_data
             return

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1123,6 +1123,55 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         return self.map(
             normalize_template_match, template=ring, inplace=inplace, **kwargs
         )
+    def filter_signal_axes(self,
+                           method="gaussian_filter",
+                           **kwargs):
+        if isinstance(method, str):
+            name = "scipy.ndimage"
+            _method = getattr(import_module(name), method)
+        return self.map(_method, **kwargs)
+
+    def get_num_chunked_axes(self):
+        axes = np.arange(self.data.ndim)
+        unspanned_dim = set(axes) - set(self.spanned_dimensions())
+        chunked_dim = len(unspanned_dim)
+        return chunked_dim
+
+    def filter(self,
+               method="gaussian_laplace",
+               inplace=False,
+               **kwargs
+               ):
+        """ Filters the entire dataset given some ndimage filter. If the dataset is lazy
+        an appropriate filter from `dask-image` will be applied if applicable.
+
+        Additional considerations for lazy signals are given to the chunk structure of
+        some signal in order to maintain efficient computation.
+
+        If you only want to filter some of the dimensions.
+
+        """
+        if isinstance(method, str):
+            if method == "difference_of_gaussians":
+                if self._lazy:
+                    _method = difference_of_gaussians_lazy
+                else:
+                    _method = difference_of_gaussians
+            elif self._lazy:
+                name = "dask_image.ndfilters"
+                _method = getattr(import_module(name), method)
+            else:
+                name = "scipy.ndimage"
+                _method = getattr(import_module(name), method)
+        else:
+            _method = method
+
+        new_data = _method(self.data, **kwargs)
+        if inplace:
+            self.data= new_data
+            return
+        else:
+            return self._deepcopy_with_new_data(data=new_data)
 
     def template_match(self, template, inplace=False, **kwargs):
         """Template match the signal dimensions with a binary image.

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -1385,22 +1385,19 @@ class TestFilter:
         if lazy:
             dask_image = pytest.importorskip("dask_image")
             from dask_image.ndfilters import gaussian_filter as gaussian_filter
+
             three_section = three_section.as_lazy()
         else:
             from scipy.ndimage import gaussian_filter
 
         sigma = (3, 3, 3, 3)
-        new = three_section.filter(func=gaussian_filter,
-                                   sigma=sigma,
-                                   inplace=False)
-        three_section.filter(func=gaussian_filter,
-                             sigma=sigma,
-                             inplace=True)
+        new = three_section.filter(func=gaussian_filter, sigma=sigma, inplace=False)
+        three_section.filter(func=gaussian_filter, sigma=sigma, inplace=True)
         np.testing.assert_array_almost_equal(new.data, three_section.data)
 
     def test_filter_fail(self, three_section):
         def small_func(x):
-            return x[1:, 1:,1:,1:]
+            return x[1:, 1:, 1:, 1:]
+
         with pytest.raises(ValueError):
-            new = three_section.filter(func=small_func,
-                                       inplace=False)
+            new = three_section.filter(func=small_func, inplace=False)

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -1382,7 +1382,7 @@ class TestFilter:
 
     @pytest.mark.parametrize("lazy", [True, False])
     def test_filter(self, three_section, lazy):
-        if lazy:
+        if lazy:  # pragma: no cover
             dask_image = pytest.importorskip("dask_image")
             from dask_image.ndfilters import gaussian_filter as gaussian_filter
 

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -23,6 +23,7 @@ import hyperspy.api as hs
 from matplotlib import pyplot as plt
 from numpy.random import default_rng
 from skimage.draw import circle_perimeter_aa
+import scipy
 
 from pyxem.signals import (
     Diffraction1D,
@@ -1367,3 +1368,39 @@ class TestPlotNavigator:
         s_nav = Diffraction2D(np.zeros((2, 19)))
         s._navigator_probe = s_nav
         s.plot()
+
+
+class TestFilter:
+    @pytest.fixture
+    def three_section(self):
+        x = np.random.random((100, 50, 20, 20))
+        x[0:20, :, 5:7, 5:7] = x[0:20, :, 5:7, 5:7] + 10
+        x[20:60, :, 1:3, 14:16] = x[20:60, :, 1:3, 14:16] + 10
+        x[60:100, :, 6:8, 10:12] = x[60:100, :, 6:8, 10:12] + 10
+        d = Diffraction2D(x)
+        return d
+
+    @pytest.mark.parametrize("lazy", [True, False])
+    def test_filter(self, three_section, lazy):
+        if lazy:
+            dask_image = pytest.importorskip("dask_image")
+            from dask_image.ndfilters import gaussian_filter as gaussian_filter
+            three_section = three_section.as_lazy()
+        else:
+            from scipy.ndimage import gaussian_filter
+
+        sigma = (3, 3, 3, 3)
+        new = three_section.filter(func=gaussian_filter,
+                                   sigma=sigma,
+                                   inplace=False)
+        three_section.filter(func=gaussian_filter,
+                             sigma=sigma,
+                             inplace=True)
+        np.testing.assert_array_almost_equal(new.data, three_section.data)
+
+    def test_filter_fail(self, three_section):
+        def small_func(x):
+            return x[1:, 1:,1:,1:]
+        with pytest.raises(ValueError):
+            new = three_section.filter(func=small_func,
+                                       inplace=False)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extra_feature_requirements = {
         "sphinx-codeautolink",
         "pydata-sphinx-theme",
         "hyperspy-gui-ipywidgets",
+        "dask-image",
     ],
     "tests": [
         "pytest     >= 5.0",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ extra_feature_requirements = {
     ],
     "dev": ["black", "pre-commit >=1.16"],
     "gpu": ["cupy >= 9.0.0"],
+    "dask": ["dask-image", "distributed"],
 }
 
 


### PR DESCRIPTION
---
name: N-D Filtering
about: This is a pretty simple addition but it allows you to use the spicy.ndimage.filters on the entire block of some 4-D dataset.

---

**Checklist**
- [x] Added nd-filters
- [x] Added filters only in reciprocal space
- [x] Test coverage 100%
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
Note that for using the dask-image implementations updating to the newest version of dask is highly recommended.