### PR TITLE
BugFix: Skimage not equal to 0.21.0 because of bug upstream

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 Fixed
 -----
 - Remove `ipywidgets` from requirements as it is not a dependency
+- Set skimage != to version 0.21.0 because of regression
 
 
 2023-05-08 - version 0.15.1

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "orix           >= 0.9",
         "psutil",
         "pyfai",  # sigma clip function broken
-        "scikit-image   >= 0.19.0",
+        "scikit-image   >= 0.19.0, !=0.21.0",  # regression in ellipse fitting"
         "scikit-learn   >= 1.0",
         "scipy",
         "tqdm",


### PR DESCRIPTION
---
name: Restrict skim age to not equal to 0.21.0

---

This fixes the small bug that was released with version 0.21.0 of skimage and is causing the CI to fail.  It only occurs on some Linux builds and is related to the distribution.  It seems like for now we can just restrict skimage to less than 0.21.0 and then we can sort out the issue a little later.