### PR TITLE
Fix accelerated indexing generator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Fixed
 - Remove `ipywidgets` from requirements as it is not a dependency
 - Set skimage != to version 0.21.0 because of regression
 - Do not reverse the y-axis of diffraction patterns when template matching (#925)
+- Fixed bug in :py:class:`pyxem.generators.indexation_generator.AcceleratedIndexationGenerator` when
+  passing orientations as tuples.
 
 
 2023-05-08 - version 0.15.1

--- a/pyxem/generators/indexation_generator.py
+++ b/pyxem/generators/indexation_generator.py
@@ -111,6 +111,9 @@ class AcceleratedIndexationGenerator:
         # test that the first euler angle is always 0
 
         for phase in diffraction_library:
+            diffraction_library[phase]["orientations"] = np.array(
+                diffraction_library[phase]["orientations"]
+            )
             if not np.allclose(
                 np.sum(diffraction_library[phase]["orientations"][:, 0]), 0
             ):


### PR DESCRIPTION
---
***Fix accelerated indexing generator:***

This should fix the error being thrown in the tutorial because a tuple and not a list is being passed.
---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
Related to https://github.com/pyxem/pyxem-demos/issues/82