### PR TITLE
Templatematching interactive result plot

### DIFF
--- a/pyxem/tests/utils/test_plotting_utils.py
+++ b/pyxem/tests/utils/test_plotting_utils.py
@@ -108,39 +108,38 @@ def mock_library(mock_phase_key_dict):
 
 
 @pytest.mark.parametrize(
-    "n_best_sim, n_best, direct_beam_position, marker_colors",
+    "n_best_sim, n_best, marker_colors",
     [
         # fmt: off
-        (1, 1, None, None),
-        (2, 2, None, None),
-        (2, 1, None, None),
-        (1, 1, (0, 0), None),
-        (1, 1, (1, 0), None),
-        (1, 1, None, None),
-        (2, 2, None, ["red"]), # Prints a warning, but is still passes as colors will just loop
-        (2, 1, None, ["red"]*4),
-        (2, 2, None, ["red"]*2),
+        (1, 1, None),
+        (2, 2, None),
+        (2, 1, None),
+        pytest.param(2, 3, None, marks=pytest.mark.xfail),
+        (2, 2, ["red"]), # Prints a warning, but is still passes as colors will just loop
+        (2, 1, ["red"]*4),
+        (2, 2, ["red"]*2),
         # fmt: on
     ],
 )
 @pytest.mark.slow
-def test_plot_templates_over_signal(
+def test_generate_template_markers(
     mock_electron_diffraction_data,
     mock_library,
     shape,
     mock_phase_key_dict,
     n_best_sim,
     n_best,
-    direct_beam_position,
     marker_colors,
 ):
     mock_result = create_mock_templatematching_results(shape, n_best_sim)
-    plu.plot_templates_over_signal(
+    markers = plu.generate_template_markers(
         mock_electron_diffraction_data,
         mock_library,
         mock_result,
         mock_phase_key_dict,
         n_best,
-        direct_beam_position,
         marker_colors,
     )
+    # markers is a generator
+    markers = list(markers)
+    assert len(markers) == n_best

--- a/pyxem/tests/utils/test_plotting_utils.py
+++ b/pyxem/tests/utils/test_plotting_utils.py
@@ -110,6 +110,7 @@ def mock_library(mock_phase_key_dict):
 @pytest.mark.parametrize(
     "n_best_sim, n_best, find_direct_beam, direct_beam_position, marker_colors",
     [
+        # fmt: off
         (1, 1, False, None, None),
         (2, 2, False, None, None),
         (2, 1, False, None, None),
@@ -119,6 +120,7 @@ def mock_library(mock_phase_key_dict):
         (2, 2, False, None, ["red"]), # Prints a warning, but is still passes as colors will just loop
         (2, 1, False, None, ["red"]*4),
         (2, 2, False, None, ["red"]*2),
+        # fmt: on
     ],
 )
 @pytest.mark.slow

--- a/pyxem/tests/utils/test_plotting_utils.py
+++ b/pyxem/tests/utils/test_plotting_utils.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import pytest
 import numpy as np
 from unittest.mock import Mock
+from pyxem.signals import ElectronDiffraction2D
 
 _, ax = plt.subplots()
 
@@ -45,3 +46,102 @@ def test_plot_sim_over_pattern_fail(mock_simulation):
         plu.plot_template_over_pattern(
             pattern, mock_simulation, coordinate_system="dracula"
         )
+
+
+@pytest.fixture
+def shape():
+    return (4, 4, 4, 4)
+
+
+@pytest.fixture
+def mock_electron_diffraction_data(shape):
+    data = np.arange(np.prod(shape)).reshape(*shape)
+    edd = ElectronDiffraction2D(data)
+    edd.set_diffraction_calibration(0.1)
+    return edd
+
+
+def create_mock_templatematching_results(shape, n_best):
+    shape = shape[2:] + (n_best,)
+    return {
+        "phase_index": np.zeros(shape, dtype=int),
+        "template_index": np.ones(shape, dtype=int),
+        "orientation": np.zeros((*shape, 3), dtype=float),
+        "correlation": np.ones(shape, dtype=float),
+        "mirrored_template": np.zeros(shape, dtype=bool),
+    }
+
+
+@pytest.fixture
+def mock_phase_key_dict():
+    return {0: "dummyphase"}
+
+
+@pytest.fixture()
+def mock_library(mock_phase_key_dict):
+    library = {}
+    mock_sim_1 = Mock()
+    mock_sim_1.calibrated_coordinates = np.array(
+        [
+            [0, 1, 0],
+            [1, 0, 0],
+            [1, 2, 0],
+            [-1, 2, 0],
+        ]
+    )
+    mock_sim_1.intensities = np.array([2, 3, 4, 2])
+    mock_sim_2 = Mock()
+    mock_sim_2.calibrated_coordinates = np.array([[-1, -2, 0], [1, 2, 0], [-2, 1, 0]])
+    mock_sim_2.intensities = np.array([1, 2, 10])
+    simlist = [mock_sim_1, mock_sim_2]
+    orientations = np.array(
+        [
+            [1, 2, 3],
+            [3, 4, 5],
+        ]
+    )
+    library[mock_phase_key_dict[0]] = {
+        "simulations": simlist,
+        "orientations": orientations,
+    }
+    return library
+
+
+@pytest.mark.parametrize(
+    "n_best_sim, n_best, find_direct_beam, direct_beam_position, marker_colors",
+    [
+        (1, 1, False, None, None),
+        (2, 2, False, None, None),
+        (2, 1, False, None, None),
+        (1, 1, False, (0, 0), None),
+        (1, 1, False, (1, 0), None),
+        (1, 1, True, None, None),
+        (2, 2, False, None, ["red"]), # Prints a warning, but is still passes as colors will just loop
+        (2, 1, False, None, ["red"]*4),
+        (2, 2, False, None, ["red"]*2),
+    ],
+)
+@pytest.mark.slow
+def test_plot_templates_over_signal(
+    mock_electron_diffraction_data,
+    mock_library,
+    shape,
+    mock_phase_key_dict,
+    n_best_sim,
+    n_best,
+    find_direct_beam,
+    direct_beam_position,
+    marker_colors,
+):
+    mock_result = create_mock_templatematching_results(shape, n_best_sim)
+    plu.plot_templates_over_signal(
+        mock_electron_diffraction_data,
+        mock_library,
+        mock_result,
+        mock_phase_key_dict,
+        n_best,
+        find_direct_beam,
+        direct_beam_position,
+        marker_colors,
+        verbose=False,
+    )

--- a/pyxem/tests/utils/test_plotting_utils.py
+++ b/pyxem/tests/utils/test_plotting_utils.py
@@ -143,5 +143,4 @@ def test_plot_templates_over_signal(
         n_best,
         direct_beam_position,
         marker_colors,
-        verbose=False,
     )

--- a/pyxem/tests/utils/test_plotting_utils.py
+++ b/pyxem/tests/utils/test_plotting_utils.py
@@ -93,7 +93,7 @@ def mock_library(mock_phase_key_dict):
     mock_sim_2 = Mock()
     mock_sim_2.calibrated_coordinates = np.array([[-1, -2, 0], [1, 2, 0], [-2, 1, 0]])
     mock_sim_2.intensities = np.array([1, 2, 10])
-    simlist = [mock_sim_1, mock_sim_2]
+    simlist = np.array([mock_sim_1, mock_sim_2])
     orientations = np.array(
         [
             [1, 2, 3],
@@ -108,18 +108,18 @@ def mock_library(mock_phase_key_dict):
 
 
 @pytest.mark.parametrize(
-    "n_best_sim, n_best, find_direct_beam, direct_beam_position, marker_colors",
+    "n_best_sim, n_best, direct_beam_position, marker_colors",
     [
         # fmt: off
-        (1, 1, False, None, None),
-        (2, 2, False, None, None),
-        (2, 1, False, None, None),
-        (1, 1, False, (0, 0), None),
-        (1, 1, False, (1, 0), None),
-        (1, 1, True, None, None),
-        (2, 2, False, None, ["red"]), # Prints a warning, but is still passes as colors will just loop
-        (2, 1, False, None, ["red"]*4),
-        (2, 2, False, None, ["red"]*2),
+        (1, 1, None, None),
+        (2, 2, None, None),
+        (2, 1, None, None),
+        (1, 1, (0, 0), None),
+        (1, 1, (1, 0), None),
+        (1, 1, None, None),
+        (2, 2, None, ["red"]), # Prints a warning, but is still passes as colors will just loop
+        (2, 1, None, ["red"]*4),
+        (2, 2, None, ["red"]*2),
         # fmt: on
     ],
 )
@@ -131,7 +131,6 @@ def test_plot_templates_over_signal(
     mock_phase_key_dict,
     n_best_sim,
     n_best,
-    find_direct_beam,
     direct_beam_position,
     marker_colors,
 ):
@@ -142,7 +141,6 @@ def test_plot_templates_over_signal(
         mock_result,
         mock_phase_key_dict,
         n_best,
-        find_direct_beam,
         direct_beam_position,
         marker_colors,
         verbose=False,

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -256,6 +256,10 @@ def plot_templates_over_signal(
                         mirrored=mirrored_sol,
                     )
 
+                    # See https://github.com/pyxem/pyxem/issues/925
+                    # Copied the solution from plot_template_over_pattern (#946)
+                    y = signal.axes_manager[1].size - y
+
                     x *= signal.axes_manager[2].scale
                     y *= signal.axes_manager[3].scale
 

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -175,15 +175,17 @@ def plot_templates_over_signal(
 
     if n_best is None:
         n_best = n_best_indexed
-    
+
     if n_best > n_best_indexed:
-        raise ValueError("`n_best` cannot be larger than the amount of indexed solutions")
+        raise ValueError(
+            "`n_best` cannot be larger than the amount of indexed solutions"
+        )
 
     if direct_beam_position is None:
         direct_beam_position = (
             signal.axes_manager[0].size // 2,
             signal.axes_manager[1].size // 2,
-            )
+        )
 
     if marker_colors is None:
         marker_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
@@ -216,24 +218,29 @@ def plot_templates_over_signal(
     result_signal = hs.signals.Signal1D(result_array)
     orientation_signal = hs.signals.Signal2D(result["orientation"])
     mirrored_template_signal = hs.signals.Signal1D(result["mirrored_template"])
-    
 
     def marker_func_generator(n: int):
-
         def marker_func(pattern, center, orientation, mirrored_template):
             angle = orientation[n, 0]
             pattern = pattern[n]
             mirrored_template = mirrored_template[n]
-            x, y, _ = get_template_cartesian_coordinates(pattern, center=center, in_plane_angle=angle, mirrored=mirrored_template)
-            y = signal.axes_manager.shape[1] - y # See https://github.com/pyxem/pyxem/issues/925
+            x, y, _ = get_template_cartesian_coordinates(
+                pattern, center=center, in_plane_angle=angle, mirrored=mirrored_template
+            )
+
+            # See https://github.com/pyxem/pyxem/issues/925
+            y = signal.axes_manager.shape[1] - y
+
             return np.array((x, y)).T
-        
-        # The inputs gets squeezed, this ensures any 1D inputs gets correcly accessed
+
+        # The inputs gets squeezed, this ensures they get correctly accessed
         if n_best_indexed == 1:
+
             def marker_func_1D(pattern, center, orientation, mirrored_template):
                 orientation = orientation.reshape(-1, 3)
                 mirrored_template = np.array([mirrored_template])
                 return marker_func(pattern, center, orientation, mirrored_template)
+
             return marker_func_1D
         else:
             return marker_func
@@ -241,15 +248,14 @@ def plot_templates_over_signal(
     signal.plot(**plot_kwargs)
     for i in range(n_best):
         markers = result_signal.map(
-            marker_func_generator(i), 
-            center=direct_beam_position, 
-            orientation=orientation_signal, 
-            mirrored_template=mirrored_template_signal, 
-            inplace=False, 
-            ragged=True, 
-            lazy_output=True
-            )
+            marker_func_generator(i),
+            center=direct_beam_position,
+            orientation=orientation_signal,
+            mirrored_template=mirrored_template_signal,
+            inplace=False,
+            ragged=True,
+            lazy_output=True,
+        )
         color = marker_colors[i % len(marker_colors)]
         m = hs.plot.markers.Points.from_signal(markers, color=color)
         signal.add_marker(m)
-    plt.gcf().legend()

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -1,5 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
+from tqdm import tqdm
+from hyperspy.utils.markers import point
 from pyxem.utils.polar_transform_utils import (
     get_template_cartesian_coordinates,
     get_template_polar_coordinates,
@@ -113,3 +115,138 @@ def plot_template_over_pattern(
         color=marker_color,
     )
     return (ax, im, sp)
+
+def plot_templates_over_signal(
+    signal, 
+    library, 
+    result: dict, 
+    phase_key_dict: dict, 
+    n_best: int = None, 
+    find_direct_beam: bool = False,
+    direct_beam_position: tuple[int, int] = None,
+    marker_colors: list[str] = None,
+    marker_type: str = "x",
+    size_factor: float = 1.0,
+    verbose: bool = True,
+    **plot_kwargs
+    ):
+
+    if n_best is None:
+        n_best = result["template_index"].shape[2]
+
+    if direct_beam_position is None and not find_direct_beam:
+        direct_beam_position = (0, 0)
+    
+    if marker_colors is None:
+        marker_colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+
+    if len(marker_colors) < n_best:
+        print("Warning: not enough colors in `marker_colors` for `n_best` different colored marks")
+
+    # Add markers as iterable, recommended in hyperspy docs.
+    # Using a genenerator will hopefully reduce memory.
+    # To avoid scope errors, pass all variables as inputs
+    def _get_markers_iter(
+        signal, 
+        library, 
+        result, 
+        phase_key_dict, 
+        n_best, 
+        find_direct_beam, 
+        direct_beam_position, 
+        marker_colors, 
+        marker_type, 
+        size_factor, 
+        verbose,
+        ):
+
+        # Hyperspy wants one marker for all pixels in the navigation space,
+        # so we generate all the data for a given solution and then yield them
+
+        # Allocate space for all navigator pixels to potentially have the maximum amount of simulated diffraction spots
+        max_marker_count = max(len(sim) for lib in library.values() for sim in lib["simulations"])
+
+        shape = (signal.axes_manager[1].size, signal.axes_manager[0].size, max_marker_count)
+
+        # Explicit zeroes instead of empty, since we won't fill all elements in the final axis
+        marker_data_x = np.zeros(shape)
+        marker_data_y = np.zeros(shape)
+        marker_data_i = np.zeros(shape)
+
+        for n in range(n_best):
+            color = marker_colors[n % len(marker_colors)]
+
+            # Generate data for a given solution index.
+            x_iter = range(signal.axes_manager[0].size)
+            if verbose:
+                x_iter = tqdm(x_iter)
+
+            for px in x_iter:
+                for py in range(signal.axes_manager[1].size):
+
+                    sim_sol_index = result["template_index"][py, px, n]
+                    mirrored_sol = result["mirrored_template"][py, px, n]
+                    in_plane_angle = result["orientation"][py, px, n, 0]
+
+                    phase_key = result["phase_index"][py, px, n]
+                    phase = phase_key_dict[phase_key]
+                    simulations = library[phase]["simulations"]
+                    pattern = simulations[sim_sol_index]
+
+                    if find_direct_beam:
+                        x, y = find_beam_center_blur(signal.inav[px, py], 1)
+                        
+                        # The result of `find_beam_center_blur` is in a corner. 
+                        # Move to center of image
+                        x -= signal.axes_manager[2].size // 2
+                        y -= signal.axes_manager[3].size // 2
+                        direct_beam_position = (x, y)
+
+                    x, y, intensities = get_template_cartesian_coordinates(
+                        pattern,
+                        center=direct_beam_position,
+                        in_plane_angle=in_plane_angle,
+                        mirrored=mirrored_sol,
+                    )
+
+                    x *= signal.axes_manager[2].scale
+                    y *= signal.axes_manager[3].scale
+
+                    marker_count = len(x)
+                    marker_data_x[py, px, :marker_count] = x
+                    marker_data_y[py, px, :marker_count] = y
+                    marker_data_i[py, px, :marker_count] = intensities
+            
+            marker_kwargs = {
+                "color": color, 
+                "marker": marker_type,
+                "label": f"Solution index: {n}",
+            }
+
+            # Plot for the given solution index
+            for i in range(max_marker_count):
+                yield point(
+                    marker_data_x[..., i], 
+                    marker_data_y[..., i], 
+                    size = 4 * np.sqrt(marker_data_i[..., i]) * size_factor, 
+                    **marker_kwargs
+                    )
+                # We only need one set of labels per solution
+                if i == 0:
+                    marker_kwargs.pop("label")
+
+    signal.plot(**plot_kwargs)
+    signal.add_marker(_get_markers_iter(
+        signal, 
+        library, 
+        result, 
+        phase_key_dict, 
+        n_best, 
+        find_direct_beam, 
+        direct_beam_position, 
+        marker_colors, 
+        marker_type, 
+        size_factor, 
+        verbose,
+        ))
+    plt.gcf().legend()

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -130,6 +130,44 @@ def plot_templates_over_signal(
     verbose: bool = True,
     **plot_kwargs
     ):
+    """
+    Display an interactive plot of the diffraction signal, 
+    with simulated diffraction patterns corresponding to template matching results displayed on top.
+
+    Parameters
+    ----------
+    signal : hyperspy.signals.Signal2D
+        The 4D-STEM dataset.
+    library : diffsims.libraries.diffraction_library.DiffractionLibrary
+        The library of simulated diffraction patterns.
+    result : dict
+        Template matching results dictionary containing keys: phase_index, template_index,
+        orientation, correlation, and mirrored_template. 
+        Returned from pyxem.utils.indexation_utils.index_dataset_with_template_rotation.
+    phase_key_dict: dictionary
+        A small dictionary to translate the integers in the phase_index array
+        to phase names in the original template library.
+        Returned from pyxem.utils.indexation_utils.index_dataset_with_template_rotation.
+    n_best : int, optional
+        Number of solutions to plot. If None, defaults to all solutions.
+    find_direct_beam: bool, optional
+        Roughly find the optimal direct beam position if it is not centered.
+    direct_beam_position: 2-tuple
+        The (x, y) position of the direct beam in pixel coordinates. Takes
+        precedence over `find_direct_beam`
+    marker_colors : list of str, optional
+        Colors of the spot markers. Must be at least n_best long.
+        Defaults to matplotlib's default color cycle
+    marker_type : str, optional
+        Type of marker used for the spots
+    size_factor : float, optional
+        Scaling factor for the spots. See notes on size.
+    **plot_kwargs : Keyword arguments passed to signal.plot
+
+    Notes
+    -----
+    The spot marker sizes are scaled by the square root of their intensity
+    """
 
     if n_best is None:
         n_best = result["template_index"].shape[2]

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -202,7 +202,7 @@ def plot_templates_over_signal(
         # so we generate all the data for a given solution and then yield them
 
         # Allocate space for all navigator pixels to potentially have the maximum amount of simulated diffraction spots
-        max_marker_count = max(len(sim) for lib in library.values() for sim in lib["simulations"])
+        max_marker_count = max(sim.intensities.size for lib in library.values() for sim in lib["simulations"])
 
         shape = (signal.axes_manager[1].size, signal.axes_manager[0].size, max_marker_count)
 

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -156,7 +156,7 @@ def plot_templates_over_signal(
         The (x, y) position of the direct beam in pixel coordinates. Takes
         precedence over `find_direct_beam`
     marker_colors : list of str, optional
-        Colors of the spot markers. Must be at least n_best long.
+        Colors of the spot markers. Should be at least n_best long, otherwise colors will loop.
         Defaults to matplotlib's default color cycle
     marker_type : str, optional
         Type of marker used for the spots
@@ -179,7 +179,7 @@ def plot_templates_over_signal(
         marker_colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
 
     if len(marker_colors) < n_best:
-        print("Warning: not enough colors in `marker_colors` for `n_best` different colored marks")
+        print("Warning: not enough colors in `marker_colors` for `n_best` different colored marks. Colors will loop")
 
     # Add markers as iterable, recommended in hyperspy docs.
     # Using a genenerator will hopefully reduce memory.

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -23,7 +23,7 @@ def plot_template_over_pattern(
     marker_color="red",
     marker_type="x",
     size_factor=1.0,
-    **kwargs
+    **kwargs,
 ):
     """A quick utility function to plot a simulated pattern over an experimental image
 
@@ -116,22 +116,23 @@ def plot_template_over_pattern(
     )
     return (ax, im, sp)
 
+
 def plot_templates_over_signal(
-    signal, 
-    library, 
-    result: dict, 
-    phase_key_dict: dict, 
-    n_best: int = None, 
+    signal,
+    library,
+    result: dict,
+    phase_key_dict: dict,
+    n_best: int = None,
     find_direct_beam: bool = False,
     direct_beam_position: tuple[int, int] = None,
     marker_colors: list[str] = None,
     marker_type: str = "x",
     size_factor: float = 1.0,
     verbose: bool = True,
-    **plot_kwargs
-    ):
+    **plot_kwargs,
+):
     """
-    Display an interactive plot of the diffraction signal, 
+    Display an interactive plot of the diffraction signal,
     with simulated diffraction patterns corresponding to template matching results displayed on top.
 
     Parameters
@@ -142,7 +143,7 @@ def plot_templates_over_signal(
         The library of simulated diffraction patterns.
     result : dict
         Template matching results dictionary containing keys: phase_index, template_index,
-        orientation, correlation, and mirrored_template. 
+        orientation, correlation, and mirrored_template.
         Returned from pyxem.utils.indexation_utils.index_dataset_with_template_rotation.
     phase_key_dict: dictionary
         A small dictionary to translate the integers in the phase_index array
@@ -174,37 +175,46 @@ def plot_templates_over_signal(
 
     if direct_beam_position is None and not find_direct_beam:
         direct_beam_position = (0, 0)
-    
+
     if marker_colors is None:
-        marker_colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+        marker_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 
     if len(marker_colors) < n_best:
-        print("Warning: not enough colors in `marker_colors` for `n_best` different colored marks. Colors will loop")
+        print(
+            "Warning: not enough colors in `marker_colors` for `n_best` different colored marks. Colors will loop"
+        )
 
     # Add markers as iterable, recommended in hyperspy docs.
     # Using a genenerator will hopefully reduce memory.
     # To avoid scope errors, pass all variables as inputs
     def _get_markers_iter(
-        signal, 
-        library, 
-        result, 
-        phase_key_dict, 
-        n_best, 
-        find_direct_beam, 
-        direct_beam_position, 
-        marker_colors, 
-        marker_type, 
-        size_factor, 
+        signal,
+        library,
+        result,
+        phase_key_dict,
+        n_best,
+        find_direct_beam,
+        direct_beam_position,
+        marker_colors,
+        marker_type,
+        size_factor,
         verbose,
-        ):
-
+    ):
         # Hyperspy wants one marker for all pixels in the navigation space,
         # so we generate all the data for a given solution and then yield them
 
         # Allocate space for all navigator pixels to potentially have the maximum amount of simulated diffraction spots
-        max_marker_count = max(sim.intensities.size for lib in library.values() for sim in lib["simulations"])
+        max_marker_count = max(
+            sim.intensities.size
+            for lib in library.values()
+            for sim in lib["simulations"]
+        )
 
-        shape = (signal.axes_manager[1].size, signal.axes_manager[0].size, max_marker_count)
+        shape = (
+            signal.axes_manager[1].size,
+            signal.axes_manager[0].size,
+            max_marker_count,
+        )
 
         # Explicit zeroes instead of empty, since we won't fill all elements in the final axis
         marker_data_x = np.zeros(shape)
@@ -221,7 +231,6 @@ def plot_templates_over_signal(
 
             for px in x_iter:
                 for py in range(signal.axes_manager[1].size):
-
                     sim_sol_index = result["template_index"][py, px, n]
                     mirrored_sol = result["mirrored_template"][py, px, n]
                     in_plane_angle = result["orientation"][py, px, n, 0]
@@ -233,8 +242,8 @@ def plot_templates_over_signal(
 
                     if find_direct_beam:
                         x, y = find_beam_center_blur(signal.inav[px, py], 1)
-                        
-                        # The result of `find_beam_center_blur` is in a corner. 
+
+                        # The result of `find_beam_center_blur` is in a corner.
                         # Move to center of image
                         x -= signal.axes_manager[2].size // 2
                         y -= signal.axes_manager[3].size // 2
@@ -254,9 +263,9 @@ def plot_templates_over_signal(
                     marker_data_x[py, px, :marker_count] = x
                     marker_data_y[py, px, :marker_count] = y
                     marker_data_i[py, px, :marker_count] = intensities
-            
+
             marker_kwargs = {
-                "color": color, 
+                "color": color,
                 "marker": marker_type,
                 "label": f"Solution index: {n}",
             }
@@ -264,27 +273,29 @@ def plot_templates_over_signal(
             # Plot for the given solution index
             for i in range(max_marker_count):
                 yield point(
-                    marker_data_x[..., i], 
-                    marker_data_y[..., i], 
-                    size = 4 * np.sqrt(marker_data_i[..., i]) * size_factor, 
-                    **marker_kwargs
-                    )
+                    marker_data_x[..., i],
+                    marker_data_y[..., i],
+                    size=4 * np.sqrt(marker_data_i[..., i]) * size_factor,
+                    **marker_kwargs,
+                )
                 # We only need one set of labels per solution
                 if i == 0:
                     marker_kwargs.pop("label")
 
     signal.plot(**plot_kwargs)
-    signal.add_marker(_get_markers_iter(
-        signal, 
-        library, 
-        result, 
-        phase_key_dict, 
-        n_best, 
-        find_direct_beam, 
-        direct_beam_position, 
-        marker_colors, 
-        marker_type, 
-        size_factor, 
-        verbose,
-        ))
+    signal.add_marker(
+        _get_markers_iter(
+            signal,
+            library,
+            result,
+            phase_key_dict,
+            n_best,
+            find_direct_beam,
+            direct_beam_position,
+            marker_colors,
+            marker_type,
+            size_factor,
+            verbose,
+        )
+    )
     plt.gcf().legend()

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -210,10 +210,10 @@ def plot_templates_over_signal(
 
         # 2D array of simulations, using the indices from template matching.
         # These might use the wrong phase
-        phase_library_simulations[result["template_index"]]
+        sim_array = phase_library_simulations[result["template_index"]]
 
         # Use the correct phase
-        result_array[mask] = phase_library_simulations[mask]
+        result_array[mask] = sim_array[mask]
 
     result_signal = hs.signals.Signal1D(result_array)
     orientation_signal = hs.signals.Signal2D(result["orientation"])

--- a/pyxem/utils/plotting_utils.py
+++ b/pyxem/utils/plotting_utils.py
@@ -193,7 +193,27 @@ def plot_templates_over_signal(
             "Warning: not enough colors in `marker_colors` for `n_best` different colored marks. Colors will loop"
         )
 
-    result_signal = hs.signals.Signal1D(library[phase_key_dict[0]]["simulations"][result["template_index"]])
+    # Fetch an array of the results, with the correct phases
+    result_array = np.empty(
+        (signal.axes_manager[0].size, signal.axes_manager[1].size, n_best_indexed),
+        dtype=object,
+    )
+
+    for phase_ind, phase in phase_key_dict.items():
+        # Mask of where the results used the current phase
+        mask = result["phase_index"] == phase_ind
+
+        # Flat array of the simulations of the current phase
+        phase_library_simulations = library[phase]["simulations"]
+
+        # 2D array of simulations, using the indices from template matching.
+        # These might use the wrong phase
+        phase_library_simulations[result["template_index"]]
+
+        # Use the correct phase
+        result_array[mask] = phase_library_simulations[mask]
+
+    result_signal = hs.signals.Signal1D(result_array)
     orientation_signal = hs.signals.Signal2D(result["orientation"])
     mirrored_template_signal = hs.signals.Signal1D(result["mirrored_template"])
     


### PR DESCRIPTION
---
name: Templatematching interactive result plot
about: Adds function to interactively plot a template matching result with the data.
Similar to the existing `plot_template_over_pattern`, but interactive.

---

**Checklist**
- [x] Support multiple solutions
- [ ] Support multiple phases
- [x] Write tests
- [ ] Write example
- [ ] Updated CHANGELOG.md
- [ ] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
Plot templatematching results on top of the data, with hyperspy's interactive capabilities:
![bilde](https://github.com/pyxem/pyxem/assets/57151700/ab2cb72a-cd04-452a-a915-350a9d7d3b35)

One can move the ROI point, similar to a normal `Signal2D.plot`:

![bilde](https://github.com/pyxem/pyxem/assets/57151700/37bbd55d-a026-48f9-9742-b3f0236bf7c6)

This allows the user to quickly verify templatematching results in multiple areas.

I am unsure if such a tool is appropriate for pyxem, that is up to the maintainers to decide of course.