### PR TITLE
Fix pypi workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,9 +10,8 @@ on:
     workflow: "*"
 
 jobs:
-  deploy:
+  Build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -23,10 +22,31 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build
         run: |
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist/*
+          name: artifacts
+  Publish:
+    needs: [build]
+    name: Publish to TestPyPI
+    # Only run when the label 'Test Publish' is added to a PR
+    runs-on: Ubuntu-latest
+    permissions:
+    # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: dist
+      - name: Display downloaded files
+        run: |
+          ls -shR
+        working-directory: dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-python-publish.yml
+++ b/.github/workflows/test-python-publish.yml
@@ -4,13 +4,11 @@
 name: Test Upload Python Package
 
 on:
-  pull_request:
-    types: [ labeled ]
+  workflow_dispatch:
+    workflow: "*"
 
 jobs:
   Build:
-    # Only run when the label 'Test Publish' is added to a PR
-    if: ${{ github.event.label.name == 'Test Publish' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +32,6 @@ jobs:
     needs: [build]
     name: Publish to TestPyPI
     # Only run when the label 'Test Publish' is added to a PR
-    if: ${{ github.event.label.name == 'Test Publish' }}
     runs-on: Ubuntu-latest
     permissions:
     # IMPORTANT: this permission is mandatory for trusted publishing


### PR DESCRIPTION
This __should__ fix the broken pypi integration.

Then we just have to run the python-publish action manually and that should push things to pypi.  We can first test things by trying to push to test-pypi as well...

@hakonanes and @ericpre any advice?