### PR TITLE
Deprecating the reduced_intenstiy1d utils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/psf/black
     # Version can be updated by running "pre-commit autoupdate"
-    rev: 23.12.1
+    rev: 24.1.0
     hooks:
-    - id: black
+      - id: black
 ci:
-    # Don't run automatically on PRs, instead add the comment
-    # "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing
-    autofix_prs: false
+  # Don't run automatically on PRs, instead add the comment
+  # "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing
+  autofix_prs: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+
+Unreleased
+==========
+Deprecated
+^^^^^^^^^^
+- The module & all functions within `utils.reduced_intensity1d` are deprecated in favour of using the methods of `ReducedIntensity1D` (#994).
+
 2024-01-05 - version 0.17.0
 ===========================
 Added

--- a/examples/processing/determining_ellipticity.py
+++ b/examples/processing/determining_ellipticity.py
@@ -13,7 +13,6 @@ Note that this workflow might change (simplify and improve!) in the future as py
 1.0.0 is developed/released.
 """
 
-
 ########################################################################################
 # First, we import the necessary packages and make a single test diffraction pattern.
 import pyxem.dummy_data.make_diffraction_test_data as mdtd

--- a/examples/vectors/slicing_vectors.py
+++ b/examples/vectors/slicing_vectors.py
@@ -9,6 +9,7 @@ boolean array are supported.
 Additionally, lazy operations are supported and can be chained together. These are often faster
 than their non-lazy counterparts as ``dask`` very effectively prunes the computation graph.
 """
+
 import pyxem as pxm
 import hyperspy.api as hs
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1654,9 +1654,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         elif method == "r":
             one_d_integration = self.get_azimuthal_integral1d(npt=npt, **kwargs)
-            integration_squared = (self**2).get_azimuthal_integral1d(
-                npt=npt, **kwargs
-            )
+            integration_squared = (self**2).get_azimuthal_integral1d(npt=npt, **kwargs)
             # Full variance is the same as the unshifted phi=0 term in angular correlation
             full_variance = (integration_squared / one_d_integration**2) - 1
 

--- a/pyxem/signals/diffraction_vectors1d.py
+++ b/pyxem/signals/diffraction_vectors1d.py
@@ -19,7 +19,6 @@ from hyperspy.signals import Signal1D
 
 
 class DiffractionVectors1D(Signal1D):
-
     """A Collection of Diffraction Vectors with a defined 1D set of vectors.
 
     For every navigation position there is specifically one vector that represents

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2024 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 
 

--- a/pyxem/utils/correlation_utils.py
+++ b/pyxem/utils/correlation_utils.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2024 The pyXem developers
+#
+# This file is part of pyXem.
+#
+# pyXem is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pyXem is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 
 

--- a/pyxem/utils/correlation_utils.py
+++ b/pyxem/utils/correlation_utils.py
@@ -70,9 +70,9 @@ def _correlation(z, axis=0, mask=None, wrap=True, normalize=True):
         number_unmasked = np.fft.irfft(
             mask_fft * np.conjugate(mask_fft), axis=axis
         ).real
-        number_unmasked[
-            number_unmasked < 1
-        ] = 1  # get rid of divide by zero error for completely masked rows
+        number_unmasked[number_unmasked < 1] = (
+            1  # get rid of divide by zero error for completely masked rows
+        )
         z[m] = 0
 
     # fast method uses a FFT and is a process which is O(n) = n log(n)
@@ -157,9 +157,9 @@ def _pearson_correlation(z, mask=None, mode="full"):
         mask_bool = ~m
         mask_fft = np.fft.fft(mask_bool, axis=1)
         n_unmasked = np.fft.ifft(mask_fft * mask_fft.conj()).real
-        n_unmasked[
-            n_unmasked < 1
-        ] = 1  # avoid dividing by zero for completely masked rows
+        n_unmasked[n_unmasked < 1] = (
+            1  # avoid dividing by zero for completely masked rows
+        )
         z[m] = 0  # set masked pixels to zero
         fft_intensity = np.divide(np.fft.fft(z, axis=1), n_unmasked)
         a = np.multiply(

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -31,7 +31,7 @@ from packaging.version import Version
 
 from pyxem.utils.pyfai_utils import get_azimuthal_integrator
 from pyxem.utils.cuda_utils import is_cupy_array
-
+from pyxem.utils._deprecated import deprecated
 
 try:
     import cupy as cp
@@ -690,7 +690,7 @@ def peaks_as_gvectors(z, center, calibration):
     g = (z - center) * calibration
     return g
 
-
+@deprecated(since="0.18.0",removal="1.0.0")
 def investigate_dog_background_removal_interactive(
     sample_dp, std_dev_maxs, std_dev_mins
 ):

--- a/pyxem/utils/expt_utils.py
+++ b/pyxem/utils/expt_utils.py
@@ -690,7 +690,8 @@ def peaks_as_gvectors(z, center, calibration):
     g = (z - center) * calibration
     return g
 
-@deprecated(since="0.18.0",removal="1.0.0")
+
+@deprecated(since="0.18.0", removal="1.0.0")
 def investigate_dog_background_removal_interactive(
     sample_dp, std_dev_maxs, std_dev_mins
 ):

--- a/pyxem/utils/ri_utils.py
+++ b/pyxem/utils/ri_utils.py
@@ -20,7 +20,7 @@ import numpy as np
 from diffsims.utils.atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
 from diffsims.utils.lobato_scattering_params import ATOMIC_SCATTERING_PARAMS_LOBATO
 from scipy import special
-from _deprecated import deprecated
+from pyxem.utils._deprecated import deprecated
 
 
 @deprecated(since="0.18.0", removal="1.0.0")

--- a/pyxem/utils/ri_utils.py
+++ b/pyxem/utils/ri_utils.py
@@ -20,8 +20,10 @@ import numpy as np
 from diffsims.utils.atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
 from diffsims.utils.lobato_scattering_params import ATOMIC_SCATTERING_PARAMS_LOBATO
 from scipy import special
+from _deprecated import deprecated
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def subtract_pattern(z, pattern, *args, **kwargs):
     """Used by hs.map in the ReducedIntensityGenerator1D to subtract a background
     pattern.
@@ -41,6 +43,7 @@ def subtract_pattern(z, pattern, *args, **kwargs):
     return z - pattern
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def mask_from_pattern(z, pattern, *args, **kwargs):
     """Used by hs.map in the ReducedIntensityGenerator1D to mask using a
     background pattern.

--- a/pyxem/utils/ri_utils.py
+++ b/pyxem/utils/ri_utils.py
@@ -16,11 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-from diffsims.utils.atomic_scattering_params import ATOMIC_SCATTERING_PARAMS
-from diffsims.utils.lobato_scattering_params import ATOMIC_SCATTERING_PARAMS_LOBATO
-from scipy import special
 from pyxem.utils._deprecated import deprecated
+from pyxem.signals.reduced_intensity1d import (
+    _damp_ri_exponential,
+    _damp_ri_extrapolate_to_zero,
+    _damp_ri_lorch,
+    _damp_ri_low_q_region_erfc,
+    _damp_ri_updated_lorch,
+)
 
 
 @deprecated(since="0.18.0", removal="1.0.0")
@@ -68,6 +71,7 @@ def mask_from_pattern(z, pattern, *args, **kwargs):
     return z * pattern
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def damp_ri_exponential(z, b, s_scale, s_size, s_offset, *args, **kwargs):
     """Used by hs.map in the ReducedIntensity1D to damp the reduced
     intensity signal to reduce noise in the high s region by a factor of
@@ -89,11 +93,10 @@ def damp_ri_exponential(z, b, s_scale, s_size, s_offset, *args, **kwargs):
         Keyword arguments to be passed to map().
     """
 
-    scattering_axis = s_scale * np.arange(s_size, dtype="float64") + s_offset
-    damping_term = np.exp(-b * np.square(scattering_axis))
-    return z * damping_term
+    return _damp_ri_exponential(z, b, s_scale, s_size, s_offset, *args, **kwargs)
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def damp_ri_lorch(z, s_max, s_scale, s_size, s_offset, *args, **kwargs):
     """Used by hs.map in the ReducedIntensity1D to damp the reduced
     intensity signal to reduce noise in the high s region by a factor of
@@ -115,14 +118,10 @@ def damp_ri_lorch(z, s_max, s_scale, s_size, s_offset, *args, **kwargs):
         Keyword arguments to be passed to map().
     """
 
-    delta = np.pi / s_max
-
-    scattering_axis = s_scale * np.arange(s_size, dtype="float64") + s_offset
-    damping_term = np.sin(delta * scattering_axis) / (delta * scattering_axis)
-    damping_term = np.nan_to_num(damping_term)
-    return z * damping_term
+    return _damp_ri_lorch(z, s_max, s_scale, s_size, s_offset, *args, **kwargs)
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def damp_ri_updated_lorch(z, s_max, s_scale, s_size, s_offset, *args, **kwargs):
     """Used by hs.map in the ReducedIntensity1D to damp the reduced
     intensity signal to reduce noise in the high s region by a factor of
@@ -149,21 +148,10 @@ def damp_ri_updated_lorch(z, s_max, s_scale, s_size, s_offset, *args, **kwargs):
         Keyword arguments to be passed to map().
     """
 
-    delta = np.pi / s_max
-
-    scattering_axis = s_scale * np.arange(s_size, dtype="float64") + s_offset
-    exponent_array = 3 * np.ones(scattering_axis.shape)
-    cubic_array = np.power(scattering_axis, exponent_array)
-    multiplicative_term = np.divide(3 / (delta**3), cubic_array)
-    sine_term = np.sin(delta * scattering_axis) - delta * scattering_axis * np.cos(
-        delta * scattering_axis
-    )
-
-    damping_term = multiplicative_term * sine_term
-    damping_term = np.nan_to_num(damping_term)
-    return z * damping_term
+    return _damp_ri_updated_lorch(z, s_max, s_scale, s_size, s_offset, *args, **kwargs)
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def damp_ri_extrapolate_to_zero(z, s_min, s_scale, s_size, s_offset, *args, **kwargs):
     """Used by hs.map in the ReducedIntensity1D to extrapolate the reduced
     intensity signal to zero below s_min.
@@ -184,17 +172,12 @@ def damp_ri_extrapolate_to_zero(z, s_min, s_scale, s_size, s_offset, *args, **kw
         Keyword arguments to be passed to map().
     """
 
-    s_min_num = int((s_min - s_offset) / s_scale)
-
-    s_min_val = z[s_min_num]
-    extrapolated_vals = np.arange(s_min_num) * s_scale + s_offset
-    extrapolated_vals *= s_min_val / extrapolated_vals[-1]  # scale zero to one
-
-    z[:s_min_num] = extrapolated_vals
-
-    return z
+    return _damp_ri_extrapolate_to_zero(
+        z, s_min, s_scale, s_size, s_offset, *args, **kwargs
+    )
 
 
+@deprecated(since="0.18.0", removal="1.0.0")
 def damp_ri_low_q_region_erfc(
     z, scale, offset, s_scale, s_size, s_offset, *args, **kwargs
 ):
@@ -221,7 +204,6 @@ def damp_ri_low_q_region_erfc(
         Keyword arguments to be passed to map().
     """
 
-    scattering_axis = s_scale * np.arange(s_size, dtype="float64") + s_offset
-
-    damping_term = (special.erf(scattering_axis * scale - offset) + 1) / 2
-    return z * damping_term
+    return _damp_ri_low_q_region_erfc(
+        z, scale, offset, s_scale, s_size, s_offset, *args, **kwargs
+    )

--- a/pyxem/utils/ri_utils.py
+++ b/pyxem/utils/ri_utils.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-# TODO: Delete come 1.0.0
+# TODO: Delete the whole module come 1.0.0
 
 from pyxem.utils._deprecated import deprecated
 from pyxem.signals.reduced_intensity1d import (

--- a/pyxem/utils/ri_utils.py
+++ b/pyxem/utils/ri_utils.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+# TODO: Delete come 1.0.0
+
 from pyxem.utils._deprecated import deprecated
 from pyxem.signals.reduced_intensity1d import (
     _damp_ri_exponential,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extra_feature_requirements = {
         "coveralls  >= 1.10",
         "coverage   >= 5.0",
     ],
-    "dev": ["black", "pre-commit >=1.16"],
+    "dev": ["black ~= 24.1", "pre-commit >=1.16"],
     "gpu": ["cupy >= 9.0.0"],
     "dask": ["dask-image", "distributed"],
 }


### PR DESCRIPTION
---
name: Deprecating the reduced_intensiity1d utils
about: These utils are all used by map functions present in `ReducedIntensity1D`. In anticipation of a stable API I have deprecated the explicit exposure of the utils and set the code up such that they can be completely purged come 1.0.0.

Specifically, each method in the util folder has been moved to the class module and made private. The 'old' utils then call these private functions (for now).

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What else does this PR do?**
- Adds the copyright statement to some stray files
- Pins black to 2024.1 in [dev] install and pre-commit-ci