### PR TITLE
Fix pytest failures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+==========
+Fixed
+-----
+- Fixed pytest failure. Changed `setup` --> `setup_method` (#997)
+
 2024-01-05 - version 0.17.0
 ===========================
 Added

--- a/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
+++ b/pyxem/tests/generators/test_displacement_gradient_tensor_generator.py
@@ -84,7 +84,7 @@ class TestDisplacementGradientMap:
     left_handed = np.asarray(([1, 1], [1, -1.2]))
     xy_vectors = np.asarray([[1, 0], [0, 1]])
 
-    def setup(self):
+    def setup_method(self):
         # reinitalizing to use inside functions...
         self.left_handed = np.asarray(([1, 1], [1, -1.2]))
         self.xy_vectors = np.asarray([[1, 0], [0, 1]])

--- a/pyxem/tests/generators/test_virtual_image_generator.py
+++ b/pyxem/tests/generators/test_virtual_image_generator.py
@@ -45,7 +45,7 @@ def vdf_generator(diffraction_pattern, diffraction_vectors):
 
 
 class TestVirtualDarkFieldGenerator:
-    def setup(self):
+    def setup_method(self):
         object1 = np.zeros((5, 5), dtype=bool)
         object1[2:4, 2:4] = True
         self.object1 = object1

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -1138,7 +1138,7 @@ class TestDiffraction2DPeakPositionRefinement:
 class TestSubtractingDiffractionBackground:
     method1 = ["difference of gaussians", "median kernel", "radial median", "h-dome"]
 
-    def setup(self):
+    def setup_method(self):
         self.data = np.random.rand(3, 2, 20, 15)
         self.data[:, :, 10:12, 7:9] = 100
         self.dp = Diffraction2D(self.data)

--- a/pyxem/tests/signals/test_diffraction_vectors2d.py
+++ b/pyxem/tests/signals/test_diffraction_vectors2d.py
@@ -28,7 +28,7 @@ from pyxem.signals import DiffractionVectors2D
 
 
 class TestDiffractionVectors2D:
-    def setup(self):
+    def setup_method(self):
         vectors = np.reshape(np.repeat(np.arange(0, 100), 2), (50, 4))
         self.vector = DiffractionVectors2D(vectors)
 
@@ -49,7 +49,7 @@ class TestDiffractionVectors2D:
 
 
 class TestSingleDiffractionVectors2D:
-    def setup(self):
+    def setup_method(self):
         self.data = np.array(
             [
                 [0.063776, 0.011958],

--- a/pyxem/tests/signals/test_segments.py
+++ b/pyxem/tests/signals/test_segments.py
@@ -181,7 +181,7 @@ def vdf_segments_cropped(vdf_segments):
 
 
 class TestVDFSegment:
-    def setup(self):
+    def setup_method(self):
         object1 = np.zeros((5, 5), dtype=bool)
         object1[0:2, 0:2] = True
         self.object1 = object1


### PR DESCRIPTION
---
name: Fix pytest failures
about: Fix failures due to setup --> setup_method
---

I think this one is on me... Apparently setup is not an appropriate method for setting up tests rather setup_method shoudl be used. 

https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
Fixes the issue raised in #994 