### PR TITLE
Change Azimuthal 1D default to `sum' + clean ups

### DIFF
--- a/examples/processing/azimuthal_integration.py
+++ b/examples/processing/azimuthal_integration.py
@@ -1,0 +1,90 @@
+"""
+Azimuthal Integration (in Pyxem!)
+=================================
+
+pyxem now includes built in azimuthal integration functionality. This is useful for
+extracting radial profiles from diffraction patterns in 1 or 2 dimensions.  The new method
+will split the pixels into radial bins and then sum the intensity in each bin resulting in
+a `Diffraction1D` or `Polar2D` signal.  In each case the total intensity of the diffraction
+pattern is preserved.
+"""
+
+import pyxem as pxm
+import hyperspy.api as hs
+import numpy as np
+
+nano_crystals = pxm.data.mgo_nanocrystals(lazy=True)
+nano_crystals.calibrate(
+    center=None
+)  # set the center to None to use center of the diffraction patterns
+nano_crystals1d = nano_crystals.get_azimuthal_integral1d(npt=100, inplace=False)
+
+nano_crystals1d.sum().plot()
+# %%
+
+"""
+Similarly, the `get_azimuthal_integral2d` method will return a `Polar2D` signal.
+"""
+
+nano_crystals_polar = nano_crystals.get_azimuthal_integral2d(
+    npt=100, npt_azim=360, inplace=False
+)
+nano_crystals_polar.sum().plot()
+
+# %%
+
+"""
+There are also other things you can account for with azimuthal integration, such as the
+effects of the Ewald sphere.  This can be done by calibrating with a known detector distance,
+and beam energy.
+
+Here we just show what might be the effect of just calibrating with the first peak vs. calibrating
+with the known beam energy and detector distance. For things like accurate template matching good
+calibration can be important when matching to high diffraction vectors. The calibration example gives 
+more information on how to get the correct values for your microscope/setup.
+
+If you are doing x-ray diffraction please raise an issue on the pyxem github to let us know! The same
+assumptions should apply for each case, but it would be good to test!
+
+We only show the 1D case here, but the same applies for the 2D case as well!
+"""
+
+nano_crystals.calibrate.detector(
+    pixel_size=0.001,
+    detector_distance=0.125,
+    beam_energy=200,
+    center=None,
+    units="k_A^-1",
+)  # set the center= None to use the center of the diffraction patterns
+nano_crystals1d_200 = nano_crystals.get_azimuthal_integral1d(npt=100, inplace=False)
+nano_crystals.calibrate.detector(
+    pixel_size=0.001,
+    detector_distance=0.075,
+    beam_energy=80,
+    center=None,
+    units="k_A^-1",
+)  # These are just made up pixel sizes and detector distances for illustration
+nano_crystals1d_80 = nano_crystals.get_azimuthal_integral1d(npt=100, inplace=False)
+
+hs.plot.plot_spectra(
+    [nano_crystals1d.sum(), nano_crystals1d_200.sum(), nano_crystals1d_80.sum()],
+    legend=["Flat Ewald Sphere Assumption", "200keV Corrected", "80keV Corrected"],
+)
+# %%
+
+"""
+At times you may want to use a mask to exclude certain pixels from the azimuthal integration or apply an affine
+transformation to the diffraction patterns before azimuthal integration.  This can be done using the `mask` and
+`affine` parameters of the `Calibration` object.
+
+Here we just show a random affine transformation for illustration.
+"""
+
+mask = nano_crystals.get_direct_beam_mask(radius=20)  # Mask the direct beam
+affine = np.array(
+    [[0.9, 0.1, 0], [0.1, 0.9, 0], [0, 0, 1]]
+)  # Just a random affine transformation for illustration
+nano_crystals.calibrate(mask=mask, affine=affine)
+nano_crystals.get_azimuthal_integral2d(
+    npt=100, npt_azim=360, inplace=False
+).sum().plot()

--- a/examples/processing/azimuthal_integration.py
+++ b/examples/processing/azimuthal_integration.py
@@ -38,7 +38,7 @@ There are also other things you can account for with azimuthal integration, such
 effects of the Ewald sphere.  This can be done by calibrating with a known detector distance,
 and beam energy.
 
-Here we just show what might be the effect of just calibrating with the first peak vs. calibrating
+Here we just show the effect of just calibrating with the first peak vs. calibrating
 with the known beam energy and detector distance. For things like accurate template matching good
 calibration can be important when matching to high diffraction vectors. The calibration example gives 
 more information on how to get the correct values for your microscope/setup.
@@ -88,3 +88,4 @@ nano_crystals.calibrate(mask=mask, affine=affine)
 nano_crystals.get_azimuthal_integral2d(
     npt=100, npt_azim=360, inplace=False
 ).sum().plot()
+# %%

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -28,6 +28,7 @@ from hyperspy.signals import Signal2D, BaseSignal
 from hyperspy._signals.lazy import LazySignal
 from hyperspy.misc.utils import isiterable
 from importlib import import_module
+from hyperspy.axes import UniformDataAxis
 
 from pyxem.signals import (
     CommonDiffraction,
@@ -1971,12 +1972,15 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             indexes, facts, factor_slices, radial_range = self.calibrate.get_slices1d(
                 npt, radial_range=radial_range
             )
+            if mask is None:
+                mask = self.calibrate.mask
             integration = self.map(
                 _slice_radial_integrate1d,
                 indexes=indexes,
                 factors=facts,
                 factor_slices=factor_slices,
                 inplace=inplace,
+                mask=mask,
                 **kwargs,
             )
         else:
@@ -2008,9 +2012,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 **kwargs,
             )
         s = self if inplace else integration
-
-        # Dealing with axis changes
         k_axis = s.axes_manager.signal_axes[0]
+        if not isinstance(k_axis, UniformDataAxis):
+            k_axis.convert_to_uniform_axis()
+        # Dealing with axis changes
         k_axis.name = "Radius"
         k_axis.scale = (radial_range[1] - radial_range[0]) / npt
         k_axis.offset = radial_range[0]
@@ -2108,6 +2113,8 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             slices, factors, factors_slice, radial_range = self.calibrate.get_slices2d(
                 npt, npt_azim, radial_range=radial_range
             )
+            if mask is None:
+                mask = self.calibrate.mask
             integration = self.map(
                 _slice_radial_integrate,
                 slices=slices,
@@ -2116,6 +2123,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                 npt_rad=npt,
                 npt_azim=npt_azim,
                 inplace=inplace,
+                mask=mask,
                 **kwargs,
             )
 
@@ -2148,6 +2156,10 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         # Dealing with axis changes
         t_axis = s.axes_manager.signal_axes[0]
         k_axis = s.axes_manager.signal_axes[1]
+        if not isinstance(k_axis, UniformDataAxis):
+            k_axis.convert_to_uniform_axis()
+        if not isinstance(t_axis, UniformDataAxis):
+            t_axis.convert_to_uniform_axis()
         t_axis.name = "Radians"
         t_axis.units = "Rad"
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1661,24 +1661,24 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         if method == "Omega":
             one_d_integration = self.get_azimuthal_integral1d(
-                npt=npt, method="bbox", **kwargs
+                npt=npt, mean=True, **kwargs
             )
             variance = (
                 (one_d_integration**2).mean(axis=navigation_axes)
                 / one_d_integration.mean(axis=navigation_axes) ** 2
             ) - 1
             if dqe is not None:
-                sum_points = self.get_azimuthal_integral1d(
-                    method="bbox", npt=npt, sum=True, **kwargs
-                ).mean(axis=navigation_axes)
+                sum_points = self.get_azimuthal_integral1d(npt=npt, **kwargs).mean(
+                    axis=navigation_axes
+                )
                 variance = variance - ((sum_points**-1) * dqe)
 
         elif method == "r":
             one_d_integration = self.get_azimuthal_integral1d(
-                npt=npt, method="bbox", **kwargs
+                npt=npt, mean=True, **kwargs
             )
             integration_squared = (self**2).get_azimuthal_integral1d(
-                method="bbox", npt=npt, **kwargs
+                mean=True, npt=npt, **kwargs
             )
             # Full variance is the same as the unshifted phi=0 term in angular correlation
             full_variance = (integration_squared / one_d_integration**2) - 1
@@ -1693,19 +1693,17 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
         elif method == "re":
             one_d_integration = self.get_azimuthal_integral1d(
-                npt=npt, method="bbox", **kwargs
+                npt=npt, mean=True, **kwargs
             ).mean(axis=navigation_axes)
             integration_squared = (
                 (self**2)
-                .get_azimuthal_integral1d(npt=npt, method="bbox", **kwargs)
+                .get_azimuthal_integral1d(npt=npt, mean=True, **kwargs)
                 .mean(axis=navigation_axes)
             )
             variance = (integration_squared / one_d_integration**2) - 1
 
             if dqe is not None:
-                sum_int = self.get_azimuthal_integral1d(
-                    npt=npt, method="bbox", **kwargs
-                ).mean()
+                sum_int = self.get_azimuthal_integral1d(npt=npt, **kwargs).mean()
                 variance = variance - (sum_int**-1) * (1 / dqe)
 
         elif method == "VImage":
@@ -1718,7 +1716,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
                     self.sum(axis=navigation_axes) ** -1
                 ) * (1 / dqe)
             variance = variance_image.get_azimuthal_integral1d(
-                npt=npt, method="bbox", **kwargs
+                npt=npt, mean=True, **kwargs
             )
         return variance
 

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -320,12 +320,7 @@ class TestVariance:
     @pytest.fixture
     def ones(self):
         ones_diff = Diffraction2D(data=np.ones(shape=(10, 10, 10, 10)))
-        ones_diff.axes_manager.signal_axes[0].scale = 0.1
-        ones_diff.axes_manager.signal_axes[1].scale = 0.1
-        ones_diff.axes_manager.signal_axes[0].name = "kx"
-        ones_diff.axes_manager.signal_axes[1].name = "ky"
-        ones_diff.unit = "2th_deg"
-        ones_diff.set_ai()
+        ones_diff.calibrate(scale=0.1, center=None)
         return ones_diff
 
     @pytest.fixture
@@ -333,12 +328,7 @@ class TestVariance:
         data = np.ones(shape=(10, 10, 10, 10))
         data[0:10:2, :, :, :] = 2
         ones_diff = Diffraction2D(data=data)
-        ones_diff.axes_manager.signal_axes[0].scale = 0.1
-        ones_diff.axes_manager.signal_axes[1].scale = 0.1
-        ones_diff.axes_manager.signal_axes[0].name = "kx"
-        ones_diff.axes_manager.signal_axes[1].name = "ky"
-        ones_diff.unit = "2th_deg"
-        ones_diff.set_ai()
+        ones_diff.calibrate(scale=0.1, center=None)
         return ones_diff
 
     @pytest.fixture
@@ -350,12 +340,7 @@ class TestVariance:
         rng = default_rng(seed=1)
         data = rng.poisson(lam=data)
         ones_diff = Diffraction2D(data=data)
-        ones_diff.axes_manager.signal_axes[0].scale = 0.1
-        ones_diff.axes_manager.signal_axes[1].scale = 0.1
-        ones_diff.axes_manager.signal_axes[0].name = "kx"
-        ones_diff.axes_manager.signal_axes[1].name = "ky"
-        ones_diff.unit = "2th_deg"
-        ones_diff.set_ai()
+        ones_diff.calibrate(scale=0.1, center=None)
         return ones_diff
 
     def test_FEM_Omega(self, ones, ones_zeros):
@@ -421,7 +406,7 @@ class TestVariance:
         bulls_eye_variance = bulls_eye_noisy.get_variance(25, method="re", dqe=1)
         # This fails at small radii and might still fail because it is random...
         np.testing.assert_array_almost_equal(
-            bulls_eye_variance.data[5:], np.zeros(20), decimal=2
+            bulls_eye_variance.data[5:], np.zeros(20), decimal=1
         )
         # Testing for non dqe=1
         bulls_eye_variance = (bulls_eye_noisy * 10).get_variance(

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -135,6 +135,20 @@ class TestAzimuthalIntegral1d:
         np.testing.assert_almost_equal(np.sum(ones.data), np.pi * 4**2, decimal=0)
         assert az is None
 
+    def test_1d_azimuthal_integral_pyxem(self, ones):
+        ones.calibrate.center = None
+        ones.calibrate.scale = 0.2
+        az = ones.get_azimuthal_integral1d(
+            npt=10,
+            method="splitpixel_pyxem",
+            inplace=True,
+            radial_range=[0.0, 0.8],
+            mean=True,
+        )
+        assert isinstance(ones, Diffraction1D)
+        np.testing.assert_array_equal(ones.data[0:8], np.ones(8))
+        assert az is None
+
     def test_1d_azimuthal_integral_inplace(self, ones):
         ones.set_ai()
         az = ones.get_azimuthal_integral1d(

--- a/pyxem/utils/_azimuthal_utils.py
+++ b/pyxem/utils/_azimuthal_utils.py
@@ -26,7 +26,7 @@ import numba
 
 @numba.njit
 def _slice_radial_integrate(
-    img, factors, factors_slice, slices, npt_rad, npt_azim
+    img, factors, factors_slice, slices, npt_rad, npt_azim, mask=None,
 ):  # pragma: no cover
     """Slice the image into small chunks and multiply by the factors.
 
@@ -49,6 +49,8 @@ def _slice_radial_integrate(
     of 2-10 speedup that could be achieved  by using cython or c++ instead of python
 
     """
+    if mask is not None:
+        img = img * np.logical_not(mask)
     val = np.empty(slices.shape[0])
     for i, (s, f) in enumerate(zip(slices, factors_slice)):
         val[i] = np.sum(
@@ -59,7 +61,7 @@ def _slice_radial_integrate(
 
 
 @numba.njit
-def _slice_radial_integrate1d(img, indexes, factors, factor_slices):  # pragma: no cover
+def _slice_radial_integrate1d(img, indexes, factors, factor_slices, mask=None):  # pragma: no cover
     """Slice the image into small chunks and multiply by the factors.
 
     Parameters
@@ -82,6 +84,8 @@ def _slice_radial_integrate1d(img, indexes, factors, factor_slices):  # pragma: 
     of 2-10 speedup that could be achieved  by using cython or c++ instead of python
 
     """
+    if mask is not None:
+        img = img * np.logical_not(mask)
     ans = np.empty(len(factor_slices) - 1)
     for i in range(len(factor_slices) - 1):
         ind = indexes[factor_slices[i] : factor_slices[i + 1]]

--- a/pyxem/utils/_azimuthal_utils.py
+++ b/pyxem/utils/_azimuthal_utils.py
@@ -68,7 +68,7 @@ def _slice_radial_integrate(
 
 @numba.njit
 def _slice_radial_integrate1d(
-    img, indexes, factors, factor_slices, mask=None
+    img, indexes, factors, factor_slices, mask=None, mean=False
 ):  # pragma: no cover
     """Slice the image into small chunks and multiply by the factors.
 
@@ -82,9 +82,10 @@ def _slice_radial_integrate1d(
         The percentage of the pixel for each radial bin associated with some index
     factor_slices:
         The slices to slice the factors and the indexes by
-    npt_rad:
-        The number of radial points
-
+    mask:
+        The mask to apply to the image
+    mean:
+        If True, return the mean of the pixels in the slice rather than the sum
 
     Note
     ----
@@ -101,6 +102,14 @@ def _slice_radial_integrate1d(
         total = 0.0
         for index, fa in zip(ind, f):
             total = total + img[index[0], index[1]] * fa
+        if mean:
+            total_f = 0.0
+            if mask is not None:
+                total_f = total_f + mask[ind[0], ind[1]] * fa
+            else:
+                for index, fa in zip(ind, f):
+                    total_f = total_f + fa
+            total = total / total_f
         ans[i] = total
     return ans
 

--- a/pyxem/utils/_azimuthal_utils.py
+++ b/pyxem/utils/_azimuthal_utils.py
@@ -26,7 +26,13 @@ import numba
 
 @numba.njit
 def _slice_radial_integrate(
-    img, factors, factors_slice, slices, npt_rad, npt_azim, mask=None,
+    img,
+    factors,
+    factors_slice,
+    slices,
+    npt_rad,
+    npt_azim,
+    mask=None,
 ):  # pragma: no cover
     """Slice the image into small chunks and multiply by the factors.
 
@@ -61,7 +67,9 @@ def _slice_radial_integrate(
 
 
 @numba.njit
-def _slice_radial_integrate1d(img, indexes, factors, factor_slices, mask=None):  # pragma: no cover
+def _slice_radial_integrate1d(
+    img, indexes, factors, factor_slices, mask=None
+):  # pragma: no cover
     """Slice the image into small chunks and multiply by the factors.
 
     Parameters


### PR DESCRIPTION
---
name: Azimuthal 1d clean up 
about: This adds the option to set "mean=True".  
---

Previously the Azimuthal 1d function was talking the mean value from some radial stripe. I think we should change the default behavior to `sum` the data and then have an option to pass mean=True.

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] Marked as finished
