### PR TITLE
Deprecate Virtual Imaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,11 +20,15 @@ Added
 - Added `pyxem.utils.calibration_utils.Calibration` class  for calibrating the signal axes of a 4-D STEM dataset(#993)
 - Added `pyxem.signals.Diffraction2D.get_azimuthal_integral1D` method to calculate the azimuthal integral of a 2D diffraction pattern (#1008)
 - Added example for doing azimuthal integration of a 2d diffraction pattern (#1009)
+- Added `pyxem.signals.CommonDiffraction.get_virtual_image` method to calculate multiple virtual images
+  from a 4D STEM dataset (#1014)
 
 Deprecated
 ----------
 - The module & all functions within `utils.reduced_intensity1d` are deprecated in favour of using the methods of `ReducedIntensity1D` (#994).
 - Deprecated `CalibrationGenerator` in favour of `pyxem.utils.calibration_utils.Calibration` class (#1000)
+- Deprecated `pyxem.generators.virtual_image_generator.VirtualImageGenerator` in
+  favor of `pyxem.signals.CommonDiffraction.get_virtual_image` (#1014)
 
 Deleted
 -------

--- a/examples/vectors/creating_virtual_images_from_vectors.py
+++ b/examples/vectors/creating_virtual_images_from_vectors.py
@@ -1,0 +1,38 @@
+""""
+# Creating Virtual Images from Vectors
+
+In this example we will show how to create virtual images from vectors.
+We will use the `find_peaks` method to find the vectors and then use the
+`get_unique_vectors` method to reduce the number of vectors to a unique set of vectors.
+
+We can convert the unique vectors to regions of interest (ROIs) objects using the `to_roi` method
+and then use the `get_virtual_image` method to create the virtual images.
+
+This method is flexible and any type of ROI defined in hyperspy can be used to create virtual images.
+
+We also included the include_labels argument to the `to_roi` method which will also return the labels
+for each ROI for use plotting on the signal.
+"""
+
+import pyxem as pxm
+
+c = pxm.dummy_data.get_cbed_signal()
+pks = c.template_match_disk(5, subtract_min=False).find_peaks(
+    interactive=False, threshold_abs=0.8, min_distance=6
+)
+dv = pxm.signals.DiffractionVectors.from_peaks(pks)
+vectors = dv.get_unique_vectors()
+roi, texts = vectors.to_roi(radius=5, include_labels=True, sizes=3, facecolor="black")
+
+c.plot()
+for r in roi:
+    r.add_widget(c, axes=(2, 3))
+
+vdfs = c.get_virtual_image(roi)
+c.add_marker(texts)
+
+# %%
+
+vdfs.plot()
+# %%
+# sphinx_gallery_thumbnail_number = 2

--- a/examples/virtual_imaging/README.rst
+++ b/examples/virtual_imaging/README.rst
@@ -1,3 +1,3 @@
-Data Processing
-================
+Virtual Imaging
+===============
 Below is a gallery of examples on how to make virtual images from 4-D STEM data in pyxem

--- a/examples/virtual_imaging/README.rst
+++ b/examples/virtual_imaging/README.rst
@@ -1,0 +1,3 @@
+Data Processing
+================
+Below is a gallery of examples on how to make virtual images from 4-D STEM data in pyxem

--- a/examples/virtual_imaging/creating_virtual_images_from_vectors.py
+++ b/examples/virtual_imaging/creating_virtual_images_from_vectors.py
@@ -1,4 +1,4 @@
-""""
+"""
 # Creating Virtual Images from Vectors
 
 In this example we will show how to create virtual images from vectors.

--- a/examples/virtual_imaging/creating_virtual_images_from_vectors.py
+++ b/examples/virtual_imaging/creating_virtual_images_from_vectors.py
@@ -1,5 +1,7 @@
 """
-# Creating Virtual Images from Vectors
+====================================
+Creating Virtual Images from Vectors
+====================================
 
 In this example we will show how to create virtual images from vectors.
 We will use the `find_peaks` method to find the vectors and then use the

--- a/examples/virtual_imaging/interactive_virtual_images.py
+++ b/examples/virtual_imaging/interactive_virtual_images.py
@@ -1,0 +1,25 @@
+"""
+# Creating Interactive Virtual Images
+
+We can create interactive virtual images by using the `interactive` method from hyperspy. Because
+this requires that we recalculate the virtual images every time we change the ROIs it works best
+with small datasets or datasets loaded completely into memory.
+
+You can drag the ROI to update the virtual image if you use the ipympl or qt5 backends for plotting!
+"""
+
+import pyxem as pxm
+import hyperspy.api as hs
+
+s = pxm.dummy_data.get_cbed_signal()
+circle = hs.roi.CircleROI(cx=26, cy=74, r=5.5, r_inner=0)
+s.plot_integrated_intensity(circle)
+# %%
+
+# Also we can do the same with a 1D signal
+s = pxm.dummy_data.get_cbed_signal()
+s.calibrate(center=None)
+s1d = s.get_azimuthal_integral1d(npt=100, mean=True)
+span = hs.roi.SpanROI(left=15.5, right=20)
+s1d.plot_integrated_intensity(span)
+# %%

--- a/examples/virtual_imaging/interactive_virtual_images.py
+++ b/examples/virtual_imaging/interactive_virtual_images.py
@@ -1,5 +1,7 @@
 """
-# Creating Interactive Virtual Images
+===================================
+Creating Interactive Virtual Images
+===================================
 
 We can create interactive virtual images by using the `interactive` method from hyperspy. Because
 this requires that we recalculate the virtual images every time we change the ROIs it works best

--- a/examples/virtual_imaging/other_virtual_imaging.py
+++ b/examples/virtual_imaging/other_virtual_imaging.py
@@ -1,0 +1,42 @@
+"""
+=====================
+Other Virtual Imaging
+=====================
+"""
+
+import pyxem as pxm
+import hyperspy.api as hs
+
+vectors = pxm.utils.virtual_images_utils.get_vectors_mesh(
+    10, 10, 40, angle=0.0, shear=0.0
+)
+rois, labels = pxm.signals.DiffractionVectors2D(vectors).to_roi(
+    radius=4, include_labels=True
+)
+c = pxm.dummy_data.get_cbed_signal()
+c.calibrate(center=None)
+c.plot()
+for r in rois:
+    r.add_widget(c, axes=(2, 3))
+c.add_marker(labels)
+# %%
+
+vdfs = c.get_virtual_image(rois)
+
+vdfs.plot()
+# %%
+
+# We can also use multiple different ROIs and combine them into a virtual image.
+
+r1 = hs.roi.RectangularROI(-35, -35, 35, 35)
+c1 = hs.roi.CircleROI(cx=25.5, cy=24.5, r=7, r_inner=0)
+c2 = hs.roi.CircleROI(cx=0, cy=0, r=30.5, r_inner=10.0)
+
+c.plot()
+for r in [r1, c1, c2]:
+    r.add_widget(c, axes=(2, 3))
+
+vdfs = c.get_virtual_image([r1, c1, c2])
+
+vdfs.plot()
+# %%

--- a/pyxem/generators/virtual_image_generator.py
+++ b/pyxem/generators/virtual_image_generator.py
@@ -24,6 +24,7 @@ import hyperspy.api as hs
 from pyxem.signals.common_diffraction import OUT_SIGNAL_AXES_DOCSTRING
 from pyxem.utils.virtual_images_utils import normalize_virtual_images, get_vectors_mesh
 from pyxem.utils._deprecated import deprecated
+from warnings import warn
 
 NORMALISE_DOCSTRING = """normalize : boolean
             If True each VDF image is normalized so that the maximum intensity
@@ -47,6 +48,11 @@ class VirtualImageGenerator:
     def __init__(self, signal, *args, **kwargs):
         self.signal = signal
         self.roi_list = []
+        warn(
+            "The VirtualImageGenerator class is deprecated and will be removed in 1.0.0. "
+            "Please use the pyxem.signals.Diffraction2D.get_virtual_image function instead.",
+            DeprecationWarning,
+        )
 
     @deprecated(
         alternative="pyxem.signals.Diffraction2D.get_azithumal_integral1d",
@@ -280,6 +286,11 @@ class VirtualDarkFieldGenerator(VirtualImageGenerator):
 
     def __init__(self, signal, vectors, *args, **kwargs):
         super().__init__(signal)
+        warn(
+            "The VirtualDarkFieldGenerator class is deprecated and will be removed in 1.0.0. "
+            "Please use the pyxem.signals.DiffractionVectors2D.to_roi function instead.",
+            DeprecationWarning,
+        )
         if len(vectors.axes_manager.signal_axes) == 0:
             unique_vectors = vectors.get_unique_vectors(*args, **kwargs)
         else:

--- a/pyxem/generators/virtual_image_generator.py
+++ b/pyxem/generators/virtual_image_generator.py
@@ -23,7 +23,7 @@ import hyperspy.api as hs
 
 from pyxem.signals.common_diffraction import OUT_SIGNAL_AXES_DOCSTRING
 from pyxem.utils.virtual_images_utils import normalize_virtual_images, get_vectors_mesh
-
+from pyxem.utils._deprecated import deprecated
 
 NORMALISE_DOCSTRING = """normalize : boolean
             If True each VDF image is normalized so that the maximum intensity
@@ -48,6 +48,11 @@ class VirtualImageGenerator:
         self.signal = signal
         self.roi_list = []
 
+    @deprecated(
+        alternative="pyxem.signals.Diffraction2D.get_azithumal_integral1d",
+        since="0.17.0",
+        removal="1.0.0",
+    )
     def get_concentric_virtual_images(
         self, k_min, k_max, k_steps, normalize=False, out_signal_axes=None
     ):
@@ -282,6 +287,11 @@ class VirtualDarkFieldGenerator(VirtualImageGenerator):
 
         self.vectors = unique_vectors
 
+    @deprecated(
+        alternative="pyxem.signals.DiffractionVectors2D.to_roi",
+        since="0.17.0",
+        removal="1.0.0",
+    )
     def get_virtual_dark_field_images(
         self, radius, normalize=False, out_signal_axes=None
     ):

--- a/pyxem/signals/common_diffraction.py
+++ b/pyxem/signals/common_diffraction.py
@@ -19,8 +19,11 @@
 import numpy as np
 
 from hyperspy.api import interactive
+from hyperspy.misc.utils import isiterable
+import hyperspy.api as hs
 
 from traits.trait_base import Undefined
+from pyxem.utils.virtual_images_utils import normalize_virtual_images
 
 
 OUT_SIGNAL_AXES_DOCSTRING = """out_signal_axes : None, iterable of int or string
@@ -127,6 +130,43 @@ class CommonDiffraction:
 
         # Plot the result
         out.plot(**kwargs)
+
+    def get_virtual_image(self, rois, new_axis_dict=None, normalize=False):
+        """Get a virtual images from a set of rois"""
+        if not isiterable(rois):
+            rois = [
+                rois,
+            ]
+        if new_axis_dict is None:
+            new_axis_dict = {
+                "name": "Virtual Dark Field",
+                "offset": 0,
+                "scale": 1,
+                "units": "a.u.",
+                "size": len(rois),
+            }
+
+        vdfs = [self.get_integrated_intensity(roi) for roi in rois]
+
+        vdfim = hs.stack(
+            vdfs, new_axis_name=new_axis_dict["name"], show_progressbar=False
+        )
+
+        vdfim.set_signal_type("virtual_dark_field")
+
+        if vdfim.metadata.has_item("Diffraction.integrated_range"):
+            del vdfim.metadata.Diffraction.integrated_range
+        vdfim.metadata.set_item("Diffraction.roi_list", [f"{roi}" for roi in rois])
+
+        # Set new axis properties
+        if len(rois) > 1:
+            new_axis = vdfim.axes_manager[new_axis_dict["name"]]
+            for k, v in new_axis_dict.items():
+                setattr(new_axis, k, v)
+
+        if normalize:
+            vdfim.map(normalize_virtual_images, show_progressbar=False)
+        return vdfim
 
     def get_integrated_intensity(self, roi, out_signal_axes=None):
         """Obtains the intensity integrated over the scattering range as

--- a/pyxem/signals/common_diffraction.py
+++ b/pyxem/signals/common_diffraction.py
@@ -132,7 +132,18 @@ class CommonDiffraction:
         out.plot(**kwargs)
 
     def get_virtual_image(self, rois, new_axis_dict=None, normalize=False):
-        """Get a virtual images from a set of rois"""
+        """Get a virtual images from a set of rois
+
+        Parameters
+        ----------
+        rois : iterable of :obj:`hyperspy.roi.BaseInteractiveROI`
+            Any interactive ROI detailed in HyperSpy.
+        new_axis_dict : dict, optional
+            A dictionary with the properties of the new axis. If None, a default
+            axis is created.
+        normalize : bool, optional
+            If True, the virtual images are normalized to the maximum value.
+        """
         if not isiterable(rois):
             rois = [
                 rois,

--- a/pyxem/signals/diffraction_vectors2d.py
+++ b/pyxem/signals/diffraction_vectors2d.py
@@ -24,8 +24,9 @@ from scipy.spatial import distance_matrix
 from sklearn.cluster import DBSCAN
 
 from hyperspy.signals import Signal2D
-
+from hyperspy.roi import CircleROI
 from pyxem.signals import DiffractionVectors
+import hyperspy.api as hs
 
 
 class DiffractionVectors2D(DiffractionVectors, Signal2D):
@@ -270,3 +271,21 @@ class DiffractionVectors2D(DiffractionVectors, Signal2D):
     @property
     def has_navigation_axis(self):
         return len(self.axes_manager.navigation_axes) > 0
+
+    def to_roi(self, radius=0.1, columns=None, include_labels=False, **kwargs):
+        if self.has_navigation_axis:
+            raise NotImplementedError(
+                "This method is not implemented for 2D vectors with a navigation axis"
+            )
+        if columns is None:
+            columns = [0, 1]
+
+        rois = [
+            CircleROI(vector[columns[1]], vector[columns[0]], r=radius)
+            for vector in self.data
+        ]
+        if include_labels:
+            pos = [(vector[columns[1]], vector[columns[0]]) for vector in self.data]
+            label = [f"{i}" for i in range(len(self.data))]
+            texts = hs.plot.markers.Texts(offsets=pos, texts=label, **kwargs)
+            return rois, texts

--- a/pyxem/signals/diffraction_vectors2d.py
+++ b/pyxem/signals/diffraction_vectors2d.py
@@ -273,6 +273,20 @@ class DiffractionVectors2D(DiffractionVectors, Signal2D):
         return len(self.axes_manager.navigation_axes) > 0
 
     def to_roi(self, radius=0.1, columns=None, include_labels=False, **kwargs):
+        """
+        Convert the diffraction vectors to regions of interest (ROIs) for creating virtual images.
+
+        Parameters
+        ----------
+        radius: float
+            The radius of the ROIs in calibrated units
+        columns: list
+            The columns to use for the ROIs. If None, columns 0 and 1 are used to create the ROIs.
+        include_labels: bool
+            If True, the labels for each ROI are returned as well using hyperspy's Texts class.
+        kwargs: dict
+            Keyword arguments to pass to the hyperspy Texts class.
+        """
         if self.has_navigation_axis:
             raise NotImplementedError(
                 "This method is not implemented for 2D vectors with a navigation axis"

--- a/pyxem/signals/diffraction_vectors2d.py
+++ b/pyxem/signals/diffraction_vectors2d.py
@@ -289,3 +289,5 @@ class DiffractionVectors2D(DiffractionVectors, Signal2D):
             label = [f"{i}" for i in range(len(self.data))]
             texts = hs.plot.markers.Texts(offsets=pos, texts=label, **kwargs)
             return rois, texts
+        else:
+            return rois


### PR DESCRIPTION
---
name: Deprecate Virtual Imaging
about: This replaces lots of the `VirtualImageGenerator` functionality with specific functions of different classes
---

@pc494 I'm not sure if this makes sense or not.  Partially I think that the `VirtualImageGenerator` is a bit difficult to work with.  Some of the methods like `get_integrated_intensity` are methods of the diffraction signals but if you want to do multi-diffraction then it is a function of `VirtualImageGenerator`.  I think we should just let `get_integrated_intensity` process single and multi rois. 

I also added an example for virtual image creation

Let me know what you think!

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished
