### PR TITLE
Increase tolerance to pass test on blas accelerate (osx)

### DIFF
--- a/pyxem/tests/utils/test_dpc_signal_tools.py
+++ b/pyxem/tests/utils/test_dpc_signal_tools.py
@@ -243,7 +243,7 @@ class TestGetLinearPlaneFromSignal2d:
         s.data[50, 51] = 10000
         mask[50, 51] = True
         plane_mask = pst._get_linear_plane_from_signal2d(s, mask=mask)
-        np.testing.assert_almost_equal(plane_mask, s_orig.data)
+        np.testing.assert_allclose(plane_mask, s_orig.data, atol=1E-6)
 
     def test_crop_signal(self):
         s, _ = hs.signals.Signal2D(np.meshgrid(range(100), range(110)))


### PR DESCRIPTION
---
name: Pull request 
about: A pull request that fixes a bug or adds a feature

---

**Checklist**
- [ ] Updated CHANGELOG.md
- [ ] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**

Fix for test failure on osx with blas accelerate
from https://github.com/ericpre/hyperspy-bundle/actions/runs/7784533865/job/21225261096
```python
=================================== FAILURES ===================================
_____________ TestGetLinearPlaneFromSignal2d.test_offest_and_scale _____________

self = <pyxem.tests.utils.test_dpc_signal_tools.TestGetLinearPlaneFromSignal2d object at 0x[143](https://github.com/ericpre/hyperspy-bundle/actions/runs/7784533865/job/21225261096#step:27:144)2dea10>

    def test_offest_and_scale(self):
        s, _ = hs.signals.Signal2D(np.meshgrid(range(100), range(110)))
        s.axes_manager[0].offset = -40
        s.axes_manager[1].offset = 50
        s.axes_manager[0].scale = -0.22
        s.axes_manager[1].scale = 5.2
        s_orig = s.deepcopy()
        mask = np.zeros_like(s.data, dtype=bool)
        s.data[50, 51] = 10000
        mask[50, 51] = True
        plane_mask = pst._get_linear_plane_from_signal2d(s, mask=mask)
>       np.testing.assert_almost_equal(plane_mask, s_orig.data)

/Users/runner/hyperspy-bundle/lib/python3.11/site-packages/pyxem/tests/utils/test_dpc_signal_tools.py:246: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/runner/hyperspy-bundle/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
/Users/runner/hyperspy-bundle/lib/python3.11/contextlib.py:81: in inner
    return func(*args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = (<function assert_array_almost_equal.<locals>.compare at 0x[151](https://github.com/ericpre/hyperspy-bundle/actions/runs/7784533865/job/21225261096#step:27:152)984cc0>, array([[ 1.57660430e-07,  1.00000016e+00,  2.00.....,
       [ 0,  1,  2, ..., 97, 98, 99],
       [ 0,  1,  2, ..., 97, 98, 99],
       [ 0,  1,  2, ..., 97, 98, 99]]))
kwds = {'err_msg': '', 'header': 'Arrays are not almost equal to 7 decimals', 'precision': 7, 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Arrays are not almost equal to 7 decimals
E           
E           Mismatched elements: 374 / 11000 (3.4%)
E           Max absolute difference: 1.6065961e-07
E           Max relative difference: 1.57690727e-07
E            x: array([[ 1.5766043e-07,  1.0000002e+00,  2.0000002e+00, ...,
E                    9.7000000e+01,  9.8000000e+01,  9.9000000e+01],
E                  [ 1.5484827e-07,  1.0000002e+00,  2.0000002e+00, ...,...
E            y: array([[ 0,  1,  2, ..., 97, 98, 99],
E                  [ 0,  1,  2, ..., 97, 98, 99],
E                  [ 0,  1,  2, ..., 97, 98, 99],...

/Users/runner/hyperspy-bundle/lib/python3.11/contextlib.py:81: AssertionError
```