### PR TITLE
Refactor Orientation Mapping

### DIFF
--- a/pyxem/hyperspy_extension.yaml
+++ b/pyxem/hyperspy_extension.yaml
@@ -125,6 +125,18 @@ signals:
     dtype: real
     lazy: False
     module: pyxem.signals.indexation_results
+  OrientationMap:
+    signal_type: orientation_map
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    module: pyxem.signals.indexation_results
+  LazyOrientationMap:
+    signal_type: orientation_map
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: pyxem.signals.indexation_results
   DisplacementGradientMap:
     signal_type: tensor_field
     signal_dimension: 2

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -19,6 +19,7 @@
 from warnings import warn
 
 import hyperspy.api as hs
+from hyperspy._signals.lazy import LazySignal
 from hyperspy.signal import BaseSignal
 import numpy as np
 from orix.crystal_map import CrystalMap
@@ -178,25 +179,43 @@ class OrientationMap(DiffractionVectors2D):
         self.metadata.set_item("simulation", value)
 
     def to_crystal_map(self):
+        """Convert the orientation map to an `orix.CrystalMap` object"""
         pass
 
-    def to_markers(self):
+    def to_markers(self, annotate=False, **kwargs):
+        """Convert the orientation map to a set of markers for plotting.
+
+        Parameters
+        ----------
+        annotate : bool
+            If True, the euler rotation and the correlation will be annotated on the plot using
+            the `Texts` class from hyperspy.
+        """
+
         pass
 
     def to_navigator(self):
+        """Create a colored navigator and a legend (in the form of a marker) which can be passed as the
+        navigator argument to the `plot` method of some signal.
+        """
         pass
 
-    def plot_over_signal(self, annotate=False, **kwargs):
-        """
+    def plot_over_signal(self, signal, annotate=False, **kwargs):
+        """Convenience method to plot the orientation map and the n-best matches over the signal.
+
         Parameters
         ----------
-        annotate
-        kwargs
-
-        Returns
-        -------
+        signal : BaseSignal
+            The signal to plot the orientation map over.
+        annotate: bool
+            If True, the euler rotation and the correlation will be annotated on the plot using
+            the `Texts` class from hyperspy.
 
         """
+        pass
+
+    def plot_inplane_rotation(self, **kwargs):
+        """Plot the in-plane rotation of the orientation map as a 2D map."""
         pass
 
 
@@ -250,6 +269,10 @@ class GenericMatchingResults:
         return CrystalMap(
             rotations=rotations, phase_id=phase_id, x=x, y=y, prop=properties
         )
+
+
+class LazyOrientationMap(LazySignal, OrientationMap):
+    pass
 
 
 class VectorMatchingResults(BaseSignal):

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -166,10 +166,6 @@ class OrientationMap(DiffractionVectors2D):
 
     _signal_type = "orientation_map"
 
-    def __init__(self):
-        super().__init__()
-        self._signal_type = "orientation_map"
-
     @property
     def simulation(self):
         return self.metadata.get_item("simulation")

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -26,6 +26,7 @@ from orix.quaternion import Rotation
 from transforms3d.euler import mat2euler
 
 from pyxem.utils.indexation_utils import get_nth_best_solution
+from pyxem.signals.diffraction_vectors2d import DiffractionVectors2D
 from pyxem.utils._signals import _transfer_navigation_axes
 
 
@@ -145,6 +146,58 @@ def _get_second_best_phase(z):
         return phase_second[4]
     else:
         return -1
+
+
+class OrientationMap(DiffractionVectors2D):
+    """Signal class for orientation maps.  Note that this is a special case where
+    for each navigation position, the signal contains the top n best matches in the form
+    of a nx4 array with columns [index,correlation, in-plane rotation, mirror(factor)]
+
+    The Simulation is saved in the metadata but can be accessed using the .simulation attribute.
+
+    Parameters
+    ----------
+    *args
+        See :class:`~hyperspy._signals.signal2d.Signal2D`.
+    **kwargs
+        See :class:`~hyperspy._signals.signal2d.Signal2D`
+    """
+
+    _signal_type = "orientation_map"
+
+    def __init__(self):
+        super().__init__()
+        self._signal_type = "orientation_map"
+
+    @property
+    def simulation(self):
+        return self.metadata.get_item("simulation")
+
+    @simulation.setter
+    def simulation(self, value):
+        self.metadata.set_item("simulation", value)
+
+    def to_crystal_map(self):
+        pass
+
+    def to_markers(self):
+        pass
+
+    def to_navigator(self):
+        pass
+
+    def plot_over_signal(self, annotate=False, **kwargs):
+        """
+        Parameters
+        ----------
+        annotate
+        kwargs
+
+        Returns
+        -------
+
+        """
+        pass
 
 
 class GenericMatchingResults:

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -23,6 +23,10 @@ from hyperspy._signals.lazy import LazySignal
 from pyxem.signals.common_diffraction import CommonDiffraction
 from pyxem.utils._correlations import _correlation, _power, _pearson_correlation
 from pyxem.utils._deprecated import deprecated
+from pyxem.utils.indexation_utils import (
+    _mixed_matching_lib_to_polar,
+    _get_integrated_polar_templates,
+)
 
 from pyxem.utils._background_subtraction import (
     _polar_subtract_radial_median,
@@ -303,6 +307,51 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             output_signal_size=self.axes_manager._signal_shape_in_array,
             **kwargs,
         )
+
+    def get_orientation(
+        self, simulation, n_keep=1, frac_keep=0.1, n_best=1, normalize_templates=True
+    ):
+        """Match the orientation with some simulated diffraction patterns using
+        an accelerated orientation mapping algorithm.
+
+        The details of the algorithm are described in the paper:
+        "Free, flexible and fast: Orientation mapping using the multi-core and
+         GPU-accelerated template matching capabilities in the python-based open
+         source 4D-STEM analysis toolbox Pyxem"
+
+
+        Parameters
+        ----------
+        simulation : DiffractionSimulation
+            The diffraction simulation object to use for indexing.
+
+        Returns
+        -------
+        orientation : BaseSignal
+            A signal with the orientation at each navigation position.
+        """
+        (
+            r_templates,
+            theta_templates,
+            intensities_templates,
+        ) = simulation.get_polar_templates()
+        radius = self.axes_manager.signal_axes[0].size  # number radial pixels
+        integrated_templates = _get_integrated_polar_templates(
+            radius, r_templates, intensities_templates, normalize_templates
+        )
+        orientation = self.map(
+            _mixed_matching_lib_to_polar,
+            integrated_templates=integrated_templates,
+            r_templates=r_templates,
+            theta_templates=theta_templates,
+            intensities_templates=intensities_templates,
+            n_keep=n_keep,
+            frac_keep=frac_keep,
+            n_best=n_best,
+            inplace=False,
+        )
+
+        return orientation
 
 
 class LazyPolarDiffraction2D(LazySignal, PolarDiffraction2D):

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -310,7 +310,13 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         )
 
     def get_orientation(
-        self, simulation, n_keep=None, frac_keep=0.1, n_best=1, normalize_templates=True
+        self,
+        simulation,
+        n_keep=None,
+        frac_keep=0.1,
+        n_best=1,
+        normalize_templates=True,
+        **kwargs
     ):
         """Match the orientation with some simulated diffraction patterns using
         an accelerated orientation mapping algorithm.
@@ -333,6 +339,8 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             The number of best matching orientations to keep.
         normalize_templates : bool
             Normalize the templates to the same intensity.
+        kwargs : dict
+            Any additional options for the :meth:`~hyperspy.signal.BaseSignal.map` function.
 
         Returns
         -------
@@ -364,6 +372,8 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             n_best=n_best,
             inplace=False,
             transpose=True,
+            output_signal_size=(n_best, 4),
+            output_dtype=float,
         )
 
         orientation.set_signal_type("orientation_map")

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -324,6 +324,14 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         ----------
         simulation : DiffractionSimulation
             The diffraction simulation object to use for indexing.
+        n_keep : int
+            The number of orientations to keep for each diffraction pattern.
+        frac_keep : float
+            The fraction of the best matching orientations to keep.
+        n_best : int
+            The number of best matching orientations to keep.
+        normalize_templates : bool
+            Normalize the templates to the same intensity.
 
         Returns
         -------
@@ -334,7 +342,10 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             r_templates,
             theta_templates,
             intensities_templates,
-        ) = simulation.get_polar_templates()
+        ) = simulation.polar_flatten_simulations(
+            radial_axes=self.axes_manager.signal_axes[0].axis,
+            azimuthal_axes=self.axes_manager.signal_axes[1].axis,
+        )
         radius = self.axes_manager.signal_axes[0].size  # number radial pixels
         integrated_templates = _get_integrated_polar_templates(
             radius, r_templates, intensities_templates, normalize_templates

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -316,17 +316,14 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         frac_keep=0.1,
         n_best=1,
         normalize_templates=True,
-        **kwargs
+        **kwargs,
     ):
         """Match the orientation with some simulated diffraction patterns using
         an accelerated orientation mapping algorithm.
-
         The details of the algorithm are described in the paper:
         "Free, flexible and fast: Orientation mapping using the multi-core and
          GPU-accelerated template matching capabilities in the python-based open
          source 4D-STEM analysis toolbox Pyxem"
-
-
         Parameters
         ----------
         simulation : DiffractionSimulation
@@ -341,7 +338,6 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             Normalize the templates to the same intensity.
         kwargs : dict
             Any additional options for the :meth:`~hyperspy.signal.BaseSignal.map` function.
-
         Returns
         -------
         orientation : BaseSignal

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -362,6 +362,10 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             inplace=False,
         )
 
+        orientation.set_signal_type("orientation_map")
+        orientation.simulation = simulation
+        orientation.column_names = ["index", "correlation", "rotation", "factor"]
+        orientation.units = ["a.u.", "a.u.", "deg", "a.u."]
         return orientation
 
 

--- a/pyxem/tests/signals/test_polar_diffraction2d.py
+++ b/pyxem/tests/signals/test_polar_diffraction2d.py
@@ -268,11 +268,6 @@ class TestOrientationMap:
         pol.axes_manager[3].scale = 0.5
         return pol
 
-    def test_orientation_map_inplace(self, diffraction_pattern):
-        s = PolarDiffraction2D(diffraction_pattern)
-        s.orientation_map(inplace=True)
-        assert s.learning_results is not None
-
 
 class TestSubtractingDiffractionBackground:
     @pytest.fixture

--- a/pyxem/tests/signals/test_polar_diffraction2d.py
+++ b/pyxem/tests/signals/test_polar_diffraction2d.py
@@ -251,6 +251,29 @@ class TestDecomposition:
         assert isinstance(s, PolarDiffraction2D)
 
 
+class TestOrientationMap:
+    @pytest.fixture
+    def polar_image(self, diffraction_pattern):
+        from pyxem.signals import PolarDiffraction2D
+
+        pol_image = np.zeros((2, 2, 20, 60))
+        pol_image[:, :, 4:6, 9:11] = 1
+        pol_image[:, :, 4:6, 29:31] = 1
+        pol_image[:, :, 4:6, 49:51] = 1
+
+        pol_image[:, :, 9:11, 9:11] = 1
+        pol_image[:, :, 9:11, 29:31] = 1
+        pol_image[:, :, 9:11, 49:51] = 1
+        pol = PolarDiffraction2D(pol_image)
+        pol.axes_manager[3].scale = 0.5
+        return pol
+
+    def test_orientation_map_inplace(self, diffraction_pattern):
+        s = PolarDiffraction2D(diffraction_pattern)
+        s.orientation_map(inplace=True)
+        assert s.learning_results is not None
+
+
 class TestSubtractingDiffractionBackground:
     @pytest.fixture
     def noisy_data(self):

--- a/pyxem/utils/indexation_utils.py
+++ b/pyxem/utils/indexation_utils.py
@@ -742,6 +742,7 @@ def _mixed_matching_lib_to_polar(
     n_keep,
     frac_keep,
     n_best,
+    transpose=False,
 ):
     """
     Match a polar image to a filtered subset of polar templates
@@ -776,6 +777,8 @@ def _mixed_matching_lib_to_polar(
         of the best fitting template, where factor is 1 if the direct template is
         matched and -1 if the mirror template is matched
     """
+    if transpose:
+        polar_image = polar_image.T
     dispatcher = get_array_module(polar_image)
     # remove templates we don't care about with a fast match
     (
@@ -1099,6 +1102,24 @@ def _prefilter_templates(
     frac_keep,
     n_keep,
 ):
+    """
+    Pre-filter the templates to reduce the number of templates to do a full match on
+
+    Parameters
+    ----------
+    polar_image: 2D numpy.ndarray
+        The image converted to polar coordinates in the form (theta, r)
+    r:
+    theta
+    intensities
+    integrated_templates
+    frac_keep
+    n_keep
+
+    Returns
+    -------
+
+    """
     dispatcher = get_array_module(polar_image)
     max_keep = _get_max_n(r.shape[0], n_keep, frac_keep)
     template_indexes = dispatcher.arange(r.shape[0], dtype=np.int32)


### PR DESCRIPTION
------------------------------------
name:Refactor Orientation Mapping
------------------------------------

about: This adds orientation mapping as a function of the `PolarDiffraction2D` signal and adds a class for holding `OrientationMaps`. The main goal here is to add a single class where we can add methods like plotting vectors over the signal or create maps of the in plane orientation etc. 



**Checklist**
- [ ] Update Tests to cover changes
- [ ] Merge https://github.com/pyxem/diffsims/pull/201 (This depends on that working)
- [ ] Validate vs old results. 
- [ ] Updated CHANGELOG.md
- [ ] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
I want this to be a very boiler plate type PR.  I think that the rest of the functions for this class can be added in separate PR's but I started typing out the doc strings just to give an idea of what those functions should do. 

@pc494 What do you think about this?



Minimum Example:

```python
from orix.crystal_map import Phase
from orix.quaternion import Rotation
from diffsims.generators.simulation_generator import SimulationGenerator


dp = hs.load("some_data.hspy")

# Creating a Library
phase = Phase.from_cif('some_phase.cif')
rots = Rotation.from_euler(list_of_euler_angles, degrees=True)
gen = SimulationGenerator(minimum_intensity=1e-5) 
sim = gen.calculate_ed_data(phase = [structure_zb,structure_wz],rotation=[rot1,rot2], ) 

# Fitting a Library
dp.calibrate(center=None) 
pol = dp.get_azimuthal_integral2d(npt=100)
orient = pol.get_orientation(sim,
                             n_keep=1,
                             n_best=2, 
                             normalize_templates=True,
                             frac_keep=1)

# Operating on the orientation map
display(orient)
```
<img width="435" alt="Screenshot 2024-02-14 at 9 38 02 AM" src="https://github.com/pyxem/pyxem/assets/41125831/0cb30f7d-fa51-4197-9247-336363a006e6">



