### PR TITLE
Consolidate two flip_diffraction_ methods into 1

### DIFF
--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -285,28 +285,30 @@ class Diffraction2D(Signal2D, CommonDiffraction):
 
     def flip_diffraction(self, axis, **kwargs):
         """Mirrors diffraction patterns about one of the coordinate axes.
-        
+
         Parameters
         ----------
-        axis : {'x', 'y'} 
+        axis : {'x', 'y'}
             The axis through which the reflection occurs
-        **kwargs : 
+        **kwargs :
             Keyword arguments to be passed to :meth:`~hyperspy.signal.BaseSignal.map`.
-        
+
         Returns
         -------
         Diffraction2D or None:
             Flipped Diffraction2D object or None (if `inplace=True`).
-        
+
         """
-        if axis == 'x':
-            return self.map(np.fliplr,**kwargs)
-        elif axis == 'y':
-            return self.map(np.flipud,**kwargs)
+        if axis == "x":
+            return self.map(np.fliplr, **kwargs)
+        elif axis == "y":
+            return self.map(np.flipud, **kwargs)
         else:
-            raise ValueError("The argument you've provided for axis is not suitable. Please use either 'x' or 'y'.")
-    
-    @deprecated(since="0.18.0", removal='1.0.0', alternative='flip_diffraction')
+            raise ValueError(
+                "The argument you've provided for axis is not suitable. Please use either 'x' or 'y'."
+            )
+
+    @deprecated(since="0.18.0", removal="1.0.0", alternative="flip_diffraction")
     def flip_diffraction_x(self):
         """Flip the dataset along the diffraction x-axis.
 
@@ -336,7 +338,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         s_out.data = np.flip(self.data, axis=-1)
         return s_out
 
-    @deprecated(since="0.18.0", removal='1.0.0', alternative='flip_diffraction')
+    @deprecated(since="0.18.0", removal="1.0.0", alternative="flip_diffraction")
     def flip_diffraction_y(self):
         """Flip the dataset along the diffraction y-axis.
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -283,6 +283,30 @@ class Diffraction2D(Signal2D, CommonDiffraction):
             s_rotated.compute(show_progressbar=show_progressbar)
         return s_rotated
 
+    def flip_diffraction(self, axis, **kwargs):
+        """Mirrors diffraction patterns about one of the coordinate axes.
+        
+        Parameters
+        ----------
+        axis : {'x', 'y'} 
+            The axis through which the reflection occurs
+        **kwargs : 
+            Keyword arguments to be passed to :meth:`~hyperspy.signal.BaseSignal.map`.
+        
+        Returns
+        -------
+        Diffraction2D or None:
+            Flipped Diffraction2D object or None (if `inplace=True`).
+        
+        """
+        if axis == 'x':
+            return self.map(np.fliplr,**kwargs)
+        elif axis == 'y':
+            return self.map(np.flipud,**kwargs)
+        else:
+            raise ValueError("The argument you've provided for axis is not suitable. Please use either 'x' or 'y'.")
+    
+    @deprecated(since="0.18.0", removal='1.0.0', alternative='flip_diffraction')
     def flip_diffraction_x(self):
         """Flip the dataset along the diffraction x-axis.
 
@@ -312,6 +336,7 @@ class Diffraction2D(Signal2D, CommonDiffraction):
         s_out.data = np.flip(self.data, axis=-1)
         return s_out
 
+    @deprecated(since="0.18.0", removal='1.0.0', alternative='flip_diffraction')
     def flip_diffraction_y(self):
         """Flip the dataset along the diffraction y-axis.
 


### PR DESCRIPTION
---
name: Consolidate two flip_diffraction_ methods into 1 
about: As alluded to in #1011 I'm trying to consolidate some 'basic' methods in `Diffraction2D' to follow a consistent API. This was a simple/trivial one. 1 new method, 2 deprecations.

**Note for reviewer: I am not 100% sure the x/y conventions are correct. I followed the signatures of the existing methods**

---

**Checklist**
- [ ] Get an approving review
- [ ] Update CHANGELOG.md
- [ ] Ping someone to merge.

**Demo**
![Screenshot from 2024-02-15 11-07-10](https://github.com/pyxem/pyxem/assets/32455330/c0813394-b9d5-4d31-bc74-c581a766ff10)
