### PR TITLE
Replace `matplotlib.cm.get_cmap` (removed in matplotlib 3.9) with `matplotlib.colormaps`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 -----
 - Fixed pytest failure. Changed `setup` --> `setup_method` (#997)
 - `pyxem.signals.Diffraction2D.center_of_mass` now uses the `map` function. (#1005)
+- Replace ``matplotlib.cm.get_cmap`` (removed in matplotlib 3.9) with ``matplotlib.colormaps``. (#1023)
 
 Added
 -----

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -20,8 +20,8 @@ from functools import cached_property
 from warnings import warn
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.cm import get_cmap
 from scipy.spatial import distance_matrix
 from sklearn.cluster import DBSCAN
 import dask.array as da
@@ -759,7 +759,7 @@ class DiffractionVectors(BaseSignal):
                     labels_to_plot[n] = labs[index]
                 # Assign a color value to each label, and shuffle these so that
                 # adjacent clusters hopefully get distinct colors.
-                cmap_lab = get_cmap("gist_rainbow")
+                cmap_lab = matplotlib.colormaps["gist_rainbow"]
                 lab_values_shuffled = np.arange(np.max(labels_to_plot) + 1)
                 np.random.shuffle(lab_values_shuffled)
                 labels_steps = np.array(


### PR DESCRIPTION
---
name: Pull request 
about: Fix deprecated matplotlib code to be removed in matplotlib 3.9

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
From https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/7945661741/job/21692574880

https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm

Using matplotlib development

```python
============================= test session starts ==============================
platform linux -- Python 3.[11](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/7945661741/job/21692574880#step:27:12).8, pytest-7.4.4, pluggy-1.4.0
Matplotlib: 3.9.0.dev0
Freetype: 2.6.1
rootdir: /home/runner/work/hyperspy-extensions-list/hyperspy-extensions-list
plugins: mpl-0.17.0, xdist-3.5.0, rerunfailures-13.0
collected 0 items / 1 error

==================================== ERRORS ====================================
________________________ ERROR collecting test session _________________________
../../../miniconda3/envs/test/lib/python3.11/importlib/__init__.py:[12](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/7945661741/job/21692574880#step:27:13)6: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1126: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1[14](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/7945661741/job/21692574880#step:27:15)7: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:940: in exec_module
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
../../../miniconda3/envs/test/lib/python3.11/site-packages/pyxem/__init__.py:27: in <module>
    from pyxem import dummy_data
../../../miniconda3/envs/test/lib/python3.11/site-packages/pyxem/dummy_data/__init__.py:[23](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/7945661741/job/21692574880#step:27:24): in <module>
    from .dummy_data import (
../../../miniconda3/envs/test/lib/python3.11/site-packages/pyxem/dummy_data/dummy_data.py:28: in <module>
    from pyxem.dummy_data import make_diffraction_test_data as mdtd
../../../miniconda3/envs/test/lib/python3.11/site-packages/pyxem/dummy_data/make_diffraction_test_data.py:28: in <module>
    from pyxem.signals import Diffraction2D, LazyDiffraction2D
../../../miniconda3/envs/test/lib/python3.11/site-packages/pyxem/signals/__init__.py:36: in <module>
    from .diffraction_vectors import DiffractionVectors
../../../miniconda3/envs/test/lib/python3.11/site-packages/pyxem/signals/diffraction_vectors.py:[24](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/7945661741/job/21692574880#step:27:25): in <module>
    from matplotlib.cm import get_cmap
E   ImportError: cannot import name 'get_cmap' from 'matplotlib.cm' (/home/runner/miniconda3/envs/test/lib/python3.11/site-packages/matplotlib/cm.py)
```