### PR TITLE
Flatten Diffraction Vector Bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 - `pyxem.signals.Diffraction2D.center_of_mass` now uses the `map` function. (#1005)
 - Replace ``matplotlib.cm.get_cmap`` (removed in matplotlib 3.9) with ``matplotlib.colormaps``. (#1023)
 - Documentation fixes and improvement. (#1028)
+- Fixed bug with flattening diffraction Vectors when there are different scales (#1024)
 
 Added
 -----

--- a/doc/dev_guide/contributing.rst
+++ b/doc/dev_guide/contributing.rst
@@ -215,9 +215,9 @@ Tips for writing Jupyter notebooks that are meant to be converted to reST text f
   command is the last line in a cell.
 - Refer to our API reference with this general markdown syntax:
   :code:`:meth:`~.signals.Diffraction2D.get_azimuthal_integral1d`` which will be
-  displayed as :meth:`~.signals.Diffraction2D.get_azimuthal_integral1d` or 
+  displayed as :meth:`~.signals.Diffraction2D.get_azimuthal_integral1d` or
   :code:`:meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral1d`` to have the full
-  path: :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral1d` 
+  path: :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral1d`
 - Reference external APIs via standard markdown like :code:`:class:`hyperspy.api.signals.Signal2D``,
   which will be displayed as :class:`hyperspy.api.signals.Signal2D`.
 - The Sphinx gallery thumbnail used for a notebook is set by adding the

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -419,7 +419,7 @@ class DiffractionVectors(BaseSignal):
 
     @units.setter
     def units(self, value):
-        if isinstance(value, str):
+        if isinstance(value, str) and self.num_columns == 1:
             value = [value]
         if (
             isiterable(value)

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -584,13 +584,13 @@ class DiffractionVectors(BaseSignal):
         """
         from pyxem.signals.diffraction_vectors2d import DiffractionVectors2D
 
-        nav_positions = self._get_navigation_positions(
-            flatten=False, real_units=real_units
-        )
         if self.axes_manager._navigation_shape_in_array == ():
             return self
 
         if self._is_object_dtype:
+            nav_positions = self._get_navigation_positions(
+                flatten=False, real_units=real_units
+            )
             vectors = np.vstack(
                 [
                     np.hstack(
@@ -603,6 +603,9 @@ class DiffractionVectors(BaseSignal):
                 ]
             )
         else:
+            nav_positions = self._get_navigation_positions(
+                flatten=True, real_units=real_units
+            )
             navs = np.repeat(nav_positions, self.num_rows, axis=0)
             data = self.data.reshape((-1, self.num_columns))
             vectors = np.vstack((navs, data))

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -96,7 +96,9 @@ class DiffractionVectors(BaseSignal):
         _units = kwargs.pop("units", None)
         super().__init__(*args, **kwargs)
         self._set_up_vector(_scales, _offsets, _detector_shape, _column_names, _units)
-        if self._is_object_dtype is None:
+        if (
+            self._is_object_dtype is None
+        ):  # empty signal with data=None due to `_deepcopy_with_new_data`
             pass
         elif self._is_object_dtype:
             self.ragged = True
@@ -387,10 +389,10 @@ class DiffractionVectors(BaseSignal):
         try:
             if self.data[0] is None:
                 return None
+            else:
+                return self.data.dtype.kind == "O"
         except IndexError:
             return None
-        else:
-            return self.data.dtype.kind == "O"
 
     @cached_property
     def num_columns(self):
@@ -1201,13 +1203,12 @@ class DiffractionVectors(BaseSignal):
         polar_vectors : DiffractionVectors
             Diffraction vectors in polar coordinates.
         """
-        if self.ragged:
-            ragged = True
-        else:
-            ragged = False
-
         polar_vectors = self.map(
-            vectors_to_polar, inplace=False, ragged=ragged, columns=columns, **kwargs
+            vectors_to_polar,
+            inplace=False,
+            ragged=self.ragged,
+            columns=columns,
+            **kwargs,
         )
         polar_vectors.set_signal_type("polar_vectors")
         polar_vectors.column_names[0] = "r"

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -537,8 +537,8 @@ class DiffractionVectors(BaseSignal):
             scales = [1 for a in self.axes_manager.navigation_axes]
             offsets = [0 for a in self.axes_manager.navigation_axes]
         else:
-            scales = [a.scale for a in self.axes_manager.navigation_axes]
-            offsets = [a.offset for a in self.axes_manager.navigation_axes]
+            scales = [a.scale for a in self.axes_manager.navigation_axes[::-1]]
+            offsets = [a.offset for a in self.axes_manager.navigation_axes[::-1]]
 
         if flatten:
             real_nav = np.array(
@@ -595,7 +595,7 @@ class DiffractionVectors(BaseSignal):
                 [
                     np.hstack(
                         [
-                            np.tile(nav_positions[ind], (len(self.data[ind]), 1)),
+                            np.tile(nav_positions[ind][::-1], (len(self.data[ind]), 1)),
                             self.data[ind],
                         ]
                     )

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -399,6 +399,8 @@ class DiffractionVectors(BaseSignal):
                 shape = self.data[self.data.ndim * (0,)].shape
             if shape is None:
                 return 0
+            elif len(shape) == 1:
+                return 1
             else:
                 return shape[1]
         else:

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -585,7 +585,7 @@ class DiffractionVectors(BaseSignal):
         from pyxem.signals.diffraction_vectors2d import DiffractionVectors2D
 
         nav_positions = self._get_navigation_positions(
-            flatten=True, real_units=real_units
+            flatten=False, real_units=real_units
         )
         if self.axes_manager._navigation_shape_in_array == ():
             return self
@@ -594,9 +594,12 @@ class DiffractionVectors(BaseSignal):
             vectors = np.vstack(
                 [
                     np.hstack(
-                        [np.tile(nav_pos, (len(self.data[ind]), 1)), self.data[ind]]
+                        [
+                            np.tile(nav_positions[ind], (len(self.data[ind]), 1)),
+                            self.data[ind],
+                        ]
                     )
-                    for ind, nav_pos in zip(np.ndindex(self.data.shape), nav_positions)
+                    for ind in np.ndindex(self.axes_manager._navigation_shape_in_array)
                 ]
             )
         else:

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -635,14 +635,18 @@ class DiffractionVectors(BaseSignal):
         column_offsets = np.append(column_offsets, offsets)
         column_scale = np.append(column_scale, scales)
 
-        column_names = [
-            a.name for a in self.axes_manager.navigation_axes
-        ] + self.column_names
+        column_names = np.append(
+            [a.name for a in self.axes_manager.navigation_axes], self.column_names
+        )
 
         if real_units:
-            units = [a.units for a in self.axes_manager.navigation_axes] + self.units
+            units = np.append(
+                [a.units for a in self.axes_manager.navigation_axes], self.units
+            )
         else:
-            units = ["pixels"] * len(self.axes_manager.navigation_axes) + self.units
+            units = np.append(
+                ["pixels"] * len(self.axes_manager.navigation_axes), self.units
+            )
 
         return DiffractionVectors2D(
             vectors,

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -124,6 +124,8 @@ class DiffractionVectors(BaseSignal):
         vectors = self._get_current_data()
         if vectors.dtype.kind == "O":
             vectors = vectors[0]
+        if self.num_columns == 1:
+            vectors = np.array([vectors]).T
         for i, row in enumerate(vectors):
             table += "<tr>"
             table += f"<td><center>{i}</center></td>"
@@ -417,12 +419,15 @@ class DiffractionVectors(BaseSignal):
 
     @units.setter
     def units(self, value):
+        if isinstance(value, str):
+            value = [value]
         if (
             isiterable(value)
             and len(value) == self.num_columns
             and not isinstance(value, str)
         ):
             self.metadata.VectorMetadata["units"] = value
+
         elif isiterable(value) and len(value) != self.num_columns:
             raise ValueError(
                 "The len of the units parameter must equal the number of"
@@ -464,6 +469,9 @@ class DiffractionVectors(BaseSignal):
     def column_names(self, value):
         if value is None:
             value = [f"column_{i}" for i in range(self.num_columns)]
+
+        if isinstance(value, str):
+            value = [value]
         if len(value) != self.num_columns:
             raise ValueError(
                 f"The len of the column_names parameter: {len(value)} must equal the"
@@ -480,6 +488,7 @@ class DiffractionVectors(BaseSignal):
     def offsets(self, value):
         if isiterable(value) and len(value) == self.num_columns:
             self.metadata.VectorMetadata["offsets"] = value
+
         elif isiterable(value) and len(value) != self.num_columns:
             raise ValueError(
                 "The len of the scales parameter must equal the number of"

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -218,7 +218,9 @@ class DiffractionVectors(BaseSignal):
             )
 
         if column_names is None and peaks.metadata.has_item("Peaks.signal_axes"):
-            column_names = [ax.name for ax in peaks.metadata.Peaks.signal_axes[::-1]]
+            column_names = [
+                str(ax.name) for ax in peaks.metadata.Peaks.signal_axes[::-1]
+            ]
         elif column_names is not None:
             pass
         else:
@@ -650,17 +652,38 @@ class DiffractionVectors(BaseSignal):
             nav_positions = self._get_navigation_positions(
                 flatten=False, real_units=real_units
             )
-            vectors = np.vstack(
-                [
-                    np.hstack(
-                        [
-                            np.tile(nav_positions[ind][::-1], (len(self.data[ind]), 1)),
-                            self.data[ind],
-                        ]
-                    )
-                    for ind in np.ndindex(self.axes_manager._navigation_shape_in_array)
-                ]
-            )
+            if self.num_columns == 1:
+                vectors = np.vstack(
+                    [
+                        np.hstack(
+                            [
+                                np.tile(
+                                    nav_positions[ind][::-1], (len(self.data[ind]), 1)
+                                ),
+                                self.data[ind][:, np.newaxis],
+                            ]
+                        )
+                        for ind in np.ndindex(
+                            self.axes_manager._navigation_shape_in_array
+                        )
+                    ]
+                )
+            else:
+                vectors = np.vstack(
+                    [
+                        np.hstack(
+                            [
+                                np.tile(
+                                    nav_positions[ind][::-1], (len(self.data[ind]), 1)
+                                ),
+                                self.data[ind],
+                            ]
+                        )
+                        for ind in np.ndindex(
+                            self.axes_manager._navigation_shape_in_array
+                        )
+                    ]
+                )
         else:
             nav_positions = self._get_navigation_positions(
                 flatten=True, real_units=real_units

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -937,8 +937,8 @@ class DiffractionVectors(BaseSignal):
             output_signal_size=signal_shape,
             output_dtype=dtype,
         )
-        new_signal.column_names = self.column_names + ["cluster"]
-        new_signal.units = self.units + ["n.a."]
+        new_signal.column_names = np.append(self.column_names, ["cluster"])
+        new_signal.units = np.append(self.units, ["n.a."])
 
         if not self.has_navigation_axis:
             new_signal.set_signal_type("labeled_diffraction_vectors")

--- a/pyxem/signals/diffraction_vectors2d.py
+++ b/pyxem/signals/diffraction_vectors2d.py
@@ -169,18 +169,6 @@ class DiffractionVectors2D(DiffractionVectors, Signal2D):
         else:
             return unique_peaks
 
-    def get_magnitudes(self, out=None, rechunk=False):
-        """
-        Calculate the magnitude of diffraction vectors.
-
-        TODO: Add in ability to get the magnitude of only certain columns.
-        """
-
-        axis = self.axes_manager[-2]
-        return self._apply_function_on_data_and_remove_axis(
-            np.linalg.norm, axes=axis, out=out, rechunk=rechunk
-        )
-
     def __lt__(self, other):
         return self._deepcopy_with_new_data(self.data < other)
 
@@ -195,34 +183,6 @@ class DiffractionVectors2D(DiffractionVectors, Signal2D):
 
     def from_peaks(cls, **kwargs):
         raise NotImplementedError("This method is not implemented for 2D vectors")
-
-    def filter_magnitude(self, min_magnitude, max_magnitude, *args, **kwargs):
-        """Filter the diffraction vectors to accept only those with a magnitude
-        within a user specified range.
-        TODO: Add in ability to filter by the magnitude of only certain columns.
-
-        Parameters
-        ----------
-        min_magnitude : float
-            Minimum allowed vector magnitude.
-        max_magnitude : float
-            Maximum allowed vector magnitude.
-        *args:
-            Arguments to be passed to map().
-        **kwargs:
-            Keyword arguments to map().
-
-        Returns
-        -------
-        filtered_vectors : DiffractionVectors
-            Diffraction vectors within allowed magnitude tolerances.
-        """
-        magnitudes = self.get_magnitudes()
-        in_range = (min_magnitude < magnitudes) * (magnitudes < max_magnitude)
-
-        # self.data[in_range]
-        new_data = self.data[in_range]
-        return DiffractionVectors2D(new_data)
 
     def filter_detector_edge(self, exclude_width, columns=[-2, -1]):
         """Filter the diffraction vectors to accept only those not within a

--- a/pyxem/signals/labeled_diffraction_vectors2d.py
+++ b/pyxem/signals/labeled_diffraction_vectors2d.py
@@ -226,8 +226,8 @@ class LabeledDiffractionVectors2D(DiffractionVectors2D):
             new_signal.axes_manager.signal_axes[0].size + 1
         )
         new_signal.is_clustered = True
-        new_signal.column_names = self.column_names + ["cluster_label"]
-        new_signal.units = self.units + ["n.a."]
+        new_signal.column_names = np.append(self.column_names, ["cluster_label"])
+        new_signal.units = np.append(self.units, ["n.a."])
         return new_signal
 
     @only_signal_axes

--- a/pyxem/signals/labeled_diffraction_vectors2d.py
+++ b/pyxem/signals/labeled_diffraction_vectors2d.py
@@ -222,6 +222,7 @@ class LabeledDiffractionVectors2D(DiffractionVectors2D):
         print(f"{np.max(labels) + 1} : Clusters Found!")
         vectors_and_labels = np.hstack([self.data, new_labels[:, np.newaxis]])
         new_signal = self._deepcopy_with_new_data(data=vectors_and_labels)
+        new_signal.ragged = False  # Need to reset this (Remove once hyperspy checks for object --> ragged)
         new_signal.axes_manager.signal_axes[0].size = (
             new_signal.axes_manager.signal_axes[0].size + 1
         )

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -697,7 +697,7 @@ class TestSlicingVectors:
     def test_column(self, vectors, index):
         slic = vectors.ivec[index]
         for i in np.ndindex((2, 2)):
-            np.testing.assert_almost_equal(slic.data[i][:, 0], vectors.data[i][:, 0])
+            np.testing.assert_almost_equal(slic.data[i][:], vectors.data[i][:, 0])
 
     def test_column_error(self, vectors):
         with pytest.raises(ValueError):
@@ -721,8 +721,17 @@ class TestSlicingVectors:
         for i in np.ndindex((2, 2)):
             assert np.all(slic.data[i][:, 0] > 0.5)
 
+    def test_row_gt_none(self, vectors):
+        vectors = vectors.as_lazy()
+        col = vectors.ivec[0] > 101
+        assert vectors.data[0, 0].compute().shape == (20, 2)
+        slic = vectors.ivec[:, col]
+        for i in np.ndindex((2, 2)):
+            assert slic.data[i].compute().shape == (0, 2)
+
     def test_row_gte(self, vectors):
         col = vectors.ivec[0] >= 0.5
+        assert col.data[0, 0].shape == (20,)
         slic = vectors.ivec[:, col]
         for i in np.ndindex((2, 2)):
             assert np.all(slic.data[i][:, 0] >= 0.5)

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -407,6 +407,7 @@ class TestConvertVectors:
         )
         assert isinstance(vectors, DiffractionVectors2D)
         assert vectors.data.shape == (32, 4)
+        assert vectors.ragged == False
 
     def test_get_navigation_positions(self):
         test_data = np.empty((2, 3), dtype=object)
@@ -747,6 +748,15 @@ class TestSlicingVectors:
         sliced.compute()
         assert sliced.data[0, 0].shape == (0, 2)
         sliced.flatten_diffraction_vectors()
+
+    def test_ragged_vectors(self, vectors):
+        vectors = vectors.as_lazy()
+        assert vectors.ragged == True
+
+    def test_inav_slicing(self, vectors):
+        slic = vectors.inav[0, 0]
+        assert isinstance(slic, DiffractionVectors)
+        assert slic.data.shape == (1,)
 
     def test_num_columns(self, vectors):
         assert vectors.num_columns == 2

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -696,7 +696,7 @@ class TestSlicingVectors:
     def test_center(self, vectors):
         np.testing.assert_almost_equal(vectors.center, (100, 100))
 
-    @pytest.mark.parametrize("index", (0, "x", ("x",)))
+    @pytest.mark.parametrize("index", (0, "x_axis", ("x_axis",)))
     def test_column(self, vectors, index):
         slic = vectors.ivec[index]
         for i in np.ndindex((2, 2)):
@@ -706,7 +706,7 @@ class TestSlicingVectors:
         with pytest.raises(ValueError):
             vectors.ivec[5.5]
 
-    @pytest.mark.parametrize("index", ([0, 1], ["x", "y"]))
+    @pytest.mark.parametrize("index", ([0, 1], ["x_axis", "y_axis"]))
     def test_column_slicing2(self, vectors, index):
         slic = vectors.ivec[index]
         for i in np.ndindex((2, 2)):

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -736,6 +736,18 @@ class TestSlicingVectors:
         with pytest.raises(ValueError):
             vectors.ivec[0, 0, 0]
 
+    def test_slicing(self, vectors):
+        sliced = vectors.ivec[:, vectors.ivec[0] > 101]
+        assert sliced.data[0, 0].shape == (0, 2)
+
+    def test_slicing_lazy(self, vectors):
+        vectors = vectors.as_lazy()
+        sliced = vectors.ivec[:, vectors.ivec[0] > 101]
+        sliced = sliced.ivec[:, sliced.ivec[0] > 101]
+        sliced.compute()
+        assert sliced.data[0, 0].shape == (0, 2)
+        sliced.flatten_diffraction_vectors()
+
     def test_num_columns(self, vectors):
         assert vectors.num_columns == 2
         lazy_vectors = vectors.as_lazy()

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -681,7 +681,10 @@ class TestSlicingVectors:
         vectors[1, 0] = np.random.randint(-100, 100, (7, 2))
         vectors[1, 1] = np.random.randint(-100, 100, (8, 2))
         v = DiffractionVectors(
-            vectors, scales=[0.1, 0.2], offsets=[10, 20], column_names=["x", "y"]
+            vectors,
+            scales=[0.1, 0.2],
+            offsets=[10, 20],
+            column_names=["x_axis", "y_axis"],
         )
 
         return v
@@ -708,6 +711,13 @@ class TestSlicingVectors:
         slic = vectors.ivec[index]
         for i in np.ndindex((2, 2)):
             np.testing.assert_almost_equal(slic.data[i][:, [0, 1]], vectors.data[i])
+
+    @pytest.mark.parametrize("item", [0, "x_axis"])
+    def test_slice(self, vectors, item):
+        sliced = vectors.ivec[item]
+        assert sliced.column_names == [
+            "x_axis",
+        ]
 
     def test_row_lt(self, vectors):
         col = vectors.ivec[0] < 0.5

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -419,10 +419,10 @@ class TestConvertVectors:
         dv.axes_manager[1].scale = 2
         dv.axes_manager[0].offset = 1
         flat = dv._get_navigation_positions(flatten=False, real_units=True)
-        np.testing.assert_array_equal(flat[0, 0, 0], 1)
-        np.testing.assert_array_equal(flat[0, 0, 1], 0)
+        np.testing.assert_array_equal(flat[0, 0, 0], 0)
+        np.testing.assert_array_equal(flat[0, 0, 1], 1)
         np.testing.assert_array_equal(flat[0, 1, 1], 2)
-        np.testing.assert_array_equal(flat[0, 1, 0], 1)
+        np.testing.assert_array_equal(flat[0, 1, 0], 0)
 
     def test_flatten_vectors_with_scales(self):
         test_data = np.empty((2, 3, 4), dtype=object)

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -679,7 +679,7 @@ class TestSlicingVectors:
         vectors[0, 0] = np.random.randint(-100, 100, (20, 2))
         vectors[0, 1] = np.random.randint(-100, 100, (6, 2))
         vectors[1, 0] = np.random.randint(-100, 100, (7, 2))
-        vectors[1, 1] = np.random.randint(-100, 100, (8, 2))
+        vectors[1, 1] = np.random.randint(-100, 100, (1, 2))
         v = DiffractionVectors(
             vectors,
             scales=[0.1, 0.2],

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -409,6 +409,10 @@ class TestConvertVectors:
         assert vectors.data.shape == (32, 4)
         assert vectors.ragged == False
 
+    def test_flatten_vectors1d(self, diffraction_vectors_map):
+        oned_vectors = diffraction_vectors_map.ivec[0]
+        vectors = oned_vectors.flatten_diffraction_vectors()
+
     def test_get_navigation_positions(self):
         test_data = np.empty((2, 3), dtype=object)
         for i in np.ndindex(test_data.shape):
@@ -759,6 +763,10 @@ class TestSlicingVectors:
     def test_slicing(self, vectors):
         sliced = vectors.ivec[:, vectors.ivec[0] > 101]
         assert sliced.data[0, 0].shape == (0, 2)
+
+    def test_slicing_first(self, vectors):
+        with pytest.raises(ValueError):
+            sliced = vectors.ivec[:, 0]
 
     def test_slicing_lazy(self, vectors):
         vectors = vectors.as_lazy()

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -442,12 +442,21 @@ class TestConvertVectors:
         assert flat.column_names[0] == "x"
         assert flat.column_names[1] == "y"
         assert flat.column_names[2] == "time"
-        assert np.max(flat.data[:, 0]) == dv.axes_manager[2].size
-        assert np.max(flat.data[:, 1]) == dv.axes_manager[1].size * 2
-        assert np.max(flat.data[:, 2]) == dv.axes_manager[0].size * 3
-        assert np.min(flat.data[:, 0]) == 1
-        assert np.min(flat.data[:, 1]) == 2
-        assert np.min(flat.data[:, 2]) == 3
+        assert (
+            np.max(flat.data[:, 0])
+            == dv.axes_manager[0].size * dv.axes_manager[0].scale
+        )
+        assert (
+            np.max(flat.data[:, 1])
+            == dv.axes_manager[1].size * dv.axes_manager[1].scale
+        )
+        assert (
+            np.max(flat.data[:, 2])
+            == dv.axes_manager[2].size * dv.axes_manager[2].scale
+        )
+        assert np.min(flat.data[:, 0]) == dv.axes_manager[0].offset
+        assert np.min(flat.data[:, 1]) == dv.axes_manager[1].offset
+        assert np.min(flat.data[:, 2]) == dv.axes_manager[2].offset
 
     def test_flatten_vectors_with_set_metadata(self, diffraction_vectors_map):
         diffraction_vectors_map.scales = [0.1, 0.1]

--- a/pyxem/tests/signals/test_diffraction_vectors2d.py
+++ b/pyxem/tests/signals/test_diffraction_vectors2d.py
@@ -21,10 +21,10 @@ import pytest
 import numpy as np
 from sklearn.cluster import DBSCAN
 
-from hyperspy.signals import Signal2D, BaseSignal
+from hyperspy.signals import Signal2D, BaseSignal, Signal1D
 import hyperspy.api as hs
 
-from pyxem.signals import DiffractionVectors2D
+from pyxem.signals import DiffractionVectors2D, DiffractionVectors1D
 
 
 class TestDiffractionVectors2D:
@@ -117,10 +117,10 @@ class TestVector2DSubclass:
     @pytest.mark.parametrize("item", [0, "x"])
     def test_slice(self, vectors, item):
         sliced = vectors.ivec[item]
-        assert isinstance(sliced, DiffractionVectors2D)
-        assert isinstance(sliced, Signal2D)
-        assert sliced.axes_manager.signal_shape == (1, 20)
-        assert sliced.column_names == ["x"]
+        assert isinstance(sliced, DiffractionVectors1D)
+        assert isinstance(sliced, Signal1D)
+        assert sliced.axes_manager.signal_shape == (20,)
+        assert sliced.column_names == "x"
 
     def test_flatten(self, vectors):
         flatten_diffraction_vectors = vectors.flatten_diffraction_vectors()

--- a/pyxem/tests/signals/test_diffraction_vectors2d.py
+++ b/pyxem/tests/signals/test_diffraction_vectors2d.py
@@ -88,6 +88,11 @@ class TestSingleDiffractionVectors2D:
         assert clustered.ivec["cluster"].data.shape[0] == 8
         assert isinstance(clustered, DiffractionVectors2D)
 
+    def test_slice(self):
+        slic = self.vector.ivec[:, self.vector.ivec[1] > 0]
+        assert slic.data.shape[0] == 5
+        assert slic.data.shape[1] == 2
+
 
 class TestVector2DSubclass:
     @pytest.fixture()

--- a/pyxem/tests/signals/test_diffraction_vectors2d.py
+++ b/pyxem/tests/signals/test_diffraction_vectors2d.py
@@ -34,16 +34,18 @@ class TestDiffractionVectors2D:
 
     def test_setup(self):
         assert isinstance(self.vector, DiffractionVectors2D)
+        assert self.vector.ragged == False
 
     def test_magnitudes(self):
         magnitudes = self.vector.get_magnitudes()
-        mags = np.linalg.norm(self.vector, axis=1)
+        assert magnitudes.ragged == False
+        mags = np.linalg.norm(self.vector.data[:, [0, 1]], axis=1)
         np.testing.assert_array_almost_equal(mags, magnitudes.data)
         assert len(magnitudes.axes_manager.signal_axes) == 1
 
     def test_filter_magnitudes(self):
         magnitudes = self.vector.filter_magnitude(min_magnitude=10, max_magnitude=40)
-        mags = np.linalg.norm(self.vector, axis=1)
+        mags = np.linalg.norm(self.vector.data[:, [0, 1]], axis=1)
         num_in_range = np.sum((mags > 10) * (mags < 40))
         assert num_in_range == magnitudes.data.shape[0]
 

--- a/pyxem/tests/utils/test_vector_utils.py
+++ b/pyxem/tests/utils/test_vector_utils.py
@@ -137,9 +137,9 @@ def test_get_angle_cartesian_vec_input_validation():
 
 
 def test_filter_near_basis():
-    basis_vectors = np.random.randint(0, 100, (10, 2))
-
-    shifts = np.random.rand(10, 2)
+    rng = np.random.default_rng(10)
+    basis_vectors = rng.integers(0, 100, (10, 2))
+    shifts = rng.random((10, 2))
     dist = np.linalg.norm(shifts, axis=1)
     shifted = basis_vectors + shifts
     filt = filter_vectors_near_basis(shifted, basis_vectors, distance=0.4)

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -20,6 +20,12 @@ import numpy as np
 
 
 def slice_signal(arr, col_slice, row_slice):
+    if (
+        hasattr(row_slice, "ndim") and row_slice.ndim == 0
+    ):  # Dealing with possible 0 d array
+        row_slice = [
+            row_slice,
+        ]
     return arr[row_slice, col_slice]
 
 
@@ -64,7 +70,6 @@ class Slicer:
             slic.column_names = np.array(self.signal.column_names)[col_slice]
         if self.signal.units is not None:
             slic.units = np.array(self.signal.units)[col_slice]
-            print(slic.units)
         return slic
 
     def str2slice(self, item):

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -47,7 +47,7 @@ class Slicer:
             col_slice = [
                 col_slice,
             ]
-        if self.signal._is_object_dtype:
+        if self.signal.ragged:
             kwargs = dict(output_signal_size=(), output_dtype=object)
         else:
             kwargs = dict()
@@ -57,7 +57,7 @@ class Slicer:
             col_slice=col_slice,
             row_slice=row_slice,
             inplace=False,
-            ragged=self.signal._is_object_dtype,
+            ragged=self.signal.ragged,
             **kwargs
         )
         if (

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -47,12 +47,18 @@ class Slicer:
             col_slice = [
                 col_slice,
             ]
+        if self.signal._is_object_dtype:
+            kwargs = dict(output_signal_size=(), output_dtype=object)
+        else:
+            kwargs = dict()
+
         slic = self.signal.map(
             slice_signal,
             col_slice=col_slice,
             row_slice=row_slice,
             inplace=False,
             ragged=self.signal._is_object_dtype,
+            **kwargs
         )
         if (
             not self.signal._is_object_dtype

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -43,10 +43,6 @@ class Slicer:
         else:
             col_slice = self.str2slice(item)
             row_slice = slice(None)
-        if isinstance(col_slice, int):
-            col_slice = [
-                col_slice,
-            ]
         if self.signal.ragged:
             kwargs = dict(output_signal_size=(), output_dtype=object)
         else:
@@ -60,12 +56,6 @@ class Slicer:
             ragged=self.signal.ragged,
             **kwargs
         )
-        if (
-            not self.signal._is_object_dtype
-            and not isinstance(col_slice, slice)
-            and len(col_slice) == 1
-        ):  # potential bug upstream
-            slic.data = slic.data[..., np.newaxis]
         if self.signal.scales is not None:
             slic.scales = np.array(self.signal.scales)[col_slice]
         if self.signal.offsets is not None:

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -72,7 +72,7 @@ class Slicer:
 
     def str2slice(self, item):
         if isinstance(item, str):
-            item = self.signal.column_names.index(item)
+            item = list(self.signal.column_names).index(item)
         elif isinstance(item, (np.ndarray, list)):
             item = np.array([self.str2slice(i) for i in item])
         elif isinstance(item, (slice, int)):

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -55,7 +55,9 @@ class Slicer:
             ragged=self.signal._is_object_dtype,
         )
         if (
-            not self.signal._is_object_dtype and len(col_slice) == 1
+            not self.signal._is_object_dtype
+            and not isinstance(col_slice, slice)
+            and len(col_slice) == 1
         ):  # potential bug upstream
             slic.data = slic.data[..., np.newaxis]
         if self.signal.scales is not None:

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -17,6 +17,7 @@
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+from hyperspy.signal import BaseSignal
 
 
 def slice_signal(arr, col_slice, row_slice):
@@ -39,7 +40,7 @@ class Slicer:
         if isinstance(item, tuple):  # multiple dimensions
             if len(item) == 0 or len(item) > 2:
                 raise ValueError(
-                    "Only column and row slicing 2-D arrays is currenlty supported"
+                    "Only column and row slicing 2-D arrays is currently supported"
                 )
             col_slice = self.str2slice(item[0])
             if len(item) == 2:
@@ -51,6 +52,11 @@ class Slicer:
             row_slice = slice(None)
         if self.signal.ragged:
             kwargs = dict(output_signal_size=(), output_dtype=object)
+            if not isinstance(row_slice, slice):
+                if not isinstance(row_slice, BaseSignal) or not row_slice.ragged:
+                    raise ValueError(
+                        "Only ragged boolean indexing is currently supported for ragged signals"
+                    )
         else:
             kwargs = dict()
 

--- a/pyxem/utils/_slicers.py
+++ b/pyxem/utils/_slicers.py
@@ -64,6 +64,7 @@ class Slicer:
             slic.column_names = np.array(self.signal.column_names)[col_slice]
         if self.signal.units is not None:
             slic.units = np.array(self.signal.units)[col_slice]
+            print(slic.units)
         return slic
 
     def str2slice(self, item):

--- a/pyxem/utils/ransac_ellipse_tools.py
+++ b/pyxem/utils/ransac_ellipse_tools.py
@@ -540,19 +540,19 @@ def ellipse_to_markers(ellipse_array, points=None, inlier=None):
         widths = np.empty(ellipse_array.shape, dtype=object)
         angles = np.empty(ellipse_array.shape, dtype=object)
         for i in np.ndindex(ellipse_array.shape):
-            offsets[i] = ellipse_array[i][:2]
-            heights[i] = ellipse_array[i][3] * 2
-            widths[i] = ellipse_array[i][2] * 2
-            angles[i] = np.rad2deg(ellipse_array[i][4])
+            offsets[i] = ellipse_array[i][:2][::-1]
+            heights[i] = ellipse_array[i][2] * 2
+            widths[i] = ellipse_array[i][3] * 2
+            angles[i] = np.rad2deg(-ellipse_array[i][4])
     else:
         offsets = np.array(
             [
-                ellipse_array[:2],
+                ellipse_array[:2][::-1],
             ]
         )
-        heights = ellipse_array[3] * 2
-        widths = ellipse_array[2] * 2
-        angles = np.rad2deg(ellipse_array[4])
+        heights = ellipse_array[2] * 2
+        widths = ellipse_array[3] * 2
+        angles = np.rad2deg(-ellipse_array[4])
 
     el = hs.plot.markers.Ellipses(
         offsets=offsets,
@@ -566,14 +566,18 @@ def ellipse_to_markers(ellipse_array, points=None, inlier=None):
 
     if points is not None and inlier is not None:
         in_points = hs.plot.markers.Points(
-            offsets=mask_peak_array(points, inlier), color="green"
+            offsets=mask_peak_array(points[:, ::-1], inlier), color="green"
         )
         out_points = hs.plot.markers.Points(
-            offsets=mask_peak_array(points, inlier, invert=True), color="red", alpha=0.5
+            offsets=mask_peak_array(points[:, ::-1], inlier, invert=True),
+            color="red",
+            alpha=0.5,
         )
         return el, in_points, out_points
     elif points is not None:
-        points = hs.plot.markers.Points(offsets=points, color="green", alpha=0.5)
+        points = hs.plot.markers.Points(
+            offsets=points[:, ::-1], color="green", alpha=0.5
+        )
         return el, points
     else:
         return el


### PR DESCRIPTION
---
name: Flatten Diffraction Vector Bugfix
about: Fixes a bug when flattening diffraction vectors

---

**Checklist**
- [x] Updated CHANGELOG.md
- [x] Marked as finished

**What does this PR do? Please describe and/or link to an open issue.**
There was a bug for flattening diffraction vectors when the scales/number of axes was wrong.  This causes problems with 5D datasets. 