### PR TITLE
Deprecating CalibrationDataLibrary and our Pyfai detectors modules

### DIFF
--- a/pyxem/detectors/generic_flat_detector.py
+++ b/pyxem/detectors/generic_flat_detector.py
@@ -23,7 +23,7 @@ operations using the pyFAI AzimuthalIntegrator for a
 """
 
 from pyFAI.detectors import Detector
-
+from pyxem.utils._deprecated import deprecated
 
 class GenericFlatDetector(Detector):
     """
@@ -57,7 +57,8 @@ class GenericFlatDetector(Detector):
     IS_CONTIGUOUS = True  # No gaps: all pixels are adjacents
     API_VERSION = "1.0"
     aliases = ["GenericFlatDetector"]
-
+    
+    @deprecated(since='0.18.0', removal='0.20.0')
     def __init__(self, size_x, size_y):
         MAX_SHAPE = size_x, size_y
         Detector.__init__(self, pixel1=1, pixel2=1, max_shape=MAX_SHAPE)

--- a/pyxem/detectors/generic_flat_detector.py
+++ b/pyxem/detectors/generic_flat_detector.py
@@ -25,6 +25,7 @@ operations using the pyFAI AzimuthalIntegrator for a
 from pyFAI.detectors import Detector
 from pyxem.utils._deprecated import deprecated
 
+
 class GenericFlatDetector(Detector):
     """
     A PyFAI Detector class for an arbitrarily sized flat detector (i.e. the
@@ -57,8 +58,8 @@ class GenericFlatDetector(Detector):
     IS_CONTIGUOUS = True  # No gaps: all pixels are adjacents
     API_VERSION = "1.0"
     aliases = ["GenericFlatDetector"]
-    
-    @deprecated(since='0.18.0', removal='0.20.0')
+
+    @deprecated(since="0.18.0", removal="0.20.0")
     def __init__(self, size_x, size_y):
         MAX_SHAPE = size_x, size_y
         Detector.__init__(self, pixel1=1, pixel2=1, max_shape=MAX_SHAPE)

--- a/pyxem/detectors/medipix_256x256.py
+++ b/pyxem/detectors/medipix_256x256.py
@@ -46,7 +46,7 @@ class Medipix256x256Detector(Detector):
     aliases = ["Medipix256x256Detector"]
     MAX_SHAPE = 256, 256
 
-    @deprecated(since='0.18.0', removal='0.20.0')
+    @deprecated(since="0.18.0", removal="0.20.0")
     def __init__(self):
         pixel1 = 55e-6  # 55 micron pixel size in x
         pixel2 = 55e-6  # 55 micron pixel size in y

--- a/pyxem/detectors/medipix_256x256.py
+++ b/pyxem/detectors/medipix_256x256.py
@@ -22,6 +22,7 @@ and other similar operations using pyFAI azimuthalIntegrator.
 """
 
 from pyFAI.detectors import Detector
+from pyxem.utils._deprecated import deprecated
 
 
 class Medipix256x256Detector(Detector):
@@ -45,6 +46,7 @@ class Medipix256x256Detector(Detector):
     aliases = ["Medipix256x256Detector"]
     MAX_SHAPE = 256, 256
 
+    @deprecated(since='0.18.0', removal='0.20.0')
     def __init__(self):
         pixel1 = 55e-6  # 55 micron pixel size in x
         pixel2 = 55e-6  # 55 micron pixel size in y

--- a/pyxem/detectors/medipix_515x515.py
+++ b/pyxem/detectors/medipix_515x515.py
@@ -52,7 +52,7 @@ class Medipix515x515Detector(Detector):
     aliases = ["Medipix515x515Detector"]
     MAX_SHAPE = 515, 515
 
-    @deprecated(since='0.18.0', removal='0.20.0')
+    @deprecated(since="0.18.0", removal="0.20.0")
     def __init__(self):
         pixel1 = 55e-6  # 55 micron pixel size in x
         pixel2 = 55e-6  # 55 micron pixel size in y

--- a/pyxem/detectors/medipix_515x515.py
+++ b/pyxem/detectors/medipix_515x515.py
@@ -25,6 +25,7 @@ and the surrounding ones are "masked".
 
 from pyFAI.detectors import Detector
 import numpy as np
+from pyxem.utils._deprecated import deprecated
 
 
 class Medipix515x515Detector(Detector):
@@ -51,6 +52,7 @@ class Medipix515x515Detector(Detector):
     aliases = ["Medipix515x515Detector"]
     MAX_SHAPE = 515, 515
 
+    @deprecated(since='0.18.0', removal='0.20.0')
     def __init__(self):
         pixel1 = 55e-6  # 55 micron pixel size in x
         pixel2 = 55e-6  # 55 micron pixel size in y

--- a/pyxem/libraries/calibration_library.py
+++ b/pyxem/libraries/calibration_library.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
+from pyxem.utils._deprecated import deprecated
 
 class CalibrationDataLibrary(dict):
     """Maps crystal structure (phase) to diffraction vectors.
@@ -28,7 +29,7 @@ class CalibrationDataLibrary(dict):
         An image of an Au X-grating standard.
 
     """
-
+    @deprecated(since='0.18.0', removal='0.20.0')
     def __init__(
         self, au_x_grating_dp=None, au_x_grating_im=None, moo3_dp=None, moo3_im=None
     ):

--- a/pyxem/libraries/calibration_library.py
+++ b/pyxem/libraries/calibration_library.py
@@ -18,6 +18,7 @@
 
 from pyxem.utils._deprecated import deprecated
 
+
 class CalibrationDataLibrary(dict):
     """Maps crystal structure (phase) to diffraction vectors.
 
@@ -29,7 +30,8 @@ class CalibrationDataLibrary(dict):
         An image of an Au X-grating standard.
 
     """
-    @deprecated(since='0.18.0', removal='0.20.0')
+
+    @deprecated(since="0.18.0", removal="0.20.0")
     def __init__(
         self, au_x_grating_dp=None, au_x_grating_im=None, moo3_dp=None, moo3_im=None
     ):


### PR DESCRIPTION
---
name: Deprecating CalibrationDataLibrary and our Pyfai detectors modules

---

**Checklist**
- [ ] implement
- [ ] await merge of #1040
- [ ] update changelog
- [ ] merge

**What does this PR do? Please describe and/or link to an open issue.**
trivial, closes #1041 and #1042