### PR TITLE
Refactor: Directly allow find_peaks to return vectors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Added
   from a 4D STEM dataset (#1014)
 - Added GPU support for lazy signals. (#1012)
 - Added GPU processing for :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral2d` (#1012)
+- Added :meth:`pyxem.signals.Diffraction2D.get_diffraction_vectors` to directly return the diffraction vectors (#1053)
 - Added method for calibrating the detector gain (#1046)
 - Added :meth:`pyxem.signals.PolarDiffraction2D.subtract_diffraction_background` for polar-specific background subtraction (#1062)
 

--- a/examples/processing/vector_finding.py
+++ b/examples/processing/vector_finding.py
@@ -14,7 +14,7 @@ import hyperspy.api as hs
 s = pxm.data.tilt_boundary_data()
 # %%
 
-s.find_peaks(iteractive=True)  # find the peaks using the interactive peak finder
+s.find_peaks(interactive=True)  # find the peaks using the interactive peak finder
 
 # %%
 

--- a/examples/processing/vector_finding.py
+++ b/examples/processing/vector_finding.py
@@ -40,30 +40,29 @@ hs.plot.plot_images(
     label=["Too Small", "Just Right", "Too Large"],
 )
 
-pks = temp.find_peaks(interactive=False, threshold_abs=0.4, min_distance=5)
+vectors = temp.get_diffraction_vectors(threshold_abs=0.4, min_distance=5)
+
 # %%
-"""
-Plotting Peaks
-==============
-We can plot the peaks using hyperSpy's markers and DiffractionVectors.
-"""
-vectors = pxm.signals.DiffractionVectors.from_peaks(
-    pks
-)  # calibration is automatically set
+
+# Plotting Peaks
+# ==============
+# We can plot the peaks using hyperSpy's markers and DiffractionVectors.
+
 s.plot()
-
 s.add_marker(vectors.to_markers(color="red", sizes=10, alpha=0.5))
-"""
-Subpixel Peak Fitting
-=====================
 
-The template matching is done on the pixel grid.  To find the peak position more accurately the correlation
-can be up-sampled using the :func:`pyxem.signals.DiffractionVectors.subpixel_refine` method.  This method takes a
-`DiffractionSignal2D` object and uses that to refine the peak positions.
+# %%
 
-This only really works up to up-sampling of 2-4. There is little improvement with increased up-sampling while 
-it greatly increases the computation time. 
-"""
+# Subpixel Peak Fitting
+# =====================
+
+# The template matching is done on the pixel grid.  To find the peak position more accurately the correlation
+# can be up-sampled using the :func:`pyxem.signals.DiffractionVectors.subpixel_refine` method.  This method takes a
+# `DiffractionSignal2D` object and uses that to refine the peak positions.
+#
+# This only really works up to up-sampling of 2-4. There is little improvement with increased up-sampling while
+# it greatly increases the computation time.
+
 refined_peaks_com = vectors.subpixel_refine(s, "center-of-mass", square_size=20)
 refined_peaks_xc = vectors.subpixel_refine(
     s, "cross-correlation", square_size=20, upsample_factor=2, disk_r=5
@@ -79,3 +78,5 @@ s.add_marker(markers2)
 s.add_marker(markers3)
 
 # %%
+
+# sphinx_gallery_thumbnail_number = 3

--- a/examples/vectors/clustering_vectors.py
+++ b/examples/vectors/clustering_vectors.py
@@ -17,12 +17,7 @@ s = pxm.data.mgo_nanocrystals()
 s.data[s.data < 120] = 1
 s.filter(gaussian_filter, sigma=(0.5, 0.5, 0, 0), inplace=True)  # only in real space
 s.template_match_disk(disk_r=3, subtract_min=False, inplace=True)
-pks = s.find_peaks(
-    interactive=False, threshold_abs=0.5, min_distance=3, get_intensity=True
-)
-vectors = pxm.signals.DiffractionVectors.from_peaks(
-    pks
-)  # calibration is automatically set
+vectors = s.get_diffraction_vectors(threshold_abs=0.5, min_distance=3)
 
 # Now we can convert the vectors into a 2D array of rows/columns
 flat_vectors = (

--- a/examples/vectors/glass_symmetry.py
+++ b/examples/vectors/glass_symmetry.py
@@ -22,12 +22,8 @@ s.axes_manager.signal_axes[1].offset = -19.3
 
 s.filter(gaussian_filter, sigma=(1, 1, 0, 0), inplace=True)  # only in real space
 s.template_match_disk(disk_r=5, subtract_min=False, inplace=True)
-pks = s.find_peaks(
-    interactive=False, threshold_abs=0.5, min_distance=3, get_intensity=True
-)
-vectors = pxm.signals.DiffractionVectors.from_peaks(
-    pks
-)  # calibration is automatically set
+
+vectors = s.get_diffraction_vectors(threshold_abs=0.5, min_distance=3)
 
 # Now we can convert to polar vectors
 pol = vectors.to_polar()

--- a/examples/vectors/slicing_vectors.py
+++ b/examples/vectors/slicing_vectors.py
@@ -17,12 +17,8 @@ hs.set_log_level("ERROR")
 
 s = pxm.data.tilt_boundary_data()
 temp = s.template_match_disk(disk_r=5, subtract_min=False)
-pks = temp.find_peaks(
-    interactive=False, threshold_abs=0.4, min_distance=5, get_intensity=True
-)
-vectors = pxm.signals.DiffractionVectors.from_peaks(
-    pks
-)  # calibration is automatically set
+
+vectors = s.get_diffraction_vectors(threshold_abs=0.4, min_distance=5)
 
 # Plotting all the vectors
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1262,10 +1262,10 @@ class Diffraction2D(CommonDiffraction, Signal2D):
                 vectors,
                 center=center,
                 calibration=calibration,
-                column_names=None,
-                units=None,
+                column_names=column_names,
+                units=units,
             )
-
+            return vectors
         else:
             return super().find_peaks(interactive=interactive, **kwargs)
 

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1218,6 +1218,57 @@ class Diffraction2D(CommonDiffraction, Signal2D):
             **kwargs,
         )
 
+    def find_peaks(
+        self,
+        return_vectors=False,
+        interactive=False,
+        center=None,
+        calibration=None,
+        column_names=None,
+        units=None,
+        **kwargs,
+    ):
+        """Find vectors from the diffraction pattern. Wraps `hyperspy.api.signals.Signal2D.find_peaks`
+
+        Parameters
+        ----------
+        return_vectors : bool
+            If True, will return a DiffractionVectors object. If False,
+            returns a BaseSignal object.
+        interactive : bool
+            If True, will use the interactive peak finding tool to help find
+            the peaks.
+        center: None or tuple
+            The center of the diffraction pattern, if None, will use the
+            center determined by the offsets in the signal axes
+        calibration: None or tuple
+            The calibration of the diffraction pattern, if None, will use the
+            scales in the signal axes
+        column_names: None or tuple
+            The column names of the vectors, if None, will use the names
+            of the signal axes
+        units: None or tuple
+            The units of the vectors, if None, will use the units of the
+            signal axes
+        kwargs:
+            Passed to the peak finding function.
+        """
+        if return_vectors:
+            from pyxem.signals import DiffractionVectors
+
+            interactive = False
+            vectors = super().find_peaks(interactive=interactive, **kwargs)
+            vectors = DiffractionVectors.from_peaks(
+                vectors,
+                center=center,
+                calibration=calibration,
+                column_names=None,
+                units=None,
+            )
+
+        else:
+            return super().find_peaks(interactive=interactive, **kwargs)
+
     def peak_position_refinement_com(
         self, peak_array, square_size=10, lazy_result=True, show_progressbar=True
     ):

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1231,12 +1231,6 @@ class Diffraction2D(CommonDiffraction, Signal2D):
 
         Parameters
         ----------
-        return_vectors : bool
-            If True, will return a DiffractionVectors object. If False,
-            returns a BaseSignal object.
-        interactive : bool
-            If True, will use the interactive peak finding tool to help find
-            the peaks.
         center: None or tuple
             The center of the diffraction pattern, if None, will use the
             center determined by the offsets in the signal axes
@@ -1249,6 +1243,9 @@ class Diffraction2D(CommonDiffraction, Signal2D):
         units: None or tuple
             The units of the vectors, if None, will use the units of the
             signal axes
+        get_intensity: bool
+            If True, will return the intensity of the peaks as well as the
+            intensity of the peaks. Default True.
         kwargs:
             Passed to the peak finding function.
         """

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -1218,14 +1218,13 @@ class Diffraction2D(CommonDiffraction, Signal2D):
             **kwargs,
         )
 
-    def find_peaks(
+    def get_diffraction_vectors(
         self,
-        return_vectors=False,
-        interactive=False,
         center=None,
         calibration=None,
         column_names=None,
         units=None,
+        get_intensity=True,
         **kwargs,
     ):
         """Find vectors from the diffraction pattern. Wraps `hyperspy.api.signals.Signal2D.find_peaks`
@@ -1253,21 +1252,19 @@ class Diffraction2D(CommonDiffraction, Signal2D):
         kwargs:
             Passed to the peak finding function.
         """
-        if return_vectors:
-            from pyxem.signals import DiffractionVectors
+        from pyxem.signals import DiffractionVectors
 
-            interactive = False
-            vectors = super().find_peaks(interactive=interactive, **kwargs)
-            vectors = DiffractionVectors.from_peaks(
-                vectors,
-                center=center,
-                calibration=calibration,
-                column_names=column_names,
-                units=units,
-            )
-            return vectors
-        else:
-            return super().find_peaks(interactive=interactive, **kwargs)
+        vectors = super().find_peaks(
+            interactive=False, get_intensity=get_intensity, **kwargs
+        )
+        vectors = DiffractionVectors.from_peaks(
+            vectors,
+            center=center,
+            calibration=calibration,
+            column_names=column_names,
+            units=units,
+        )
+        return vectors
 
     def peak_position_refinement_com(
         self, peak_array, square_size=10, lazy_result=True, show_progressbar=True

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -227,7 +227,7 @@ class DiffractionVectors(BaseSignal):
             column_names = ["x", "y"]
 
         if units is None and peaks.metadata.has_item("Peaks.signal_axes"):
-            units = [ax.units for ax in peaks.metadata.Peaks.signal_axes[::-1]]
+            units = [str(ax.units) for ax in peaks.metadata.Peaks.signal_axes[::-1]]
         elif units is not None:
             pass
         else:

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pyXem.  If not, see <http://www.gnu.org/licenses/>.
 
-from functools import cached_property
+from functools import cached_property, partial
 from warnings import warn
 
 import numpy as np
@@ -50,6 +50,7 @@ from pyxem.utils._subpixel_finding import (
     _conventional_xc_map,
     _center_of_mass_map,
     _get_simulated_disc,
+    _wrap_columns,
 )
 
 from pyxem.utils._deprecated import deprecated
@@ -344,8 +345,11 @@ class DiffractionVectors(BaseSignal):
             square_size=square_size,
             columns=columns,
         )
+        method_func = partial(_wrap_columns, f=funct, columns=columns)
+
+        _wrap_columns
         refined_vectors = signal.map(
-            funct,
+            method_func,
             vectors=pixels,
             inplace=False,
             ragged=True,

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -30,6 +30,7 @@ from pyxem.signals import (
     Diffraction2D,
     LazyDiffraction2D,
     PolarDiffraction2D,
+    DiffractionVectors,
 )
 
 
@@ -1070,6 +1071,34 @@ class TestCenterDirectBeam:
         s = self.s
         with pytest.raises(ValueError):
             s.center_direct_beam()
+
+
+class TestFindVectors:
+    def setup_method(self):
+        data = np.zeros((8, 6, 20, 16), dtype=np.int16)
+        x_pos_list = np.random.randint(8 - 2, 8 + 2, 6, dtype=np.int16)
+        x_pos_list[x_pos_list == 8] = 9
+        y_pos_list = np.random.randint(10 - 2, 10 + 2, 8, dtype=np.int16)
+        for ix in range(len(x_pos_list)):
+            for iy in range(len(y_pos_list)):
+                data[iy, ix, y_pos_list[iy], x_pos_list[ix]] = 9
+        s = Diffraction2D(data)
+        s.axes_manager[0].scale = 0.5
+        s.axes_manager[1].scale = 0.6
+        s.axes_manager[2].scale = 3
+        s.axes_manager[3].scale = 4
+        s_lazy = s.as_lazy()
+        self.s = s
+        self.s_lazy = s_lazy
+        self.x_pos_list = x_pos_list
+        self.y_pos_list = y_pos_list
+
+    def test_find_vectors(self):
+        s = self.s
+        vectors = s.get_diffraction_vectors()
+        assert isinstance(vectors, DiffractionVectors)
+        assert vectors.column_names == ["<undefined>", "<undefined>", "intensity"]
+        assert vectors.units == ["<undefined>", "<undefined>", "a.u."]
 
 
 class TestSubtractingDiffractionBackground:

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -279,6 +279,21 @@ class TestInitVectors:
         for i in np.ndindex((2, 2)):
             np.testing.assert_almost_equal(peaks.data[i], pixels.data[i])
 
+    def test_peaks_with_intensity(self, peaks_w_intensity):
+        peaks_w_intensity.metadata.add_node("Peaks.signal_axes")
+        peaks_w_intensity.metadata.Peaks.signal_axes = (
+            UniformDataAxis(scale=0.1, offset=-5.0, units="nm"),
+            UniformDataAxis(scale=0.1, offset=-5.0, units="nm"),
+        )
+        dv = DiffractionVectors.from_peaks(
+            peaks_w_intensity,
+            center=None,
+            calibration=None,
+        )
+        pixels = dv.pixel_vectors
+        for i in np.ndindex((2, 2)):
+            np.testing.assert_almost_equal(peaks_w_intensity.data[i], pixels.data[i])
+
     def test_initial_metadata(self, diffraction_vectors_map):
         assert diffraction_vectors_map.scales is None
         assert diffraction_vectors_map.metadata.VectorMetadata["scales"] == None

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -375,7 +375,8 @@ class TestSubpixelRefinement:
         cen = _conventional_xc(sq, kernel, upsample_factor=1)
         assert np.allclose(np.array(cen), (-2.0, 0.0))
 
-    def test_subpixel_refinement_com(self):
+    @pytest.mark.parametrize("intensity", (True, False))
+    def test_subpixel_refinement_com(self, intensity):
         import pyxem.data.dummy_data.make_diffraction_test_data as mdtd
         import pyxem as pxm
         import numpy as np
@@ -390,11 +391,17 @@ class TestSubpixelRefinement:
         dtd.add_diffraction_image(di)
         s = dtd.get_signal()
         temp = s.template_match_disk(disk_r=5, subtract_min=False)
-        pks = temp.find_peaks(threshold_abs=0.4, interactive=False)
-        dv = pxm.signals.DiffractionVectors.from_peaks(pks)
+        dv = temp.get_diffraction_vectors(
+            threshold_abs=0.4, min_distance=5, get_intensity=intensity
+        )
         dv.subpixel_refine(s, method="center-of-mass")
+        if intensity:
+            assert dv.data[0, 0].shape[1] == 3
+        else:
+            assert dv.data[0, 0].shape[1] == 2
 
-    def test_subpixel_refinement_xc(self):
+    @pytest.mark.parametrize("intensity", (True, False))
+    def test_subpixel_refinement_xc(self, intensity):
         import pyxem.data.dummy_data.make_diffraction_test_data as mdtd
         import pyxem as pxm
         import numpy as np
@@ -409,9 +416,14 @@ class TestSubpixelRefinement:
         dtd.add_diffraction_image(di)
         s = dtd.get_signal()
         temp = s.template_match_disk(disk_r=5, subtract_min=False)
-        pks = temp.find_peaks(threshold_abs=0.4, interactive=False)
-        dv = pxm.signals.DiffractionVectors.from_peaks(pks)
+        dv = temp.get_diffraction_vectors(
+            threshold_abs=0.4, min_distance=5, get_intensity=intensity
+        )
         dv.subpixel_refine(s, method="cross-correlation", upsample_factor=2, disk_r=5)
+        if intensity:
+            assert dv.data[0, 0].shape[1] == 3
+        else:
+            assert dv.data[0, 0].shape[1] == 2
 
 
 class TestConvertVectors:

--- a/pyxem/utils/_subpixel_finding.py
+++ b/pyxem/utils/_subpixel_finding.py
@@ -164,9 +164,16 @@ def _center_of_mass_map(dp, vectors, square_size, offsets, scales):
 
 
 def _conventional_xc_map(
-    dp, vectors, kernel, square_size, upsample_factor, offsets, scales
+    dp,
+    vectors,
+    kernel,
+    square_size,
+    upsample_factor,
+    offsets,
+    scales,
+    columns,
 ):
-    shifts = np.zeros_like(vectors, dtype=np.float64)
+    shifts = np.zeros_like(vectors[columns], dtype=np.float64)
     for i, vector in enumerate(vectors):
         expt_disc = _get_experimental_square(dp, vector, square_size)
         shifts[i] = _conventional_xc(expt_disc, kernel, upsample_factor)


### PR DESCRIPTION
---
Refactor: Directly allow find_peaks to return vectors
---

This changes the defaults for the `find_peaks` function and directly allows you to return a `DiffractionVectors` object. 

For the 1.0.0 version I intend to have the default to be `return_vectors=True` which saves a couple of steps when creating diffraction vectors. 

**Checklist**

- [x] implementation steps
- [x] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
