### PR TITLE
Azimuthal integral off-by-one bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 - Documentation fixes and improvement. (#1028)
 - Fixed bug with flattening diffraction Vectors when there are different scales (#1024)
 - Fixed intersphinx links and improved api documentation (#1056)
+- Fix an off-by-one error in the :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral2d` (#1058)
 
 Added
 -----

--- a/examples/standards/README.rst
+++ b/examples/standards/README.rst
@@ -1,0 +1,3 @@
+Standards
+=========
+Below is a gallery of examples showing different standards in pyxem

--- a/examples/standards/pixel_coodinates.py
+++ b/examples/standards/pixel_coodinates.py
@@ -1,0 +1,65 @@
+"""
+====================
+Coordinates in Pyxem
+====================
+
+Pyxem is flexible in how it handles coordinates for a diffraction pattern.
+
+There are three main ways to handle coordinates in Pyxem:
+
+1. Pixel coordinates
+2. Calibrated Coordinates with evenly spaced axes
+3. Calibrated Coordinates with unevenly spaced axes (e.g. corrected for the Ewald sphere)
+"""
+
+import pyxem as pxm
+from skimage.morphology import disk
+
+
+s = pxm.signals.Diffraction2D(disk((10)))
+s.calibrate.center = None
+print(s.calibrate.center)
+
+# %%
+
+s.plot(axes_ticks=True)
+# %%
+
+# From the plot above you can see that hyperspy automatically sets the axes ticks to be centered
+# on each pixel. This means that for a 21x21 pixel image, the center is at (-10, -10) in pixel coordinates.
+# if we change the scale using the calibrate function it will automatically adjust the center.  Here it is
+# now (-1, -1)
+
+s.calibrate.scale = 0.1
+s.calibrate.units = "nm$^{-1}$"
+s.plot(axes_ticks=True)
+print(s.calibrate.center)
+
+
+# %%
+
+# Azimuthal Integration
+# ---------------------
+#
+# Now if we do integrate this dataset it will choose the appropriate center based on the center pixel.
+
+az = s.get_azimuthal_integral2d(npt=30)
+az.plot()
+
+# %%
+
+# Non-Linear Axes
+# ---------------
+#
+# Now consider the case where we have non-linear axes. In this case the center is still (10,10)
+# but things are streatched based on the effects of the Ewald Sphere.
+
+s.calibrate.beam_energy = 200
+s.calibrate.detector(pixel_size=0.1, detector_distance=3)
+print(s.calibrate.center)
+s.plot()
+
+az = s.get_azimuthal_integral2d(npt=30)
+az.plot()
+
+# %%

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -570,6 +570,42 @@ class TestAzimuthalIntegral2d:
         ring_sum = np.sum(az.data, axis=1)
         assert ring_sum.shape == (40,)
 
+    @pytest.mark.parametrize(
+        "corner",
+        [
+            (0, 0),
+            (0, -1),
+            (-1, 0),
+            (-1, -1),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (10, 10),  # Square
+            (4, 6),  # Even numbers
+            (5, 9),  # Odd numbers
+            (5, 10),  # Odd and even
+            (10, 5),  # Even and odd
+        ],
+    )
+    def test_internal_azimuthal_integration_data_range(self, corner, shape):
+        # Test that the edges of the cartesian data are included in the polar transform
+
+        max_val = 10
+        data = np.zeros(shape)
+        data[corner] = max_val
+
+        signal = Diffraction2D(data)
+
+        # Reality check
+        assert np.allclose(np.nanmax(signal.data), max_val)
+
+        # Use mean=True to conserve values
+        pol = signal.get_azimuthal_integral2d(npt=20, mean=True)
+
+        assert np.allclose(np.nanmax(pol.data), max_val)
+
 
 class TestPyFAIIntegration:
     @pytest.fixture

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -582,9 +582,10 @@ class TestAzimuthalIntegral2d:
     @pytest.mark.parametrize(
         "shape",
         [
-            (10, 10),  # Square
-            (4, 6),  # Even numbers
-            (5, 9),  # Odd numbers
+            (10, 10),  # Even square
+            (9, 9),  # Odd square
+            (4, 6),  # Even
+            (5, 9),  # Odd
             (5, 10),  # Odd and even
             (10, 5),  # Even and odd
         ],

--- a/pyxem/tests/utils/test_calibration_utils.py
+++ b/pyxem/tests/utils/test_calibration_utils.py
@@ -90,16 +90,20 @@ class TestCalibrationClass:
             calibration.detector(pixel_size=0.1, detector_distance=1)
         calibration.beam_energy = 200
         calibration.detector(pixel_size=0.1, detector_distance=1)
+        # The center, in pixel coordinates, is (4.5, 4.5)
+        # When using a detector, this gets rounded down to 4
+        assert calibration.center == [4, 4]
         calibration.detector(
             pixel_size=0.1, detector_distance=1, beam_energy=200, units="k_nm^-1"
         )
         assert calibration.flat_ewald is False
+        assert calibration.center == [4, 4]
         with pytest.raises(ValueError):
             calibration(scale=0.01)
         assert calibration.scale is None
         with pytest.raises(ValueError):
             calibration(center=(5, 5))
-        assert calibration.center == [5, 5]
+        assert calibration.center == [4, 4]
 
         with pytest.raises(ValueError):
             calibration.detector(pixel_size=0.1, detector_distance=1, units="nm^-1")

--- a/pyxem/utils/_azimuthal_integrations.py
+++ b/pyxem/utils/_azimuthal_integrations.py
@@ -199,6 +199,8 @@ def _get_factors(control_points, slices, axes):
     factors = []
     factors_slice = []
     start = 0
+    x_scale = axes[0][1] - axes[0][0]
+    y_scale = axes[1][1] - axes[1][0]
     for cp, sl in zip(control_points, slices):
         p = Polygon(cp)
         x_edges = list(range(sl[0], sl[2]))
@@ -206,7 +208,9 @@ def _get_factors(control_points, slices, axes):
         boxes = []
         for i, x in enumerate(x_edges):
             for j, y in enumerate(y_edges):
-                b = box(axes[0][x], axes[1][y], axes[0][x + 1], axes[1][y + 1])
+                b = box(
+                    axes[0][x], axes[1][y], axes[0][x] + x_scale, axes[1][y] + y_scale
+                )
                 boxes.append(b)
         factors += list(
             shapely.area(shapely.intersection(boxes, p)) / shapely.area(boxes)

--- a/pyxem/utils/_azimuthal_integrations.py
+++ b/pyxem/utils/_azimuthal_integrations.py
@@ -190,7 +190,7 @@ def _slice_radial_integrate1d(
     return ans
 
 
-def _get_factors(control_points, slices, axes):
+def _get_factors(control_points, slices, pixel_extents):
     """This function takes a set of control points (vertices of bounding polygons) and
     slices (min and max indices for each control point) and returns the factors for
     each slice. The factors are the area of the intersection of the polygon and the
@@ -199,8 +199,10 @@ def _get_factors(control_points, slices, axes):
     factors = []
     factors_slice = []
     start = 0
-    x_scale = axes[0][1] - axes[0][0]
-    y_scale = axes[1][1] - axes[1][0]
+    # unpack extents
+    x_extent, y_extent = pixel_extents
+    x_ext_left, x_ext_right = x_extent
+    y_ext_left, y_ext_right = y_extent
     for cp, sl in zip(control_points, slices):
         p = Polygon(cp)
         x_edges = list(range(sl[0], sl[2]))
@@ -209,7 +211,10 @@ def _get_factors(control_points, slices, axes):
         for i, x in enumerate(x_edges):
             for j, y in enumerate(y_edges):
                 b = box(
-                    axes[0][x], axes[1][y], axes[0][x] + x_scale, axes[1][y] + y_scale
+                    x_ext_left[x],
+                    y_ext_left[y],
+                    x_ext_right[x],
+                    y_ext_right[y],
                 )
                 boxes.append(b)
         factors += list(

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -249,12 +249,10 @@ class Calibration:
         y_ext_l = translate_pixel_coords(y_pixels - 0.5)
         y_ext_r = translate_pixel_coords(y_pixels + 0.5)
 
-        self._pixel_extent = np.array(
-            [
+        self._pixel_extent = [
                 np.stack((x_ext_l, x_ext_r)),
                 np.stack((y_ext_l, y_ext_r)),
             ]
-        )
 
         for ax, axis in zip(self.signal.axes_manager.signal_axes, [x_axes, y_axes]):
             if isinstance(ax, UniformDataAxis):
@@ -286,7 +284,7 @@ class Calibration:
         return [ax.axis for ax in self.signal.axes_manager.signal_axes][::-1]
 
     @property
-    def pixel_extent(self) -> list[np.ndarray, np.ndarray]:
+    def pixel_extent(self):
         """Return an array with axes [x/y, left/right, pixel_extent], as follows:
         [
             # x axis

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -305,10 +305,9 @@ class Calibration:
         """
         if self.flat_ewald:
             extents = []
-            for ax in self.axes:
-                pixel_size = ax[1] - ax[0]
-                left = ax - pixel_size / 2
-                right = ax + pixel_size / 2
+            for ax, scale in zip(self.axes,  self.scale):
+                left = ax - scale / 2
+                right = ax + scale / 2
                 extent = np.stack((left, right))
                 extents.append(extent)
             return extents

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -482,7 +482,7 @@ class Calibration:
             )
         if center is None:
             for ax in self.signal.axes_manager.signal_axes:
-                ax.offset = -ax.scale * (ax.size / 2)
+                ax.offset = -ax.scale * ((ax.size - 1) / 2)
         else:
             for ax, off in zip(self.signal.axes_manager.signal_axes, center):
                 ax.offset = -off * ax.scale

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -18,7 +18,6 @@
 
 """Utils for calibrating Diffraction Patterns."""
 
-
 import numpy as np
 import json
 
@@ -296,10 +295,18 @@ class Calibration:
             left_scales = self.scale
             right_scales = self.scale
         else:
-            scales = np.array([ax[1:] - ax[:-1] for ax in self.axes])
-            scales = np.pad(scales, 1, mode="edge")
-            left_scales = scales[:, :-1]
-            right_scales = scales[:, 1:]
+            x_scales = self.axes[0][1:] - self.axes[0][:-1]
+            x_scales = np.pad(x_scales, 1, mode="edge")
+            y_scales = self.axes[1][1:] - self.axes[1][:-1]
+            y_scales = np.pad(y_scales, 1, mode="edge")
+            left_scales = [
+                x_scales[:-1],
+                y_scales[:-1],
+            ]
+            right_scales = [
+                x_scales[1:],
+                y_scales[1:],
+            ]
 
         extents = []
         for ax, left_scale, right_scale in zip(self.axes, left_scales, right_scales):

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -411,7 +411,7 @@ class Calibration:
         # get the points which bound each azimuthal pixel
         control_points = _get_control_points(npt, npt_azim, radial_range, self.affine)
 
-        # get the min and max indices for each control point using the 
+        # get the min and max indices for each control point using the
         pixel_ext_x, pixel_ext_y = self.pixel_extent
         min_x = (
             np.min(
@@ -433,15 +433,11 @@ class Calibration:
         )
 
         max_x = np.max(
-            np.searchsorted(
-                pixel_ext_x[0, :], control_points[:, :, 0], side="right"
-            ),
+            np.searchsorted(pixel_ext_x[0, :], control_points[:, :, 0], side="right"),
             axis=1,
         ).astype(int)
         max_y = np.max(
-            np.searchsorted(
-                pixel_ext_y[0, :], control_points[:, :, 1], side="right"
-            ),
+            np.searchsorted(pixel_ext_y[0, :], control_points[:, :, 1], side="right"),
             axis=1,
         ).astype(int)
         # Note that if a point is outside the range of the axes it will be set to the

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -293,7 +293,13 @@ class Calibration:
         if radial_range is None:
             from itertools import combinations
 
-            edges = np.reshape([[ax.min() ** 2, (ax.max() + scale) ** 2] for ax, scale in zip(self.axes, self.scale)], -1)
+            edges = np.reshape(
+                [
+                    [ax.min() ** 2, (ax.max() + scale) ** 2]
+                    for ax, scale in zip(self.axes, self.scale)
+                ],
+                -1,
+            )
             max_range = np.max(
                 np.power(np.sum(list(combinations(edges, 2)), axis=1), 0.5)
             )

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -230,7 +230,7 @@ class Calibration:
             )
 
         if center is None:
-            center = [(ax.max() - ax.min()) / 2 for ax in self.axes]
+            center = [(ax.size - 1) / 2 for ax in self.axes]
 
         def translate_pixel_coords(px: np.ndarray) -> np.ndarray:
             coord = pixel_size * px
@@ -305,7 +305,7 @@ class Calibration:
         """
         if self.flat_ewald:
             extents = []
-            for ax, scale in zip(self.axes,  self.scale):
+            for ax, scale in zip(self.axes, self.scale):
                 left = ax - scale / 2
                 right = ax + scale / 2
                 extent = np.stack((left, right))

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -250,9 +250,9 @@ class Calibration:
         y_ext_r = translate_pixel_coords(y_pixels + 0.5)
 
         self._pixel_extent = [
-                np.stack((x_ext_l, x_ext_r)),
-                np.stack((y_ext_l, y_ext_r)),
-            ]
+            np.stack((x_ext_l, x_ext_r)),
+            np.stack((y_ext_l, y_ext_r)),
+        ]
 
         for ax, axis in zip(self.signal.axes_manager.signal_axes, [x_axes, y_axes]):
             if isinstance(ax, UniformDataAxis):

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -293,7 +293,7 @@ class Calibration:
         if radial_range is None:
             from itertools import combinations
 
-            edges = np.reshape([[ax[0] ** 2, ax[-1] ** 2] for ax in self.axes], -1)
+            edges = np.reshape([[ax.min() ** 2, (ax.max() + scale) ** 2] for ax, scale in zip(self.axes, self.scale)], -1)
             max_range = np.max(
                 np.power(np.sum(list(combinations(edges, 2)), axis=1), 0.5)
             )
@@ -386,8 +386,8 @@ class Calibration:
         slices = np.array(
             [[mx, my, mxx, myy] for mx, my, mxx, myy in zip(min_x, min_y, max_x, max_y)]
         )
-        max_y_ind = len(self.axes[1]) - 1
-        max_x_ind = len(self.axes[0]) - 1
+        max_y_ind = len(self.axes[1])
+        max_x_ind = len(self.axes[0])
 
         # set the slices to be within the range of the axes.  If the entire slice is outside
         # the range of the axes then set the slice to be the maximum value of the axis


### PR DESCRIPTION
---
Fixes an off-by-one error in azimuthal integration
---

**Checklist**

- [x] implementation steps
- [ ] update the Changelog
- [ ] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
An off-by-one error meant the final row and column of the signal was ignored when transforming to polar coordinates with `Diffraction2D.get_azimuthal_integral2d`.
In the old code, the new test fails for all `corner != (0, 0)`, i.e. all corners at the last row and/or column.
The new implementation calculates the extent in cartesian space of each pixel, accounting for the curvature of Ewald's sphere where applicable, and uses those for `utils._azimuthal_integrations._get_factors`.

The previous implementation relied on the `Calibration.axes`, where the final element was not included due to the off-by-one error. Furthermore, from looking at hyperspy plots with few signal pixels, the coordinates of the axes represent the centers rather than the edges of the pixels, which is now accounted for