### PR TITLE
Support `azimuth_range` in `Diffraction2d.get_azimuthal_integral2d`

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -101,7 +101,7 @@
     {
       "name": "Tiarnan Doherty"
     },
-
+    
     {
       "name":"Tomas Ostasevicius"
     },
@@ -118,6 +118,10 @@
     {
       "name": "Petr Vacek",
       "orcid": "0000-0002-1625-9258"
+    },
+    {
+      "name":"Viljar Johan Femoen",
+      "affiliation": "Norwegian University of Science and Technology"
     }
   ]
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 - Fixed bug with flattening diffraction Vectors when there are different scales (#1024)
 - Fixed intersphinx links and improved api documentation (#1056)
 - Fix an off-by-one error in the :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral2d` (#1058)
+- Fix handling of azimuthal range in :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral2d` (#1060)
 
 Added
 -----

--- a/examples/processing/azimuthal_integration.py
+++ b/examples/processing/azimuthal_integration.py
@@ -93,8 +93,6 @@ nano_crystals.get_azimuthal_integral2d(
 # The `azimuth_range`-argument lets you choose what angular range to calculate the azimuthal integral for.
 # The range can be increasing, decreasing, and does not need to be a multiple of pi.
 
-nano_crystals.calibrate(center=None)
-
 pol1 = nano_crystals.get_azimuthal_integral2d(npt=100, azimuth_range=(-np.pi, np.pi))
 
 pol2 = nano_crystals.get_azimuthal_integral2d(npt=100, azimuth_range=(0, 1))

--- a/examples/processing/azimuthal_integration.py
+++ b/examples/processing/azimuthal_integration.py
@@ -89,3 +89,27 @@ nano_crystals.get_azimuthal_integral2d(
     npt=100, npt_azim=360, inplace=False
 ).sum().plot()
 # %%
+
+# The `azimuth_range`-argument lets you choose what angular range to calculate the azimuthal integral for.
+# The range can be increasing, decreasing, and does not need to be a multiple of pi.
+
+nano_crystals.calibrate(center=None)
+
+pol1 = nano_crystals.get_azimuthal_integral2d(npt=100, azimuth_range=(-np.pi, np.pi))
+
+pol2 = nano_crystals.get_azimuthal_integral2d(npt=100, azimuth_range=(0, 1))
+
+pol3 = nano_crystals.get_azimuthal_integral2d(
+    npt=100, npt_azim=720, azimuth_range=(0, 4 * np.pi)
+)
+
+pol4 = nano_crystals.get_azimuthal_integral2d(npt=100, azimuth_range=(np.pi, 0))
+
+hs.plot.plot_images(
+    [pol1.sum(), pol2.sum(), pol3.sum(), pol4.sum()],
+    label=["(-pi, pi) default", "(0, 1)", "(0, 4pi)", "(pi, 0)"],
+    cmap="viridis",
+    tight_layout=True,
+    colorbar=None,
+)
+# %%

--- a/examples/virtual_imaging/creating_a_segmented_detector.py
+++ b/examples/virtual_imaging/creating_a_segmented_detector.py
@@ -22,7 +22,11 @@ dp.calibrate.scale = 0.1  # Scale the diffraction patterns in reciprocal space
 
 # Visualizing the virtual detector
 cp = _get_control_points(
-    1, npt_azim=8, radial_range=(1, 5), affine=dp.calibrate.affine
+    1,
+    npt_azim=8,
+    radial_range=(1, 5),
+    azimuthal_range=(-np.pi, np.pi),
+    affine=dp.calibrate.affine,
 )[:, :, ::-1]
 poly = hs.plot.markers.Polygons(verts=cp, edgecolor="w", facecolor="none")
 dp.plot()

--- a/pyxem/release_info.py
+++ b/pyxem/release_info.py
@@ -40,6 +40,7 @@ credits = [
     "Matt von Lany",
     "Rob Tovey",
     "Petr Vacek",
+    "Viljar Johan Femoen",
 ]
 license = "GPLv3+"
 maintainer = "Duncan Johnstone, Phillip Crout, Magnus Nord, Carter Francis"

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -2012,12 +2012,18 @@ class Diffraction2D(CommonDiffraction, Signal2D):
         pyxem.signals.Diffraction2D.get_azimuthal_integral1d
 
         """
+        if azimuth_range is None:
+            azimuth_range = (-np.pi, np.pi)
+
         usepyfai = method not in ["splitpixel_pyxem"]
         if not usepyfai:
             # get_slices2d should be sped up in the future by
             # getting rid of shapely and using numba on the for loop
             slices, factors, factors_slice, radial_range = self.calibrate.get_slices2d(
-                npt, npt_azim, radial_range=radial_range
+                npt,
+                npt_azim,
+                radial_range=radial_range,
+                azimuthal_range=azimuth_range,
             )
             if self._gpu and CUPY_INSTALLED:  # pragma: no cover
                 from pyxem.utils._azimuthal_integrations import (
@@ -2088,15 +2094,11 @@ class Diffraction2D(CommonDiffraction, Signal2D):
             k_axis.convert_to_uniform_axis()
         if not isinstance(t_axis, UniformDataAxis):
             t_axis.convert_to_uniform_axis()
+
         t_axis.name = "Radians"
         t_axis.units = "Rad"
-
-        if azimuth_range is None:
-            t_axis.scale = np.pi * 2 / npt_azim
-            t_axis.offset = -np.pi
-        else:
-            t_axis.scale = (azimuth_range[1] - azimuth_range[0]) / npt
-            t_axis.offset = azimuth_range[0]
+        t_axis.scale = (azimuth_range[1] - azimuth_range[0]) / npt_azim
+        t_axis.offset = azimuth_range[0]
 
         k_axis.name = "Radius"
         k_axis.scale = (radial_range[1] - radial_range[0]) / npt

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -620,11 +620,11 @@ class TestAzimuthalIntegral2d:
 
         assert np.allclose(np.nanmax(pol.data), max_val)
 
-    # polar unwrapping `arange` should look like [3 1 0 2]
+    # polar unwrapping `arange` should look like [1 0 2 3]
     # since data looks like:
     # 0 1
     # 2 3
-    # and the data gets unwrapped from the center and downwards, using the right hand rule
+    # and the data gets unwrapped from the center to the right
     @pytest.mark.parametrize(
         [
             "azimuthal_range",
@@ -633,19 +633,19 @@ class TestAzimuthalIntegral2d:
         [
             [
                 (0 * np.pi / 2, 1 * np.pi / 2),
-                3,
-            ],
-            [
-                (1 * np.pi / 2, 2 * np.pi / 2),
                 1,
             ],
             [
-                (2 * np.pi / 2, 3 * np.pi / 2),
+                (1 * np.pi / 2, 2 * np.pi / 2),
                 0,
             ],
             [
-                (3 * np.pi / 2, 4 * np.pi / 2),
+                (2 * np.pi / 2, 3 * np.pi / 2),
                 2,
+            ],
+            [
+                (3 * np.pi / 2, 4 * np.pi / 2),
+                3,
             ],
         ],
     )

--- a/pyxem/tests/utils/test_calibration_utils.py
+++ b/pyxem/tests/utils/test_calibration_utils.py
@@ -134,7 +134,7 @@ class TestCalibrationClass:
         s = Diffraction2D(np.zeros((100, 100)))
         s.calibrate(scale=0.1, center=None)
         slices, factors, factor_slices = s.calibrate._get_slices_and_factors(
-            npt=100, npt_azim=360, radial_range=(0, 4)
+            npt=100, npt_azim=360, radial_range=(0, 4), azimuthal_range=(0, 2 * np.pi)
         )
         # check that the number of pixels for each radial slice is the same
         sum_factors = [np.sum(factors[f[0] : f[1]]) for f in factor_slices]
@@ -148,7 +148,7 @@ class TestCalibrationClass:
         all_sum = np.sum(sum_factors)
         assert np.allclose(all_sum, 3.1415 * 40**2, atol=1)
         slices, factors, factor_slices = s.calibrate._get_slices_and_factors(
-            npt=100, npt_azim=360, radial_range=(0, 15)
+            npt=100, npt_azim=360, radial_range=(0, 15), azimuthal_range=(0, 2 * np.pi)
         )
         # check that the number of pixels for each radial slice is the same
         sum_factors = [np.sum(factors[f[0] : f[1]]) for f in factor_slices]
@@ -157,9 +157,7 @@ class TestCalibrationClass:
         # Up to rounding due to the fact that we are actually finding the area of an n-gon where
         # n = npt_azim
         all_sum = np.sum(sum_factors)
-        # For some reason we are missing 1 row/ column of pixels on the edge
-        # of the image so this is 9801 instead of 10000!
-        # assert np.allclose(all_sum, 10000, atol=1)
+        assert np.allclose(all_sum, 10000, atol=1)
 
     def test_get_slices_and_factors1d(self):
         s = Diffraction2D(np.zeros((100, 100)))

--- a/pyxem/utils/_azimuthal_integrations.py
+++ b/pyxem/utils/_azimuthal_integrations.py
@@ -225,7 +225,7 @@ def _get_factors(control_points, slices, pixel_extents):
     return np.array(factors), np.array(factors_slice)
 
 
-def _get_control_points(npt, npt_azim, radial_range, affine):
+def _get_control_points(npt, npt_azim, radial_range, azimuthal_range, affine):
     """Get the control points in the form of an array (npt_azim*npt, 4, 2) representing
     the cartesian coordinates of the control points for each azimuthal pixel.
 
@@ -249,7 +249,7 @@ def _get_control_points(npt, npt_azim, radial_range, affine):
 
     """
     r = np.linspace(radial_range[0], radial_range[1], npt + 1)
-    phi = np.linspace(0, 2 * np.pi, npt_azim + 1)
+    phi = np.linspace(azimuthal_range[0], azimuthal_range[1], npt_azim + 1)
     control_points = np.empty(((len(r) - 1) * (len(phi) - 1), 4, 2))
     # lower left
     control_points[:, 0, 0] = (np.cos(phi[:-1]) * r[:-1][:, np.newaxis]).ravel()

--- a/pyxem/utils/_azimuthal_integrations.py
+++ b/pyxem/utils/_azimuthal_integrations.py
@@ -241,6 +241,8 @@ def _get_control_points(npt, npt_azim, radial_range, azimuthal_range, affine):
         The center of the diffraction pattern
     radial_range: (float, float)
         The radial range of the data
+    azimuthal_range: (float, float)
+        The azumuthal range of the data, in radians
 
     Returns
     -------

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -409,6 +409,17 @@ class Calibration:
         return indexes, facts, factor_slices, radial_range
 
     def _get_slices_and_factors(self, npt, npt_azim, radial_range, azimuthal_range):
+        # In `_get_control_points`, positive x-direction is downwards, and positive y is to the right.
+        # This is 90 degrees off from the pyxem definition:
+        # https://pyxem.readthedocs.io/en/stable/tutorials/pyxem-demos/13%20Conventions.html
+        # As the azimuthal integration performed with a `Calibration`-object should align with
+        # the $X_L$ / $Y_L$-definitions in pyxem, we add pi/2 to the azimuthal range.
+        # This aligns the azimuthal angle 0 to $X_L$.
+        azimuthal_range = (
+            azimuthal_range[0] + np.pi / 2,
+            azimuthal_range[1] + np.pi / 2,
+        )
+
         # get the points which bound each azimuthal pixel
         control_points = _get_control_points(
             npt, npt_azim, radial_range, azimuthal_range, self.affine

--- a/pyxem/utils/calibration.py
+++ b/pyxem/utils/calibration.py
@@ -316,7 +316,7 @@ class Calibration:
             extents.append(extent)
         return extents
 
-    def get_slices2d(self, npt, npt_azim, radial_range=None):
+    def get_slices2d(self, npt, npt_azim, radial_range=None, azimuthal_range=None):
         """Get the slices and factors for some image that can be used to
         slice the image for 2d integration.
 
@@ -328,9 +328,11 @@ class Calibration:
             The number of azimuthal points
         """
         radial_range = self._get_radial_range(radial_range)
+        if azimuthal_range is None:
+            azimuthal_range = (-np.pi, np.pi)
         # Get the slices and factors for the integration
         slices, factors, factors_slice = self._get_slices_and_factors(
-            npt, npt_azim, radial_range
+            npt, npt_azim, radial_range, azimuthal_range
         )
         return slices, factors, factors_slice, radial_range
 
@@ -380,7 +382,7 @@ class Calibration:
         npt_azim = 360  # approximate a circle with a 360-gon... Using a circle is harder/ not much better
 
         slices, factors, factors_slice, radial_range = self.get_slices2d(
-            npt, 360, radial_range
+            npt, npt_azim, radial_range
         )
 
         # convert into 1d slices
@@ -406,9 +408,11 @@ class Calibration:
         indexes, facts = np.vstack(indexes), np.hstack(facts)
         return indexes, facts, factor_slices, radial_range
 
-    def _get_slices_and_factors(self, npt, npt_azim, radial_range):
+    def _get_slices_and_factors(self, npt, npt_azim, radial_range, azimuthal_range):
         # get the points which bound each azimuthal pixel
-        control_points = _get_control_points(npt, npt_azim, radial_range, self.affine)
+        control_points = _get_control_points(
+            npt, npt_azim, radial_range, azimuthal_range, self.affine
+        )
 
         # get the min and max indices for each control point using the
         pixel_ext_x, pixel_ext_y = self.pixel_extent


### PR DESCRIPTION
---
Add proper support for the `azimuth_range`-argument in `Diffraction2d.get_azimuthal_integral2d`
---

**Checklist**

- [x] implementation steps
- [x] update the Changelog
- [ ] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**

Previously the only thing `azimuth_range` did was change the axis limis. Now, the argument is considered also when integrating.
I added a test to ensure only the specified range is included in the final output.
With this, the angle along the azimuthal axis is consistent for any specified range, with angle 0 pointing downwards in the image.
This is not in line with [Pyxem's standards](https://pyxem.readthedocs.io/en/latest/tutorials/pyxem-demos/13%20Conventions.html), if the angle is measured along $X_L$. Currently, the angle is measured along $-Y_L$.
This affects the new template matching code for the in-plane angle, which needs to be measured from $X_L$.
It can either be handled here, or in the template matching code specifically, as we need to convert from an index into the azimuthal axis (the current TM output) to an angle in degrees regardless.

I updated the contributors but I'm not sure where in the list I slot in..