### PR TITLE
Implement some polar-specific background subtraction algorithms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Added
 - Added GPU support for lazy signals. (#1012)
 - Added GPU processing for :meth:`pyxem.signals.Diffraction2D.get_azimuthal_integral2d` (#1012)
 - Added method for calibrating the detector gain (#1046)
+- Added :meth:`pyxem.signals.PolarDiffraction2D.subtract_diffraction_background` for polar-specific background subtraction (#1062)
 
 Deprecated
 ----------

--- a/examples/processing/background_subtraction.py
+++ b/examples/processing/background_subtraction.py
@@ -1,0 +1,56 @@
+"""
+Background subtraction
+==============
+
+If your diffraction data is noisy, you might want to subtract the background from the
+dataset. Pyxem offers some built-in functionality for this, with the
+`subtract_diffraction_background` class method. Custom filtering is also possible, an
+example is shown in the 'Filtering Data'-example.
+"""
+
+import pyxem as pxm
+import hyperspy.api as hs
+
+s = pxm.data.twinned_nanowire(allow_download=True)
+
+s_filtered = s.subtract_diffraction_background(
+    "difference of gaussians", 
+    inplace=False, 
+    min_sigma=2, 
+    max_sigma=8,
+    )
+
+hs.plot.plot_images(
+    [s.inav[9, 42], s_filtered.inav[9, 42]],
+    label=["Original", "Difference of Gaussians"],
+    tight_layout=True,
+    norm="symlog",
+    cmap="viridis",
+    colorbar=None,
+)
+# %%
+"""
+The available methods differ for `Diffraction2D` datasets and `PolarDiffraction2D`
+datasets.
+"""
+
+# Set the center of the diffraction pattern to its default,
+# i.e. the middle of the image
+s.calibrate.center = None
+
+# Transform to polar coordinates
+s_polar = s.get_azimuthal_integral2d(npt=100, mean=True)
+
+s_polar_filtered = s_polar.subtract_diffraction_background(
+    "radial median", 
+    inplace=False, 
+    )
+
+hs.plot.plot_images(
+    [s_polar.inav[9, 42], s_polar_filtered.inav[9, 42]],
+    label=["Original (polar)", "Radial Median"],
+    tight_layout=True,
+    norm="symlog",
+    cmap="viridis",
+    colorbar=None,
+)

--- a/examples/processing/background_subtraction.py
+++ b/examples/processing/background_subtraction.py
@@ -14,11 +14,11 @@ import hyperspy.api as hs
 s = pxm.data.twinned_nanowire(allow_download=True)
 
 s_filtered = s.subtract_diffraction_background(
-    "difference of gaussians", 
-    inplace=False, 
-    min_sigma=2, 
+    "difference of gaussians",
+    inplace=False,
+    min_sigma=2,
     max_sigma=8,
-    )
+)
 
 hs.plot.plot_images(
     [s.inav[9, 42], s_filtered.inav[9, 42]],
@@ -29,6 +29,7 @@ hs.plot.plot_images(
     colorbar=None,
 )
 # %%
+
 """
 The available methods differ for `Diffraction2D` datasets and `PolarDiffraction2D`
 datasets.
@@ -42,9 +43,9 @@ s.calibrate.center = None
 s_polar = s.get_azimuthal_integral2d(npt=100, mean=True)
 
 s_polar_filtered = s_polar.subtract_diffraction_background(
-    "radial median", 
-    inplace=False, 
-    )
+    "radial median",
+    inplace=False,
+)
 
 hs.plot.plot_images(
     [s_polar.inav[9, 42], s_polar_filtered.inav[9, 42]],

--- a/examples/processing/background_subtraction.py
+++ b/examples/processing/background_subtraction.py
@@ -24,7 +24,7 @@ s_filtered_h = s.subtract_diffraction_background("h-dome", inplace=False, h=0.7)
 
 
 hs.plot.plot_images(
-    [s.inav[2, 2], s_filtered.inav[2, 2], s_filtered_median.inav[2, 2]],
+    [s.inav[2, 2], s_filtered.inav[2, 2], s_filtered_h.inav[2, 2]],
     label=["Original", "Difference of Gaussians", "H-Dome"],
     tight_layout=True,
     norm="symlog",

--- a/examples/processing/background_subtraction.py
+++ b/examples/processing/background_subtraction.py
@@ -11,35 +11,42 @@ example is shown in the 'Filtering Data'-example.
 import pyxem as pxm
 import hyperspy.api as hs
 
-s = pxm.data.twinned_nanowire(allow_download=True)
+s = pxm.data.tilt_boundary_data()
 
 s_filtered = s.subtract_diffraction_background(
     "difference of gaussians",
     inplace=False,
-    min_sigma=2,
-    max_sigma=8,
+    min_sigma=3,
+    max_sigma=20,
 )
 
+s_filtered_h = s.subtract_diffraction_background("h-dome", inplace=False, h=0.7)
+
+
 hs.plot.plot_images(
-    [s.inav[9, 42], s_filtered.inav[9, 42]],
-    label=["Original", "Difference of Gaussians"],
+    [s.inav[2, 2], s_filtered.inav[2, 2], s_filtered_median.inav[2, 2]],
+    label=["Original", "Difference of Gaussians", "H-Dome"],
     tight_layout=True,
     norm="symlog",
     cmap="viridis",
     colorbar=None,
 )
+
 # %%
-
-"""
-The available methods differ for `Diffraction2D` datasets and `PolarDiffraction2D`
-datasets.
-"""
-
+# ======================
+# Filtering Polar Images
+# ======================
+# The available methods differ for `Diffraction2D` datasets and `PolarDiffraction2D`
+# datasets.
+#
 # Set the center of the diffraction pattern to its default,
 # i.e. the middle of the image
+
 s.calibrate.center = None
 
+# %%
 # Transform to polar coordinates
+
 s_polar = s.get_azimuthal_integral2d(npt=100, mean=True)
 
 s_polar_filtered = s_polar.subtract_diffraction_background(
@@ -47,11 +54,19 @@ s_polar_filtered = s_polar.subtract_diffraction_background(
     inplace=False,
 )
 
+s_polar_filtered2 = s_polar.subtract_diffraction_background(
+    "radial percentile",
+    percentile=70,
+    inplace=False,
+)
+
 hs.plot.plot_images(
-    [s_polar.inav[9, 42], s_polar_filtered.inav[9, 42]],
-    label=["Original (polar)", "Radial Median"],
+    [s_polar.inav[2, 2], s_polar_filtered.inav[2, 2], s_polar_filtered2.inav[2, 2]],
+    label=["Original (polar)", "Radial Median", "Radial Percentile"],
     tight_layout=True,
     norm="symlog",
     cmap="viridis",
     colorbar=None,
 )
+
+# %%

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -24,6 +24,11 @@ from pyxem.signals.common_diffraction import CommonDiffraction
 from pyxem.utils._correlations import _correlation, _power, _pearson_correlation
 from pyxem.utils._deprecated import deprecated
 
+from pyxem.utils._background_subtraction import (
+    _polar_subtract_radial_median,
+    _polar_subtract_radial_percentile,
+)
+
 
 class PolarDiffraction2D(CommonDiffraction, Signal2D):
     """Signal class for two-dimensional diffraction data in polar coordinates.
@@ -73,7 +78,7 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             mask=mask,
             normalize=normalize,
             inplace=inplace,
-            **kwargs
+            **kwargs,
         )
         s = self if inplace else correlation
         theta_axis = s.axes_manager.signal_axes[0]
@@ -255,6 +260,43 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         k_axis.scale = self.axes_manager[-1].scale
 
         return correlation
+
+    def subtract_diffraction_background(
+        self, method="radial median", inplace=False, **kwargs
+    ):
+        """Background subtraction of the diffraction data.
+
+        Parameters
+        ----------
+        method : str, optional
+            'radial median', 'radial percentile'
+            Default 'radial median'.
+
+            For 'radial median' no extra parameters are necessary.
+
+            For 'radial percentile' the 'percentile' argument decides 
+            which percentile to substract.
+        **kwargs :
+                To be passed to the chosen method.
+
+        Returns
+        -------
+        s : PolarDiffraction2D or LazyPolarDiffraction2D signal
+
+        """
+        method_dict = {
+            "radial median": _polar_subtract_radial_median,
+            "radial percentile": _polar_subtract_radial_percentile,
+        }
+        if method not in method_dict:
+            raise NotImplementedError(
+                f"The method specified, '{method}',"
+                f" is not implemented.  The different methods are:  "
+                f"{', '.join(method_dict.keys())}."
+            )
+        subtraction_function = method_dict[method]
+
+        return self.map(subtraction_function, inplace=inplace, **kwargs)
 
 
 class LazyPolarDiffraction2D(LazySignal, PolarDiffraction2D):

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -274,7 +274,7 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
 
             For 'radial median' no extra parameters are necessary.
 
-            For 'radial percentile' the 'percentile' argument decides 
+            For 'radial percentile' the 'percentile' argument decides
             which percentile to substract.
         **kwargs :
                 To be passed to the chosen method.
@@ -296,7 +296,13 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             )
         subtraction_function = method_dict[method]
 
-        return self.map(subtraction_function, inplace=inplace, **kwargs)
+        return self.map(
+            subtraction_function,
+            inplace=inplace,
+            output_dtype=self.data.dtype,
+            output_signal_size=self.axes_manager._signal_shape_in_array,
+            **kwargs,
+        )
 
 
 class LazyPolarDiffraction2D(LazySignal, PolarDiffraction2D):

--- a/pyxem/tests/signals/test_polar_diffraction2d.py
+++ b/pyxem/tests/signals/test_polar_diffraction2d.py
@@ -249,3 +249,31 @@ class TestDecomposition:
         s = PolarDiffraction2D(diffraction_pattern)
         s.decomposition()
         assert isinstance(s, PolarDiffraction2D)
+
+
+class TestSubtractingDiffractionBackground:
+    @pytest.fixture
+    def noisy_data(self):
+        data = np.random.rand(3, 2, 20, 15)
+        data[:, :, 10:12, 7:9] = 100
+        dp = PolarDiffraction2D(data)
+        return dp
+
+    @pytest.mark.parametrize(
+        ["method", "kwargs"],
+        [
+            ("radial median", {}),
+            ("radial percentile", {"percentile": 40}),
+            pytest.param(
+                "this method does not exist",
+                {},
+                marks=pytest.mark.xfail(raises=NotImplementedError),
+            ),
+        ],
+    )
+    def test_subtract_backgrounds(self, method, kwargs, noisy_data):
+        kwargs["inplace"] = False
+
+        subtracted = noisy_data.subtract_diffraction_background(method=method, **kwargs)
+        assert isinstance(subtracted, PolarDiffraction2D)
+        assert subtracted.data.shape == noisy_data.data.shape

--- a/pyxem/utils/_background_subtraction.py
+++ b/pyxem/utils/_background_subtraction.py
@@ -100,3 +100,29 @@ def _subtract_hdome(frame, **kwargs):
     )
     bg_subtracted = bg_subtracted / np.max(bg_subtracted)
     return bg_subtracted
+
+
+def _polar_subtract_radial_median(frame):
+    """Background removal using the radial median"""
+    median = np.nanmedian(frame, axis=1)
+    image = frame - median[:, np.newaxis]
+    image[image < 0] = 0
+    return image
+
+
+def _polar_subtract_radial_percentile(frame, percentile: int):
+    """Background removal using the specified radial percentile.
+
+    Parameters
+    ----------
+    frame : NumPy 2D array
+    percentile : percentile, between 0 and 100
+
+    Note
+    -------
+    if `percentile` is 50, then this is equivalent to `_polar_subtract_radial_median`.
+    """
+    percentile = np.nanpercentile(frame, percentile, axis=1)
+    image = frame - percentile[:, np.newaxis]
+    image[image < 0] = 0
+    return image


### PR DESCRIPTION
---
Implement some polar-specific background subtraction algorithms
---
**Checklist**

- [x] implementation steps
- [x] update the Changelog
- [ ] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
With the new orientation mapping API coming in #1018, users are responsible for polar unwrapping (rather than it happening under the hood). This lets them take advantage of the format for background substraction.
With this PR, `PolarDiffraction2D` now has the method `subtract_diffraction_background` which mimics `Diffraction2D.subtract_diffraction_background`.

The only algorithms I implemented were radial median and radial percentile. Radial median already exists for `Diffraction2D`, but that implementation handles the transformation from cartesian to polar coordinates poorly compared to the actual polar signal.

