### PR TITLE
Fixed indexing error in `get_direct_beam_position`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 
+Unreleased
+==========
+Fixed
+-----
+- Fixed indexing error in :meth:`~pyxem.signals.Diffraction2D.get_direct_beam_position` (#1080)
+
+
+
 2024-05-08 - version 0.18.0
 ==========
 Fixed

--- a/pyxem/signals/diffraction2d.py
+++ b/pyxem/signals/diffraction2d.py
@@ -654,7 +654,7 @@ class Diffraction2D(CommonDiffraction, Signal2D):
             Half the side length of square that captures the direct beam in all
             scans. Means that the centering algorithm is stable against
             diffracted spots brighter than the direct beam. Crops the diffraction
-            pattern to `half_square_width` pixels around th center of the diffraction
+            pattern to `half_square_width` pixels around the center of the diffraction
             pattern. Only one of `half_square_width` or signal_slice can be defined.
         **kwargs:
             Additional arguments accepted by :func:`pyxem.utils.diffraction.find_beam_center_blur`,
@@ -751,9 +751,10 @@ class Diffraction2D(CommonDiffraction, Signal2D):
             shifts = -centers + origin_coordinates
         elif method == "center_of_mass":
             if "mask" in kwargs and signal_slice is not None:
+                # Shifts mask into coordinate space of sliced signal
                 x, y, r = kwargs["mask"]
                 x = x - signal_slice[0]
-                y = y - signal_slice[1]
+                y = y - signal_slice[2]
                 kwargs["mask"] = (x, y, r)
             centers = signal.center_of_mass(
                 lazy_result=lazy_output,

--- a/pyxem/tests/signals/test_diffraction2d.py
+++ b/pyxem/tests/signals/test_diffraction2d.py
@@ -857,7 +857,7 @@ class TestGetDirectBeamPosition:
                     "kind": "nearest",
                 },
             ),
-            ("center_of_mass", {}),
+            ("center_of_mass", {"mask": (10, 13, 10)}),
         ],
     )
     def test_get_direct_beam(self, method, sig_slice, kwargs):


### PR DESCRIPTION
---
name: Fix bug as described in #1079
---

**Checklist**

- [x] implementation steps
- [x] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
This PR fixes a small indexing error in the `get_direct_beam_position` method when using both a mask and slicing the signal. The previous implementation used the max x-coordinate rather than the intended min y-coordinate. This bug is elaborated on in #1079.
