### PR TITLE
Vectors to Mask

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Fixed
 Added
 -----
 - Added Examples for doing a Circular Hough Transform and Increased Documentation for Filtering Data (#1082)
+
+
 Added
 -----
 - Added `circular_background` to :meth:`~pyxem.signals.Diffraction2D.template_match_disk` to account for
@@ -37,7 +39,7 @@ Added
 
 - Added new datasets of in situ crystalization, Ag SPED,
   Organic Semiconductor Orientation mapping, Orientation Mapping, and DPC (#1081)
-
+- Added Vectors to mask in :meth:`~pyxem.signals.DiffractionVectors.to_mask` (#1087)
 
 2024-05-08 - version 0.18.0
 ==========

--- a/examples/vectors/masking_vectors.py
+++ b/examples/vectors/masking_vectors.py
@@ -1,0 +1,44 @@
+"""
+Diffraction Vectors to Mask
+===========================
+
+This example shows how to take a set of vectors and create a mask
+from a set of circles around each vector. Multiplying by the original signal
+will remove all the signal except for the circles around the vectors.
+"""
+
+import pyxem as pxm
+import hyperspy.api as hs
+
+s = pxm.data.tilt_boundary_data()
+s.calibration.center = None
+
+s.axes_manager[2].scale = 0.3
+temp = s.template_match_disk(disk_r=5, subtract_min=False)  # Just right
+vectors = temp.get_diffraction_vectors(threshold_abs=0.4, min_distance=5)
+
+mask = vectors.to_mask(disk_r=7)
+masked_s = s * mask
+masked_s.plot()
+
+# %%
+# Selecting One Position
+# ----------------------
+# We can also just select one position and create a mask from that.
+
+masked_s = s * mask.inav[0, 0]
+masked_s.plot()
+
+# %%
+# Removing Vectors
+# ----------------
+# We can also remove the vectors from the signal by inverting the mask
+# and multiplying by the original signal.
+
+vectors_filtered = vectors.filter_magnitude(1, 15)
+mask = vectors_filtered.to_mask(disk_r=9)
+masked_s = s * ~mask
+masked_s.plot()
+
+# %%
+# sphinx_gallery_thumbnail_number = 6

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -1305,7 +1305,7 @@ class DiffractionVectors(BaseSignal):
 
         return xim
 
-    def to_mask(self, disk_r, columns=[0, 1], signal_axes=None):
+    def to_mask(self, disk_r, signal_axes=None):
         """Convert the diffraction vectors to a N-D mask.
 
         This can be useful for Orientation Mapping including the fitting of mulitple

--- a/pyxem/signals/diffraction_vectors.py
+++ b/pyxem/signals/diffraction_vectors.py
@@ -1305,7 +1305,7 @@ class DiffractionVectors(BaseSignal):
 
         return xim
 
-    def vectors_to_mask(self, disk_r, columns=[0, 1], signal_axes=None):
+    def to_mask(self, disk_r, columns=[0, 1], signal_axes=None):
         """Convert the diffraction vectors to a N-D mask.
 
         This can be useful for Orientation Mapping including the fitting of mulitple

--- a/pyxem/tests/signals/test_diffraction_vectors.py
+++ b/pyxem/tests/signals/test_diffraction_vectors.py
@@ -32,6 +32,7 @@ from pyxem.utils._subpixel_finding import (
     _get_experimental_square,
     _conventional_xc,
 )
+from pyxem.data import tilt_boundary_data
 from hyperspy.axes import UniformDataAxis
 
 # DiffractionVectors correspond to a single list of vectors, a map of vectors
@@ -816,3 +817,14 @@ class TestSlicingVectors:
         assert vectors.num_columns == 2
         lazy_vectors = vectors.as_lazy()
         assert lazy_vectors.num_columns == 2
+
+
+class TestMask:
+    def test_remove_peaks(self):
+        s = tilt_boundary_data()
+        s.calibration.center = None
+        temp = s.template_match_disk(disk_r=5, subtract_min=False)  # Just right
+        vectors = temp.get_diffraction_vectors(threshold_abs=0.4, min_distance=5)
+        mask = vectors.to_mask(disk_r=12)
+        masked_s = s * ~mask
+        assert np.max(masked_s.data) < 2

--- a/pyxem/utils/vectors.py
+++ b/pyxem/utils/vectors.py
@@ -896,7 +896,7 @@ def convert_to_markers(
     new_peaks[:, 1] = np.round((new_peaks[:, 1] - y_axis.offset) / y_axis.scale)
     ind = np.lexsort((new_peaks[:, 1], new_peaks[:, 0]))
     sorted_peaks = new_peaks[ind]
-    shape = signal.axes_manager.navigation_shape
+    shape = signal.axes_manager._navigation_shape_in_array
     by_ind_peaks = np.empty(shape, dtype=object)
     by_ind_colors = np.empty(shape, dtype=object)
     num_labels = np.max(new_peaks[:, -1])
@@ -904,14 +904,14 @@ def convert_to_markers(
         np.random.random((int(num_labels + 1), 3)) * 0.9
     )  # (Stay away from white)
     colors_by_index = np.vstack((colors_by_index, [1, 1, 1]))
-    low_x_ind = np.searchsorted(sorted_peaks[:, 0], range(0, shape[0]), side="left")
+    low_x_ind = np.searchsorted(sorted_peaks[:, 0], range(0, shape[1]), side="left")
     high_x_ind = np.searchsorted(
-        sorted_peaks[:, 0], range(1, shape[0] + 1), side="left"
+        sorted_peaks[:, 0], range(1, shape[1] + 1), side="left"
     )
     for i, (lo_x, hi_x) in enumerate(zip(low_x_ind, high_x_ind)):
         x_inds = sorted_peaks[lo_x:hi_x]
-        low_y_ind = np.searchsorted(x_inds[:, 1], range(0, shape[1]), side="left")
-        high_y_ind = np.searchsorted(x_inds[:, 1], range(1, shape[1] + 1), side="left")
+        low_y_ind = np.searchsorted(x_inds[:, 1], range(0, shape[0]), side="left")
+        high_y_ind = np.searchsorted(x_inds[:, 1], range(1, shape[0] + 1), side="left")
         for j, (lo_y, hi_y) in enumerate(zip(low_y_ind, high_y_ind)):
             x_values = x_inds[lo_y:hi_y, 2]
             y_values = x_inds[lo_y:hi_y, 3]


### PR DESCRIPTION
---
Vectors to Mask
---

**Checklist**

- [x] implementation steps
- [x] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**

I'll add an example and some tests for this later tonight but the simple idea here (from a great suggestion from @tinabe) is that you can take a set of vectors and make a 4D mask. 

```python 
import pyxem as pxm
s = pxm.data.sped_ag(lazy=True)
temp = s.template_match_disk(disk_r=3, subtract_min=False)
dv = temp.get_diffraction_vectors(threshold_abs=0.55)
mask = dv.vectors_to_mask(disk_r=4)
filtered = s*mask
```

Alternatively you __should__ be able to subtract the best fit from some phase mapping.  I'll make an example of that later. 