### PR TITLE
Bug Fix Orientation

### DIFF
--- a/examples/orientation_mapping/mulit_phase_orientation.py
+++ b/examples/orientation_mapping/mulit_phase_orientation.py
@@ -56,6 +56,7 @@ sim = generator.calculate_diffraction2d(
     reciprocal_radius=2,
     with_direct_beam=False,
 )
+polar_multi = polar_multi**0.5  # gamma correction
 orientation_map = polar_multi.get_orientation(sim)
 
 

--- a/examples/orientation_mapping/on_zone_orientation.py
+++ b/examples/orientation_mapping/on_zone_orientation.py
@@ -57,6 +57,7 @@ sim = generator.calculate_diffraction2d(
 # This should be fairly good at finding the orientation of the grains on each side of the tilt boundary.
 # The rotation is stored in the rotation column of the orientation map or .isg[2,0] if you want to use the
 # rotation as a navigator or plot it directly.
+polar_si_tilt = polar_si_tilt**0.5  # gamma correction
 
 orientation_map = polar_si_tilt.get_orientation(sim)
 orientation_map.plot_over_signal(simulated_si_tilt)

--- a/examples/orientation_mapping/single_phase_orientation.py
+++ b/examples/orientation_mapping/single_phase_orientation.py
@@ -55,7 +55,7 @@ sim = generator.calculate_diffraction2d(
 # there?" rather than "Is the Bragg vector the right intensity?" patially because the intensity of the Bragg vector might have
 # many different effects.
 
-
+polar_si = polar_si**0.5  # gamma correction.
 orientation_map = polar_si.get_orientation(sim)
 orientation_map.plot_over_signal(simulated_si, vmax="96th")
 

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -839,7 +839,7 @@ class OrientationMap(DiffractionVectors2D):
             offset_transform="display",
             offsets=[[0, 0]],
         )
-        return polygon_sector, texts, mesh
+        return polygon_sector, mesh, texts
 
     def to_ipf_colormap(
         self,

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -196,7 +196,7 @@ def vectors_to_text(vectors, fast=True):
 
     def add_bar(i: int) -> str:
         if i < 0:
-            return f"\\bar{{{abs(i)}}}"
+            return f"$\\bar{{{abs(i)}}}$"
         else:
             return f"{i}"
 
@@ -328,7 +328,11 @@ class OrientationMap(DiffractionVectors2D):
             raise ValueError(
                 "Cannot create rotation from lazy signal. Please compute the signal first."
             )
-        all_rotations = Rotation.stack(self.simulation.rotations).flatten()
+        if isinstance(self.simulation.rotations, (list, np.ndarray)):
+            quats = np.vstack([r.data for r in self.simulation.rotations])
+            all_rotations = Rotation(data=quats)
+        else:
+            all_rotations = self.simulation.rotations
         rotations = self.map(
             rotation_from_orientation_map,
             rots=all_rotations.data,

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -336,13 +336,7 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         n_best : int
             The number of best matching orientations to keep.
         normalize_templates : bool
-            Normalize the templates to the same intensity.
-        gamma : float
-            The gamma correction applied to the diffraction patterns. The default
-            value is 0.5 which takes the square root of the diffraction patterns to
-            increase the intensity of the low intensity reflections and decrease the
-            intensity of the high intensity reflections. In most cases gamma<1 is a
-            good starting point.  See :cite:`pyxemorientationmapping2022` for more information.
+            Normalize the templates to the same intensity..
         kwargs : dict
             Any additional options for the :meth:`~hyperspy.signal.BaseSignal.map` function.
         Returns
@@ -350,9 +344,24 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         orientation : BaseSignal
             A signal with the orientation at each navigation position.
 
+        Notes
+        -----
+            A gamma correction is often applied to the diffraction patterns. A good value
+            to start with is thethe square root (gamma=0.5) of the diffraction patterns to
+            increase the intensity of the low intensity reflections and decrease the
+            intensity of the high intensity reflections. This can be applied via:
+
+            >>> s_gamma = s**0.5
+
+            In most cases gamma<1 See :cite:`pyxemorientationmapping2022` for more information.
+            Additionally, subtracting a small value can sometimes be helpful as it penalizes
+            diffraction patterns which do not have the full compliment of simulated diffraction
+            vectors.
+
         References
         ----------
             .. bibliography::
+
         """
         (
             r_templates,

--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -316,7 +316,6 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         n_keep=None,
         frac_keep=0.1,
         n_best=1,
-        gamma=0.5,
         normalize_templates=True,
         **kwargs,
     ):
@@ -355,8 +354,6 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         ----------
             .. bibliography::
         """
-        if gamma != 1:
-            self.data = self.data**gamma
         (
             r_templates,
             theta_templates,
@@ -384,6 +381,7 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
             transpose=True,
             output_signal_size=(n_best, 4),
             output_dtype=float,
+            **kwargs,
         )
 
         # Translate in-plane rotation from index to degrees

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -227,7 +227,8 @@ class TestOrientationResult:
             reciprocal_radius=2,
             with_direct_beam=True,
         )
-        orientations = polar.get_orientation(sims, alpha=1)  # in this case we
+        polar = polar**0.5
+        orientations = polar.get_orientation(sims)
         return orientations, r, s
 
     @pytest.fixture(scope="class")
@@ -294,14 +295,23 @@ class TestOrientationResult:
         assert np.all(crystal_map.phase_id < 2)
 
     @pytest.mark.parametrize("annotate", [True, False])
+    @pytest.mark.parametrize("fast", [True, False])
     @pytest.mark.parametrize("lazy_output", [True, False])
     @pytest.mark.parametrize("add_intensity", [True, False])
     def test_to_markers(
-        self, simple_multi_rot_orientation_result, annotate, lazy_output, add_intensity
+        self,
+        simple_multi_rot_orientation_result,
+        annotate,
+        lazy_output,
+        add_intensity,
+        fast,
     ):
         orientations, rotations, s = simple_multi_rot_orientation_result
         markers = orientations.to_markers(
-            lazy_output=lazy_output, annotate=annotate, include_intensity=add_intensity
+            lazy_output=lazy_output,
+            annotate=annotate,
+            include_intensity=add_intensity,
+            fast=fast,
         )
         assert isinstance(markers[0], hs.plot.markers.Markers)
 

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -243,7 +243,7 @@ class TestOrientationResult:
 
         generator = SimulationGenerator(200, minimum_intensity=0.05)
         rotations = get_sample_reduced_fundamental(
-            resolution=1, point_group=phase.point_group
+            resolution=2, point_group=phase.point_group
         )
         rotations2 = get_sample_reduced_fundamental(
             resolution=1, point_group=phase2.point_group


### PR DESCRIPTION
---
Bug Fix Orientation Mapping
---

@tinabe let me know if this fixes the problems with the template matching.  This removed the gamma correction (you can do that easily with s**0.5 etc). 

The gamma correction was also operating on the data inplace which leads to some not ideal behavior. 

This also fixes the labels for the hkl although it is a rather "quick" fix and it would be good to have a better way of handling that. That is a larger issue that might need to be properly handled upstream in orix. Particularly speeding up how long it takes to deep copy a `Phase` object. 

I also allowed for `fast=True` which just uses negative values rather than using latex to render the bar above the text which is quite slow currently, although this is quite possibly computer dependent.

We can make a 0.19.1 release if we know that this fixes the problems. 
