### PR TITLE
Multi phase marker support for orientation map plots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 Added
 -----
 - Added Examples for general plotting functions focusing on plotting diffraction patterns (#1108)
+- Added support for marker plotting for multi-phase orientation mapping results (#1092)
 
 Removed
 -------

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -436,6 +436,15 @@ def rotation_from_orientation_map(result, rots):
     return ori
 
 
+@deprecated(
+    since="0.20",
+    removal="1.0.0",
+    alternative="pyxem.signals.indexation_results.vectors_from_orientation_map",
+)
+def extract_vectors_from_orientation_map(result, all_vectors, n_best_index=0):
+    return vectors_from_orientation_map(result, all_vectors, n_best_index=n_best_index)
+
+
 def vectors_from_orientation_map(result, all_vectors, n_best_index=0):
     index, _, rotation, mirror = result[n_best_index, :].T
     index = index.astype(int)
@@ -603,6 +612,16 @@ class OrientationMap(DiffractionVectors2D):
             ),
             symmetry=self.simulation.phases.point_group,
         )
+
+    @deprecated(
+        since="0.20",
+        removal="1.0.0",
+        alternative="pyxem.signals.OrientationMap.to_vectors",
+    )
+    def to_single_phase_vectors(
+        self, n_best_index: int = 0, **kwargs
+    ) -> hs.signals.Signal1D:
+        return self.to_vectors(n_best_index=n_best_index, **kwargs)
 
     def to_vectors(self, n_best_index: int = 0, **kwargs) -> hs.signals.Signal1D:
         """Get the reciprocal lattice vectors for each navigation position.

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -1128,6 +1128,8 @@ class OrientationMap(DiffractionVectors2D):
             raise ValueError("Only a single phase present in simulation")
 
         phase_idxs = self.to_phase_index()
+        # in case n_best = 1
+        phase_idxs = phase_idxs.reshape(*self.axes_manager._navigation_shape_in_array, -1)
         colors = [p.color_rgb for p in self.simulation.phases]
 
         float_rgb = np.take(colors, phase_idxs[..., 0], axis=0)

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -394,10 +394,10 @@ class OrientationMap(DiffractionVectors2D):
             symmetry=self.simulation.phases.point_group,
         )
 
-    def to_single_phase_vectors(
+    def to_vectors(
         self, n_best_index: int = 0, **kwargs
     ) -> hs.signals.Signal1D:
-        """Get the reciprocal lattice vectors for a single-phase simulation.
+        """Get the reciprocal lattice vectors for each navigation position.
 
         Parameters
         ----------
@@ -408,10 +408,10 @@ class OrientationMap(DiffractionVectors2D):
         """
 
         if self.simulation.has_multiple_phases:
-            raise ValueError("Multiple phases found in simulation")
-
-        # Use vector data as signal in case of different vectors per navigation position
-        vectors_signal = hs.signals.Signal1D(self.simulation.coordinates)
+            # Use vector data as signal in case of different vectors per navigation position
+            vectors_signal = hs.signals.Signal1D(self.simulation.coordinates)
+        else:
+            vectors_signal = hs.signals.Signal1D([sim for sim in self.simulations])
         v = self.map(
             extract_vectors_from_orientation_map,
             all_vectors=vectors_signal,
@@ -580,7 +580,7 @@ class OrientationMap(DiffractionVectors2D):
             navigation_chunks = None
         all_markers = []
         for n in range(n_best):
-            vectors = self.to_single_phase_vectors(
+            vectors = self.to_vectors(
                 lazy_output=True, navigation_chunks=navigation_chunks
             )
             color = marker_colors[n % len(marker_colors)]

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -768,8 +768,11 @@ class OrientationMap(DiffractionVectors2D):
 
         Notes
         -----
+        It is recommended to have a large `n_keep` for this to look nice, e.g. 75% of the simulation bank.
+
         This will not look good if the rotations used in the simulation(s) consists of
         multiple different regions in the IPF.
+        
         """
         phase_idx_signal = hs.signals.Signal1D(self.to_phase_index())
         phases = self.simulation.phases
@@ -1140,9 +1143,9 @@ class OrientationMap(DiffractionVectors2D):
         signal,
         add_vector_markers=True,
         add_ipf_markers=True,
+        add_ipf_correlation_heatmap=False,
         add_ipf_colorkey=True,
         vector_kwargs=None,
-        ipf_marker_show_correlation=False,
         **kwargs,
     ):
         """Convenience method to plot the orientation map and the n-best matches over the signal.
@@ -1155,6 +1158,9 @@ class OrientationMap(DiffractionVectors2D):
             If True, the vector markers will be added to the signal.
         add_ipf_markers : bool
             If True, the IPF best fit will be added to the signal in an overlay
+        add_ipf_correlation_heatmap : bool
+            If True, a correlation score heatmap as an IPF will be added to the signal in an overlay.
+            This overrides the `add_ipf_markers` parameter.
         add_ipf_colorkey : bool
             If True, the IPF colorkey will be added to the signal
         vector_kwargs : dict
@@ -1173,10 +1179,12 @@ class OrientationMap(DiffractionVectors2D):
         signal.plot(navigator=nav, **kwargs)
         if add_vector_markers:
             signal.add_marker(self.to_markers(1, **vector_kwargs))
-        if add_ipf_markers:
-            cmap = "magma" if ipf_marker_show_correlation else None
-            ipf_markers = self.to_ipf_markers(cmap=cmap)
+        if add_ipf_markers and not add_ipf_correlation_heatmap:
+            ipf_markers = self.to_ipf_markers()
             signal.add_marker(ipf_markers)
+        if add_ipf_correlation_heatmap:
+            heatmap_markers = self.to_ipf_correlation_heatmap_markers()
+            signal.add_marker(heatmap_markers)
         if add_ipf_colorkey:
             signal.add_marker(
                 get_ipf_annotation_markers(self.simulation.phases), plot_on_signal=False

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -440,9 +440,7 @@ def vectors_from_orientation_map(result, all_vectors, n_best_index=0):
     rotation = Rotation.from_euler(
         (mirror * rotation, 0, 0), degrees=True, direction="crystal2lab"
     )
-    assert len(vectors.shape) == 1
-    assert vectors.size > 1
-    assert rotation.data.size == 4
+
     vectors = ~rotation * vectors.to_miller()
     vectors = DiffractingVector(
         vectors.phase, xyz=vectors.data.copy(), intensity=intensity

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -1129,7 +1129,9 @@ class OrientationMap(DiffractionVectors2D):
 
         phase_idxs = self.to_phase_index()
         # in case n_best = 1
-        phase_idxs = phase_idxs.reshape(*self.axes_manager._navigation_shape_in_array, -1)
+        phase_idxs = phase_idxs.reshape(
+            *self.axes_manager._navigation_shape_in_array, -1
+        )
         colors = [p.color_rgb for p in self.simulation.phases]
 
         float_rgb = np.take(colors, phase_idxs[..., 0], axis=0)

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -772,7 +772,7 @@ class OrientationMap(DiffractionVectors2D):
 
         This will not look good if the rotations used in the simulation(s) consists of
         multiple different regions in the IPF.
-        
+
         """
         phase_idx_signal = hs.signals.Signal1D(self.to_phase_index())
         phases = self.simulation.phases

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -53,6 +53,7 @@ from pyxem.utils.indexation_utils import get_nth_best_solution
 from pyxem.signals.diffraction_vectors2d import DiffractionVectors2D
 from pyxem.utils._signals import _transfer_navigation_axes
 from pyxem.utils.signal import compute_markers
+from pyxem.utils._deprecated import deprecated
 
 
 def crystal_from_vector_matching(z_matches):

--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -697,7 +697,12 @@ class OrientationMap(DiffractionVectors2D):
             The color of the markers. Overridden by cmap, if not None
         cmap : str
             Use a color map to show correlation scores.
-            Takes priority over the `color` parameter
+            Takes priority over the `color` parameter.
+
+        Notes
+        -----
+        This function can be slow with a large n_keep.
+        Use `to_ipf_correlation_heatmap_markers` instead.
         """
         rots = self.to_rotation()
         vecs = rots * Vector3d.zvector()
@@ -734,7 +739,7 @@ class OrientationMap(DiffractionVectors2D):
             )
         return markers
 
-    def get_ipf_correlation_heatmap(
+    def to_ipf_correlation_heatmap_markers(
         self,
         offset_x: float = 0.85,
         offset_y: float = 0.85,
@@ -760,7 +765,7 @@ class OrientationMap(DiffractionVectors2D):
             The text labels for the IPF axes
         mesh : hs.plot.markers.Markers
             The color mesh for the IPF (using :class:`matplotlib.collections.QuadMesh`)
-        
+
         Notes
         -----
         This will not look good if the rotations used in the simulation(s) consists of

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -385,3 +385,16 @@ class TestOrientationResult:
             ]
         )
         multi_phase_orientation_result.plot_over_signal(s)
+
+    def test_to_ipf_correlation_heatmap_markers_single_phase(
+        self, simple_multi_rot_orientation_result
+    ):
+        orientations, rotations, s = simple_multi_rot_orientation_result
+        markers = orientations.to_ipf_correlation_heatmap_markers()
+        assert all(isinstance(m, hs.plot.markers.Markers) for m in markers)
+
+    def test_to_ipf_correlation_heatmap_markers_multi_phase(
+        self, multi_phase_orientation_result
+    ):
+        markers = multi_phase_orientation_result.to_ipf_correlation_heatmap_markers()
+        assert all(isinstance(m, hs.plot.markers.Markers) for m in markers)

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -341,12 +341,6 @@ class TestOrientationResult:
         markers = orientations.to_ipf_markers()
         assert isinstance(markers[0], hs.plot.markers.Markers)
 
-    def test_to_ipf_annotation(self, simple_multi_rot_orientation_result):
-        orientations, rotations, s = simple_multi_rot_orientation_result
-        annotations = orientations.get_ipf_annotation_markers()
-        for a in annotations:
-            assert isinstance(a, hs.plot.markers.Markers)
-
     @pytest.mark.parametrize("add_markers", [True, False])
     def test_to_ipf_map(self, simple_multi_rot_orientation_result, add_markers):
         orientations, rotations, s = simple_multi_rot_orientation_result
@@ -355,15 +349,15 @@ class TestOrientationResult:
         if add_markers:
             assert len(navigator.metadata.Markers) == 3
 
+    def test_to_phasemap(self, multi_phase_orientation_result):
+        navigator = multi_phase_orientation_result.to_phase_map()
+        assert isinstance(navigator, hs.signals.BaseSignal)
+
     def test_multi_phase_errors(self, multi_phase_orientation_result):
         with pytest.raises(ValueError):
             multi_phase_orientation_result.to_ipf_colormap()
         with pytest.raises(ValueError):
-            multi_phase_orientation_result.to_single_phase_vectors()
-        with pytest.raises(ValueError):
             multi_phase_orientation_result.to_single_phase_orientations()
-        with pytest.raises(ValueError):
-            multi_phase_orientation_result.to_ipf_markers()
 
     def test_lazy_error(self, simple_multi_rot_orientation_result):
         orientations, rotations, s = simple_multi_rot_orientation_result
@@ -382,3 +376,12 @@ class TestOrientationResult:
     def test_plot_over_signal(self, simple_multi_rot_orientation_result):
         orientations, rotations, s = simple_multi_rot_orientation_result
         orientations.plot_over_signal(s)
+
+    def test_plot_over_signal_multi_phase(self, multi_phase_orientation_result):
+        # Mock signal
+        s = hs.signals.Signal2D(
+            np.zeros(multi_phase_orientation_result.data.shape[:-2])[
+                ..., np.newaxis, np.newaxis
+            ]
+        )
+        multi_phase_orientation_result.plot_over_signal(s)

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -373,18 +373,62 @@ class TestOrientationResult:
         with pytest.raises(ValueError):
             rotations = orientations.to_crystal_map()
 
-    def test_plot_over_signal(self, simple_multi_rot_orientation_result):
+    @pytest.mark.parametrize("add_vector_markers", [False, True])
+    @pytest.mark.parametrize("add_ipf_markers", [False, True])
+    @pytest.mark.parametrize("add_ipf_correlation_heatmap", [False, True])
+    @pytest.mark.parametrize("add_ipf_colorkey", [False, True])
+    @pytest.mark.parametrize(
+        "vector_kwargs", [None, {"annotate": False}, {"annotate": True}]
+    )
+    def test_plot_over_single_phase_signal(
+        self,
+        simple_multi_rot_orientation_result,
+        add_vector_markers,
+        add_ipf_markers,
+        add_ipf_correlation_heatmap,
+        add_ipf_colorkey,
+        vector_kwargs,
+    ):
         orientations, rotations, s = simple_multi_rot_orientation_result
-        orientations.plot_over_signal(s)
+        orientations.plot_over_signal(
+            s,
+            add_vector_markers=add_vector_markers,
+            add_ipf_markers=add_ipf_markers,
+            add_ipf_correlation_heatmap=add_ipf_correlation_heatmap,
+            add_ipf_colorkey=add_ipf_colorkey,
+            vector_kwargs=vector_kwargs,
+        )
 
-    def test_plot_over_signal_multi_phase(self, multi_phase_orientation_result):
+    @pytest.mark.parametrize("add_vector_markers", [False, True])
+    @pytest.mark.parametrize("add_ipf_markers", [False, True])
+    @pytest.mark.parametrize("add_ipf_correlation_heatmap", [False, True])
+    @pytest.mark.parametrize("add_ipf_colorkey", [False, True])
+    @pytest.mark.parametrize(
+        "vector_kwargs", [None, {"annotate": False}, {"annotate": True}]
+    )
+    def test_plot_over_multi_phase_signal(
+        self,
+        multi_phase_orientation_result,
+        add_vector_markers,
+        add_ipf_markers,
+        add_ipf_correlation_heatmap,
+        add_ipf_colorkey,
+        vector_kwargs,
+    ):
         # Mock signal
         s = hs.signals.Signal2D(
             np.zeros(multi_phase_orientation_result.data.shape[:-2])[
                 ..., np.newaxis, np.newaxis
             ]
         )
-        multi_phase_orientation_result.plot_over_signal(s)
+        multi_phase_orientation_result.plot_over_signal(
+            s,
+            add_vector_markers=add_vector_markers,
+            add_ipf_markers=add_ipf_markers,
+            add_ipf_correlation_heatmap=add_ipf_correlation_heatmap,
+            add_ipf_colorkey=add_ipf_colorkey,
+            vector_kwargs=vector_kwargs,
+        )
 
     def test_to_ipf_correlation_heatmap_markers_single_phase(
         self, simple_multi_rot_orientation_result


### PR DESCRIPTION
---
Multi phase marker support for orientation map plots
---

**Checklist**

- [x] implementation steps
- [ ] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
Add support for multiple phases in `OrientationMap` plots.
Example for single phase (Ag) (current):
![bilde](https://github.com/pyxem/pyxem/assets/57151700/dfbc7540-3059-4f23-8f42-0071f97ed5d6)

And multi-phase (graphite and BCC iron) (new):
![bilde](https://github.com/pyxem/pyxem/assets/57151700/4347a356-c66c-4840-ae60-79a900fe35f0)

Note how the top `n_best` are distributed among both phases, although the results are poor as I spent no time on pre-processing.
I used the phase map as a navigator, which does not have a legend like `to_crystal_map().plot()` has. It could probably be done similarly to the ipf in the corner.

