### PR TITLE
Fix failing docs build

### DIFF
--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -22,7 +22,6 @@ explanations of the functionality.
     detectors
     data
     components
-    dummy_data
     generators
     libraries
     signals


### PR DESCRIPTION
---
Fix failing docs build
---

Fix  #1111 

**Checklist**

- [x] Remove the deleted `dummy_data` from the API reference
- [ ] Something else blocking the build maybe
- [ ] update the Changelog
- [ ] mark as ready for review

