### PR TITLE
Fit linear plane in pyxem.signals.BeamShift.get_linear_plane by minimising magnitude variance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,11 @@ Fixed
 - Fixed bugs releated to orientation mapping with multiple phases and the plotting of the
   vector annotations. (#1090)
 
+Added
+-----
+- Added a way to fit linear planes in :meth:`pyxem.signals.BeamShift.get_linear_plane` by minimizing magnitude variance. (#1116)
+- In :meth:`pyxem.signals.BeamShift.get_linear_plane` exposed initial values for optimization to make it more flexible. (#1116)
+
 2024-06-08 - version 0.19.0
 ===========================
 

--- a/examples/processing/centering_the_zero_beam.py
+++ b/examples/processing/centering_the_zero_beam.py
@@ -38,4 +38,57 @@ s_pacbed_centered = s_centered.sum()
 s_pacbed = s.sum()
 
 hs.plot.plot_images([s_pacbed, s_pacbed_centered], label=["Original", "Centered"])
+
+# %%
+# Centering the Zero Beam with constant deflection magnitude
+# -----------------------
+# In the presence of electromagnetic fields in the entire sample area, 
+# the plane fitting can fail However, if there are several domains expected 
+# to have equal deflection magnitude, we can try to fit a plane to this by 
+# minimizing the magnitude variance.
+
+def direct_beam_dataset_with_constant_shift_magnitude():
+
+    import numpy as np
+    bright_field_disk = np.zeros((128,128),dtype=np.int16)
+    bright_field_disk[np.sum((np.mgrid[:128,:128]-64)**2,axis=0) < 10**2 ] = 500
+
+    probes = np.zeros((20,20),dtype=int)
+    probes = bright_field_disk[np.newaxis][probes]
+    probes = pxm.signals.Diffraction2D(probes)
+
+
+    p = [0.5] * 6  # Plane parameters
+    x, y = np.meshgrid(np.arange(20), np.arange(20))
+    base_plane_x = p[0] * x + p[1] * y + p[2]
+    base_plane_y = p[3] * x + p[4] * y + p[5]
+
+    base_plane = np.stack((base_plane_x, base_plane_y)).T
+    data = base_plane.copy()
+
+    shifts = np.zeros_like(data)
+    shifts[:10, 10:] = (10, 10)
+    shifts[:10, :10] = (10, -10)
+    shifts[10:, 10:] = (-10, 10)
+    shifts[10:, :10] = (-10, -10)
+    data += shifts
+    data = pxm.signals.BeamShift(data)
+    probes.center_direct_beam(shifts=-data)
+    return probes
+
+probes = direct_beam_dataset_with_constant_shift_magnitude()
+
+s_shifts = probes.get_direct_beam_position(method="center_of_mass")
+
+# %%
+# We call `get_linear_plane` with `constrain_magnitude_variance=True`. 
+s_linear_plane = s_shifts.get_linear_plane(constrain_magnitude_variance=True)
+s_shifts.data -= s_linear_plane.data
+
+probes.center_direct_beam(shifts=s_linear_plane)
+probes.plot()
+
+# %%
+# The found electromagnetic domains can be visualized like such.
+s_shifts.get_magnitude_phase_signal().plot()
 # %%

--- a/examples/processing/centering_the_zero_beam.py
+++ b/examples/processing/centering_the_zero_beam.py
@@ -43,15 +43,17 @@ hs.plot.plot_images([s_pacbed, s_pacbed_centered], label=["Original", "Centered"
 # Centering the Zero Beam with constant deflection magnitude
 # -----------------------
 # In the presence of electromagnetic fields in the entire sample area, 
-# the plane fitting can fail However, if there are several domains expected 
+# the plane fitting can fail. However, if there are several domains expected 
 # to have equal deflection magnitude, we can try to fit a plane to this by 
 # minimizing the magnitude variance.
 
 def direct_beam_dataset_with_constant_shift_magnitude():
 
+    direct_beam_radius = 10
+
     import numpy as np
     bright_field_disk = np.zeros((128,128),dtype=np.int16)
-    bright_field_disk[np.sum((np.mgrid[:128,:128]-64)**2,axis=0) < 10**2 ] = 500
+    bright_field_disk[np.sum((np.mgrid[:128,:128]-64)**2,axis=0) < direct_beam_radius**2 ] = 500
 
     probes = np.zeros((20,20),dtype=int)
     probes = bright_field_disk[np.newaxis][probes]
@@ -81,14 +83,16 @@ probes = direct_beam_dataset_with_constant_shift_magnitude()
 s_shifts = probes.get_direct_beam_position(method="center_of_mass")
 
 # %%
-# We call `get_linear_plane` with `constrain_magnitude_variance=True`. 
+# We call `get_linear_plane` with `constrain_magnitude_variance=True`. Then
+# we can center the direct beam as normal.
 s_linear_plane = s_shifts.get_linear_plane(constrain_magnitude_variance=True)
-s_shifts.data -= s_linear_plane.data
 
 probes.center_direct_beam(shifts=s_linear_plane)
 probes.plot()
 
 # %%
 # The found electromagnetic domains can be visualized like such.
+s_shifts.data -= s_linear_plane.data
 s_shifts.get_magnitude_phase_signal().plot()
+
 # %%

--- a/examples/processing/centering_the_zero_beam.py
+++ b/examples/processing/centering_the_zero_beam.py
@@ -45,7 +45,7 @@ hs.plot.plot_images([s_pacbed, s_pacbed_centered], label=["Original", "Centered"
 # In the presence of electromagnetic fields in the entire sample area, 
 # the plane fitting can fail. However, if there are several domains expected 
 # to have equal deflection magnitude, we can try to fit a plane to this by 
-# minimizing the magnitude variance.
+# minimizing the magnitude variance. You may need a mask for good performance.
 
 def direct_beam_dataset_with_constant_shift_magnitude():
 
@@ -78,17 +78,16 @@ def direct_beam_dataset_with_constant_shift_magnitude():
     probes.center_direct_beam(shifts=-data)
     return probes
 
-probes = direct_beam_dataset_with_constant_shift_magnitude()
+s_probes = direct_beam_dataset_with_constant_shift_magnitude()
 
-s_shifts = probes.get_direct_beam_position(method="center_of_mass")
+s_shifts = s_probes.get_direct_beam_position(method="center_of_mass")
 
 # %%
 # We call `get_linear_plane` with `constrain_magnitude_variance=True`. Then
 # we can center the direct beam as normal.
 s_linear_plane = s_shifts.get_linear_plane(constrain_magnitude_variance=True)
 
-probes.center_direct_beam(shifts=s_linear_plane)
-probes.plot()
+s_probes.center_direct_beam(shifts=s_linear_plane)
 
 # %%
 # The found electromagnetic domains can be visualized like such.

--- a/examples/processing/centering_the_zero_beam.py
+++ b/examples/processing/centering_the_zero_beam.py
@@ -49,8 +49,8 @@ hs.plot.plot_images([s_pacbed, s_pacbed_centered], label=["Original", "Centered"
 # 2. The zero beam will be deflected from electromagnetic fields in the sample
 #
 # Assuming that the effects of 1 are systematic and that the electromagnetic fields have
-# constant strengths, we can try to fit a plane to correct for effects of 1 by minimizing the 
-# magnitude variance. You may need use a mask and/or have several electromagnetic 
+# constant strengths, we can try to fit a plane to correct for effects of 1 by minimizing the
+# magnitude variance. You may need use a mask and/or have several electromagnetic
 # domains for good performance.
 
 s_probes = pxm.data.simulated_constant_shift_magnitude()

--- a/examples/processing/centering_the_zero_beam.py
+++ b/examples/processing/centering_the_zero_beam.py
@@ -43,14 +43,15 @@ hs.plot.plot_images([s_pacbed, s_pacbed_centered], label=["Original", "Centered"
 # Centering the Zero Beam with constant deflection magnitude
 # ----------------------------------------------------------
 # In the presence of electromagnetic fields in the entire sample area,
-# the plane fitting can fail. In this case, two seperate effects can be observed:
+# the plane fitting can fail. In this case, two separate effects can be observed:
 #
 # 1. The zero beam position varies systematically with the scan position due to the effects of descan
 # 2. The zero beam will be deflected from electromagnetic fields in the sample
 #
-# Assuming that the effects of 1 are systematic and that the electomagnetic fields are
-# large we can try to fit a plane to correct for effects of 1 by minimizing the magnitude
-# variance. You may need a mask for good performance.
+# Assuming that the effects of 1 are systematic and that the electromagnetic fields have
+# constant strengths, we can try to fit a plane to correct for effects of 1 by minimizing the 
+# magnitude variance. You may need use a mask and/or have several electromagnetic 
+# domains for good performance.
 
 s_probes = pxm.data.simulated_constant_shift_magnitude()
 
@@ -75,5 +76,10 @@ s_probes.center_direct_beam(shifts=s_linear_plane)
 # from the original shifts.
 s_shifts -= s_linear_plane
 s_shifts.get_magnitude_phase_signal().plot()
+
+# For more realistic data, the linear plane optimization algorithm can give poor results. In this case,
+# you can change the initial values for the optimization algorithm by using the `initial_values` parameter
+# in `get_linear_plane`. See the docstring for more information. Try varying this and see if the plane
+# changes significantly.
 
 # %%

--- a/pyxem/data/__init__.py
+++ b/pyxem/data/__init__.py
@@ -51,7 +51,10 @@ from pyxem.data._data import (
     sped_ag,
     pdcusi_insitu,
 )
-from pyxem.data.simulated_dpc import simulated_stripes
+from pyxem.data.simulated_dpc import (
+    simulated_stripes,
+    simulated_constant_shift_magnitude,
+)
 
 __all__ = [
     "au_grating",
@@ -75,4 +78,5 @@ __all__ = [
     "feal_stripes",
     "sped_ag",
     "pdcusi_insitu",
+    "simulated_constant_shift_magnitude",
 ]

--- a/pyxem/data/simulated_dpc.py
+++ b/pyxem/data/simulated_dpc.py
@@ -33,3 +33,50 @@ def simulated_stripes(beam_shifts=None):
     s.axes_manager[2].scale = 0.1
     s.axes_manager[3].scale = 0.1
     return s
+
+
+def simulated_constant_shift_magnitude(beam_radius=10):
+    """
+    Create a simulated diffraction pattern with a direct beam that is shifted by a constant magnitude across
+    the entire pattern. In the presence of electromagnetic fields in the entire sample area, the plane fitting
+    can fail, however by minimizing the magnitude variance, we can fit a plane to the shifts
+
+
+    Parameters
+    ----------
+    beam_radius : int, optional
+        The radius of the direct beam in pixels. The default is 10.
+
+    Returns
+    -------
+    probes : Diffraction2D
+        A simulated diffraction pattern with a direct beam that is shifted by a constant
+        magnitude across the entire pattern.
+
+    """
+    bright_field_disk = np.zeros((128, 128), dtype=np.int16)
+    bright_field_disk[
+        np.sum((np.mgrid[:128, :128] - 64) ** 2, axis=0) < beam_radius**2
+    ] = 500
+
+    probes = np.zeros((20, 20), dtype=int)
+    probes = bright_field_disk[np.newaxis][probes]
+    probes = pxm.signals.Diffraction2D(probes)
+
+    p = [0.5] * 6  # Plane parameters
+    x, y = np.meshgrid(np.arange(20), np.arange(20))
+    base_plane_x = p[0] * x + p[1] * y + p[2]
+    base_plane_y = p[3] * x + p[4] * y + p[5]
+
+    base_plane = np.stack((base_plane_x, base_plane_y)).T
+    data = base_plane.copy()
+
+    shifts = np.zeros_like(data)
+    shifts[:10, 10:] = (10, 10)
+    shifts[:10, :10] = (10, -10)
+    shifts[10:, 10:] = (-10, 10)
+    shifts[10:, :10] = (-10, -10)
+    data += shifts
+    data = pxm.signals.BeamShift(data)
+    probes.center_direct_beam(shifts=-data)
+    return probes

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -48,7 +48,7 @@ class BeamShift(DiffractionVectors1D):
         mask=None,
         fit_corners=None,
         initial_values=None,
-        constrain_magnitude=False,
+        constrain_magnitude_variance=False,
     ):
         """Fit linear planes to the beam shifts, and returns a BeamShift signal
         with the planes.
@@ -89,13 +89,17 @@ class BeamShift(DiffractionVectors1D):
             signal. This mush be set with a number, like 0.05 (5%) or 0.10 (10%).
         initial_values : array of floats, optional
             Initial guess for the plane parameters. Useful to vary if the plane fitting
-            does not give desirable results. The parameters are as follows:
+            does not give desirable results. 
+            The x- and y-shifts are described by two linear planes with three parameters. 
+            The two first parameters, d/dx and d/dy, are the changes in x- or y-shift 
+            as you move one position in the navigation space in respectively the x- and y-
+            directions. The third parameter, x_0 or y_0, are respectively the x- and y-
+            shifts in the (0, 0) navigation position. The parameters are laid out thusly,
+            with the first three being for the x-shifts and the rest for the y-shifts:
             [d/dx, d/dy, x_0, d/dx, d/dy, y_0]
-            where the first three entries are for the x-shift, being in order the
-            step in x, step in y and the initial value at (0, 0). Similarly for the
-            last three entries for the y-shift. Currently only implemented for the
-            case when `constrain_magnitude` is `True`.
-        constrain_magnitude : bool, optional
+            Currently only implemented for the case when `constrain_magnitude_variance` 
+            is `True`.
+        constrain_magnitude_variance : bool, optional
             Fits the linear planes to deflections with constant magnitude. By default
             set to `False`.
             In the presence of electromagnetic fields in the sample area, least squares
@@ -103,7 +107,9 @@ class BeamShift(DiffractionVectors1D):
             uniform field strength, we can fit planes by trying to minimise the variance
             of the magnitudes, giving a constant deflection magnitude.
             Note that for this to work several field directions must be present. Extra
-            care must be taken in presence of significant noise.
+            care must be taken in presence of significant noise, such as with a mask.
+            If desirable results are not found, try varying the `initial_values`
+            parameter.
 
         Examples
         --------
@@ -142,7 +148,7 @@ class BeamShift(DiffractionVectors1D):
             mask = mask.__array__()
             if mask.dtype != bool:
                 raise ValueError("mask needs to have a datatype of bool")
-        if constrain_magnitude:
+        if constrain_magnitude_variance:
             plane_image = bst._get_linear_plane_by_minimizing_magnitude_variance(
                 self, mask=mask, initial_values=initial_values
             )

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -96,7 +96,8 @@ class BeamShift(DiffractionVectors1D):
             last three entries for the y-shift. Currently only implemented for the
             case when `constrain_magnitude` is `True`.
         constrain_magnitude : bool, optional
-            Fits the linear planes to deflections with constant magnitude.
+            Fits the linear planes to deflections with constant magnitude. By default
+            set to `False`.
             In the presence of electromagnetic fields in the sample area, least squares
             fitting can give inaccurate results. If the region is expected to have
             uniform field strength, we can fit planes by trying to minimise the variance

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -43,7 +43,7 @@ class BeamShift(DiffractionVectors1D):
         self.data = s_linear_plane.data
         self.events.data_changed.trigger(None)
 
-    def get_linear_plane(self, mask=None, fit_corners=None, constrain_magnitude=False):
+    def get_linear_plane(self, mask=None, fit_corners=None, initial_values=None, constrain_magnitude=False):
         """Fit linear planes to the beam shifts, and returns a BeamShift signal
         with the planes.
 
@@ -81,6 +81,13 @@ class BeamShift(DiffractionVectors1D):
         fit_corners : float, optional
             Make a mask so that the planes are fitted to the corners of the
             signal. This mush be set with a number, like 0.05 (5%) or 0.10 (10%).
+        initial_values : array of floats, optional
+            Initial guess for the plane parameters. Useful to vary if the plane fitting
+            does not give desirable results. The parameters are as follows:
+            [d/dx, d/dy, x_0, d/dx, d/dy, y_0]
+            where the first three entries are for the x-shift, being in order the
+            step in x, step in y and the initial value at (0, 0). Similarly for the
+            last three entries for the y-shift.
         constrain_magnitude : bool, optional
             Fits the linear planes so there are deflection with constant magnitude.
             In the presence of electromagnetic fields in the sample area, least squares 
@@ -128,7 +135,7 @@ class BeamShift(DiffractionVectors1D):
             if mask.dtype != bool:
                 raise ValueError("mask needs to be an array of bools")
         if constrain_magnitude:
-            plane_image = bst._get_linear_plane_by_minimizing_magnitude_variance(self, mask=mask)
+            plane_image = bst._get_linear_plane_by_minimizing_magnitude_variance(self, mask=mask, initial_values=initial_values)
         else:
             plane_image_x = bst._get_linear_plane_from_signal2d(s_shift_x, mask=mask)
             plane_image_y = bst._get_linear_plane_from_signal2d(s_shift_y, mask=mask)

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -128,7 +128,7 @@ class BeamShift(DiffractionVectors1D):
             if mask.dtype != bool:
                 raise ValueError("mask needs to be an array of bools")
         if constrain_magnitude:
-            plane_image = bst._get_linear_xy_planes_from_signal2d(self, mask=mask)
+            plane_image = bst._get_linear_plane_by_minimizing_magnitude_variance(self, mask=mask)
         else:
             plane_image_x = bst._get_linear_plane_from_signal2d(s_shift_x, mask=mask)
             plane_image_y = bst._get_linear_plane_from_signal2d(s_shift_y, mask=mask)

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -43,7 +43,13 @@ class BeamShift(DiffractionVectors1D):
         self.data = s_linear_plane.data
         self.events.data_changed.trigger(None)
 
-    def get_linear_plane(self, mask=None, fit_corners=None, initial_values=None, constrain_magnitude=False):
+    def get_linear_plane(
+        self,
+        mask=None,
+        fit_corners=None,
+        initial_values=None,
+        constrain_magnitude=False,
+    ):
         """Fit linear planes to the beam shifts, and returns a BeamShift signal
         with the planes.
 
@@ -91,11 +97,11 @@ class BeamShift(DiffractionVectors1D):
             case when constrain_magnitude is `True`.
         constrain_magnitude : bool, optional
             Fits the linear planes to deflections with constant magnitude.
-            In the presence of electromagnetic fields in the sample area, least squares 
-            fitting can give inaccurate results. If the region is expected to have 
+            In the presence of electromagnetic fields in the sample area, least squares
+            fitting can give inaccurate results. If the region is expected to have
             uniform field strength, we can fit planes by trying to minimise the variance
             of the magnitudes, giving a constant deflection magnitude.
-            Note that for this to work several field directions must be present. Extra 
+            Note that for this to work several field directions must be present. Extra
             care must be taken in presence of significant noise.
 
         Examples
@@ -132,11 +138,13 @@ class BeamShift(DiffractionVectors1D):
         s_shift_x = self.isig[0].T
         s_shift_y = self.isig[1].T
         if mask is not None:
-            mask = mask.__array__()            
+            mask = mask.__array__()
             if mask.dtype != bool:
-                raise ValueError("mask needs to be an array of bools")
+                raise ValueError("mask needs to have a datatype of bool")
         if constrain_magnitude:
-            plane_image = bst._get_linear_plane_by_minimizing_magnitude_variance(self, mask=mask, initial_values=initial_values)
+            plane_image = bst._get_linear_plane_by_minimizing_magnitude_variance(
+                self, mask=mask, initial_values=initial_values
+            )
         else:
             plane_image_x = bst._get_linear_plane_from_signal2d(s_shift_x, mask=mask)
             plane_image_y = bst._get_linear_plane_from_signal2d(s_shift_y, mask=mask)

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -87,9 +87,10 @@ class BeamShift(DiffractionVectors1D):
             [d/dx, d/dy, x_0, d/dx, d/dy, y_0]
             where the first three entries are for the x-shift, being in order the
             step in x, step in y and the initial value at (0, 0). Similarly for the
-            last three entries for the y-shift.
+            last three entries for the y-shift. Currently only implemented for the
+            case when constrain_magnitude is `True`.
         constrain_magnitude : bool, optional
-            Fits the linear planes so there are deflection with constant magnitude.
+            Fits the linear planes to deflections with constant magnitude.
             In the presence of electromagnetic fields in the sample area, least squares 
             fitting can give inaccurate results. If the region is expected to have 
             uniform field strength, we can fit planes by trying to minimise the variance

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -94,7 +94,7 @@ class BeamShift(DiffractionVectors1D):
             where the first three entries are for the x-shift, being in order the
             step in x, step in y and the initial value at (0, 0). Similarly for the
             last three entries for the y-shift. Currently only implemented for the
-            case when constrain_magnitude is `True`.
+            case when `constrain_magnitude` is `True`.
         constrain_magnitude : bool, optional
             Fits the linear planes to deflections with constant magnitude.
             In the presence of electromagnetic fields in the sample area, least squares

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -90,13 +90,16 @@ class BeamShift(DiffractionVectors1D):
         initial_values : array of floats, optional
             Initial guess for the plane parameters. Useful to vary if the plane fitting
             does not give desirable results. 
-            The x- and y-shifts are described by two linear planes with three parameters. 
-            The two first parameters, d/dx and d/dy, are the changes in x- or y-shift 
-            as you move one position in the navigation space in respectively the x- and y-
-            directions. The third parameter, x_0 or y_0, are respectively the x- and y-
-            shifts in the (0, 0) navigation position. The parameters are laid out thusly,
-            with the first three being for the x-shifts and the rest for the y-shifts:
-            [d/dx, d/dy, x_0, d/dx, d/dy, y_0]
+            The horizontal- and vertical-shifts are described by two linear planes 
+            with three parameters. The two first parameters, d/dx and d/dy, are the changes 
+            in horizontal-shift as you move one position in the navigation space in 
+            respectively the x- and y-directions. I. e. they are the steps in 
+            horizontal-shift as you change x- or y-coordinates. The third parameter,
+            shift_0, is the horizontal-shift in the (0, 0) navigation position. The 
+            vertical-shift are described by similar parameters. In this argument
+            supply the plane parameters in the following way, with the first three 
+            being for the horizontal-shift and the rest for the vertical-shift:
+            [d/dx, d/dy, shift_0, d/dx, d/dy, shift_0]
             Currently only implemented for the case when `constrain_magnitude_variance` 
             is `True`.
         constrain_magnitude_variance : bool, optional

--- a/pyxem/signals/beam_shift.py
+++ b/pyxem/signals/beam_shift.py
@@ -89,18 +89,18 @@ class BeamShift(DiffractionVectors1D):
             signal. This mush be set with a number, like 0.05 (5%) or 0.10 (10%).
         initial_values : array of floats, optional
             Initial guess for the plane parameters. Useful to vary if the plane fitting
-            does not give desirable results. 
-            The horizontal- and vertical-shifts are described by two linear planes 
-            with three parameters. The two first parameters, d/dx and d/dy, are the changes 
-            in horizontal-shift as you move one position in the navigation space in 
-            respectively the x- and y-directions. I. e. they are the steps in 
+            does not give desirable results.
+            The horizontal- and vertical-shifts are described by two linear planes
+            with three parameters. The two first parameters, d/dx and d/dy, are the changes
+            in horizontal-shift as you move one position in the navigation space in
+            respectively the x- and y-directions. I. e. they are the steps in
             horizontal-shift as you change x- or y-coordinates. The third parameter,
-            shift_0, is the horizontal-shift in the (0, 0) navigation position. The 
+            shift_0, is the horizontal-shift in the (0, 0) navigation position. The
             vertical-shift are described by similar parameters. In this argument
-            supply the plane parameters in the following way, with the first three 
+            supply the plane parameters in the following way, with the first three
             being for the horizontal-shift and the rest for the vertical-shift:
             [d/dx, d/dy, shift_0, d/dx, d/dy, shift_0]
-            Currently only implemented for the case when `constrain_magnitude_variance` 
+            Currently only implemented for the case when `constrain_magnitude_variance`
             is `True`.
         constrain_magnitude_variance : bool, optional
             Fits the linear planes to deflections with constant magnitude. By default

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -84,8 +84,11 @@ class TestGetLinearPlane:
 
         s = BeamShift(data)
 
+        s_lp = s.get_linear_plane()#constrain_magnitude=True)
+        assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+        
         s_lp = s.get_linear_plane(constrain_magnitude=True)
-        assert s_lp.data == approx(base_plane.data, abs=1e-7)
+        assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
     def test_lazy_input_error(self):
         s = LazyBeamShift(da.zeros((50, 40, 2)))

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -90,6 +90,95 @@ class TestGetLinearPlane:
         s_lp = s.get_linear_plane(constrain_magnitude=True)
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
+    def test_constrain_magnitude_mask(self):
+        
+        p = [0.5]*6 # Plane parameters
+        x, y = np.meshgrid(np.arange(256), np.arange(256))
+        base_plane_x = p[0] * x + p[1] * y + p[2]
+        base_plane_y = p[3] * x + p[4] * y + p[5]
+
+        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        data = base_plane.copy()
+
+        shifts = np.zeros_like(data)
+        shifts[:128,128:] =(10,10)
+        shifts[:128,:128] =(-10,-10)
+        shifts[128:,128:] =(-10,10)
+        shifts[128:,:128] =(10,10)
+        shifts[:,-10:] =(9999,1321)
+        shifts[:,:10] =(2213,-9879)
+        data += shifts
+
+        mask = np.zeros((256, 256), dtype=bool)
+        mask[:,-10:] =True
+        mask[:,:10] =True
+
+        s = BeamShift(data)
+
+        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+        
+        s_lp = s.get_linear_plane(constrain_magnitude=True, mask=mask)
+        assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+    
+    def test_constrain_magnitude_mask(self):
+        
+        p = [0.5]*6 # Plane parameters
+        x, y = np.meshgrid(np.arange(256), np.arange(256))
+        base_plane_x = p[0] * x + p[1] * y + p[2]
+        base_plane_y = p[3] * x + p[4] * y + p[5]
+
+        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        data = base_plane.copy()
+
+        shifts = np.zeros_like(data)
+        shifts[:128,128:] =(10,10)
+        shifts[:128,:128] =(-10,-10)
+        shifts[128:,128:] =(-10,10)
+        shifts[128:,:128] =(10,10)
+        shifts[:,-10:] =(9999,1321)
+        shifts[:,:10] =(2213,-9879)
+        data += shifts
+
+        mask = np.zeros((256, 256), dtype=bool)
+        mask[:,-10:] =True
+        mask[:,:10] =True
+
+        s = BeamShift(data)
+
+        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+        
+        s_lp = s.get_linear_plane(constrain_magnitude=True, mask=mask)
+        assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+
+    def test_constrain_magnitude_initial_values(self):
+        
+        p = [0.5]*6 # Plane parameters
+        x, y = np.meshgrid(np.arange(256), np.arange(256))
+        base_plane_x = p[0] * x + p[1] * y + p[2]
+        base_plane_y = p[3] * x + p[4] * y + p[5]
+
+        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        data = base_plane.copy()
+
+        shifts = np.zeros_like(data)
+        shifts[:128,128:] =(10,10)
+        shifts[:128,:128] =(-10,-10)
+        shifts[128:, :] =(-10,10)
+        data += shifts
+
+        s = BeamShift(data)
+
+        # Plane fitting does poorly here, likely due to not enough different domains
+        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+
+        # Varying the initial values around can help find different planes
+        initial_values= [1.0]*6
+        s_lp = s.get_linear_plane(constrain_magnitude=True, initial_values=initial_values)
+        assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
+
     def test_lazy_input_error(self):
         s = LazyBeamShift(da.zeros((50, 40, 2)))
         with pytest.raises(ValueError):

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -66,106 +66,75 @@ class TestGetLinearPlane:
         assert s_lp.data == approx(s_orig.data, abs=1e-6)
 
     def test_constrain_magnitude(self):
-        
-        p = [0.5]*6 # Plane parameters
+
+        p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
         base_plane_x = p[0] * x + p[1] * y + p[2]
         base_plane_y = p[3] * x + p[4] * y + p[5]
 
-        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        base_plane = np.stack((base_plane_x, base_plane_y)).T
         data = base_plane.copy()
 
         shifts = np.zeros_like(data)
-        shifts[:128,128:] =(10,10)
-        shifts[:128,:128] =(-10,-10)
-        shifts[128:,128:] =(-10,10)
-        shifts[128:,:128] =(10,10)
+        shifts[:128, 128:] = (10, 10)
+        shifts[:128, :128] = (-10, -10)
+        shifts[128:, 128:] = (-10, 10)
+        shifts[128:, :128] = (10, 10)
         data += shifts
 
         s = BeamShift(data)
 
-        s_lp = s.get_linear_plane()#constrain_magnitude=True)
+        s_lp = s.get_linear_plane()  # constrain_magnitude=True)
         assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
-        
+
         s_lp = s.get_linear_plane(constrain_magnitude=True)
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
     def test_constrain_magnitude_mask(self):
-        
-        p = [0.5]*6 # Plane parameters
+
+        p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
         base_plane_x = p[0] * x + p[1] * y + p[2]
         base_plane_y = p[3] * x + p[4] * y + p[5]
 
-        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        base_plane = np.stack((base_plane_x, base_plane_y)).T
         data = base_plane.copy()
 
         shifts = np.zeros_like(data)
-        shifts[:128,128:] =(10,10)
-        shifts[:128,:128] =(-10,-10)
-        shifts[128:,128:] =(-10,10)
-        shifts[128:,:128] =(10,10)
-        shifts[:,-10:] =(9999,1321)
-        shifts[:,:10] =(2213,-9879)
+        shifts[:128, 128:] = (10, 10)
+        shifts[:128, :128] = (-10, -10)
+        shifts[128:, 128:] = (-10, 10)
+        shifts[128:, :128] = (10, 10)
+        shifts[:, -10:] = (9999, 1321)
+        shifts[:, :10] = (2213, -9879)
         data += shifts
 
         mask = np.zeros((256, 256), dtype=bool)
-        mask[:,-10:] =True
-        mask[:,:10] =True
+        mask[:, -10:] = True
+        mask[:, :10] = True
 
         s = BeamShift(data)
 
         s_lp = s.get_linear_plane(constrain_magnitude=True)
         assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
-        
-        s_lp = s.get_linear_plane(constrain_magnitude=True, mask=mask)
-        assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
-    
-    def test_constrain_magnitude_mask(self):
-        
-        p = [0.5]*6 # Plane parameters
-        x, y = np.meshgrid(np.arange(256), np.arange(256))
-        base_plane_x = p[0] * x + p[1] * y + p[2]
-        base_plane_y = p[3] * x + p[4] * y + p[5]
 
-        base_plane = np.stack((base_plane_x,base_plane_y)).T
-        data = base_plane.copy()
-
-        shifts = np.zeros_like(data)
-        shifts[:128,128:] =(10,10)
-        shifts[:128,:128] =(-10,-10)
-        shifts[128:,128:] =(-10,10)
-        shifts[128:,:128] =(10,10)
-        shifts[:,-10:] =(9999,1321)
-        shifts[:,:10] =(2213,-9879)
-        data += shifts
-
-        mask = np.zeros((256, 256), dtype=bool)
-        mask[:,-10:] =True
-        mask[:,:10] =True
-
-        s = BeamShift(data)
-
-        s_lp = s.get_linear_plane(constrain_magnitude=True)
-        assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
-        
         s_lp = s.get_linear_plane(constrain_magnitude=True, mask=mask)
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
     def test_constrain_magnitude_initial_values(self):
-        
-        p = [0.5]*6 # Plane parameters
+
+        p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
         base_plane_x = p[0] * x + p[1] * y + p[2]
         base_plane_y = p[3] * x + p[4] * y + p[5]
 
-        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        base_plane = np.stack((base_plane_x, base_plane_y)).T
         data = base_plane.copy()
 
         shifts = np.zeros_like(data)
-        shifts[:128,128:] =(10,10)
-        shifts[:128,:128] =(-10,-10)
-        shifts[128:, :] =(-10,10)
+        shifts[:128, 128:] = (10, 10)
+        shifts[:128, :128] = (-10, -10)
+        shifts[128:, :] = (-10, 10)
         data += shifts
 
         s = BeamShift(data)
@@ -175,8 +144,10 @@ class TestGetLinearPlane:
         assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
         # Varying the initial values around can help find different planes
-        initial_values= [1.0]*6
-        s_lp = s.get_linear_plane(constrain_magnitude=True, initial_values=initial_values)
+        initial_values = [1.0] * 6
+        s_lp = s.get_linear_plane(
+            constrain_magnitude=True, initial_values=initial_values
+        )
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
     def test_lazy_input_error(self):
@@ -202,6 +173,15 @@ class TestGetLinearPlane:
         s = BeamShift(np.zeros((5, 5, 2)))
         with pytest.raises(ValueError):
             s.get_linear_plane(fit_corners=0.05, mask=np.ones((5, 5)))
+
+    def test_non_bool_mask(self):
+        s = BeamShift(np.zeros((50, 40, 2)))
+        mask = np.zeros((50, 40), dtype=np.int32)
+        s_mask = Signal2D(mask)
+        with pytest.raises(ValueError):
+            s.get_linear_plane(mask=s_mask)
+        s_mask.change_dtype(bool)
+        s.get_linear_plane(mask=s_mask)
 
 
 class TestBeamShiftFitCorners:

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -65,6 +65,28 @@ class TestGetLinearPlane:
         s_lp = s.get_linear_plane(mask=s_mask)
         assert s_lp.data == approx(s_orig.data, abs=1e-6)
 
+    def test_constrain_magnitude(self):
+        
+        p = [0.5]*6 # Plane parameters
+        x, y = np.meshgrid(np.arange(256), np.arange(256))
+        base_plane_x = p[0] * x + p[1] * y + p[2]
+        base_plane_y = p[3] * x + p[4] * y + p[5]
+
+        base_plane = np.stack((base_plane_x,base_plane_y)).T
+        data = base_plane.copy()
+
+        shifts = np.zeros_like(data)
+        shifts[:128,128:] =(10,10)
+        shifts[:128,:128] =(-10,-10)
+        shifts[128:,128:] =(-10,10)
+        shifts[128:,:128] =(10,10)
+        data += shifts
+
+        s = BeamShift(data)
+
+        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        assert s_lp.data == approx(base_plane.data, abs=1e-7)
+
     def test_lazy_input_error(self):
         s = LazyBeamShift(da.zeros((50, 40, 2)))
         with pytest.raises(ValueError):

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -65,7 +65,7 @@ class TestGetLinearPlane:
         s_lp = s.get_linear_plane(mask=s_mask)
         assert s_lp.data == approx(s_orig.data, abs=1e-6)
 
-    def test_constrain_magnitude(self):
+    def test_constrain_magnitude_variance(self):
 
         p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
@@ -84,13 +84,13 @@ class TestGetLinearPlane:
 
         s = BeamShift(data)
 
-        s_lp = s.get_linear_plane()  # constrain_magnitude=True)
+        s_lp = s.get_linear_plane()
         assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
-        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        s_lp = s.get_linear_plane(constrain_magnitude_variance=True)
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
-    def test_constrain_magnitude_mask(self):
+    def test_constrain_magnitude_variance_mask(self):
 
         p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
@@ -115,13 +115,13 @@ class TestGetLinearPlane:
 
         s = BeamShift(data)
 
-        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        s_lp = s.get_linear_plane(constrain_magnitude_variance=True)
         assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
-        s_lp = s.get_linear_plane(constrain_magnitude=True, mask=mask)
+        s_lp = s.get_linear_plane(constrain_magnitude_variance=True, mask=mask)
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
-    def test_constrain_magnitude_initial_values(self):
+    def test_constrain_magnitude_variance_initial_values(self):
 
         p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
@@ -140,13 +140,13 @@ class TestGetLinearPlane:
         s = BeamShift(data)
 
         # Plane fitting does poorly here, likely due to not enough different domains
-        s_lp = s.get_linear_plane(constrain_magnitude=True)
+        s_lp = s.get_linear_plane(constrain_magnitude_variance=True)
         assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
         # Varying the initial values around can help find different planes
         initial_values = [1.0] * 6
         s_lp = s.get_linear_plane(
-            constrain_magnitude=True, initial_values=initial_values
+            constrain_magnitude_variance=True, initial_values=initial_values
         )
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 

--- a/pyxem/tests/signals/test_beam_shift.py
+++ b/pyxem/tests/signals/test_beam_shift.py
@@ -66,7 +66,6 @@ class TestGetLinearPlane:
         assert s_lp.data == approx(s_orig.data, abs=1e-6)
 
     def test_constrain_magnitude_variance(self):
-
         p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
         base_plane_x = p[0] * x + p[1] * y + p[2]
@@ -91,7 +90,6 @@ class TestGetLinearPlane:
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
     def test_constrain_magnitude_variance_mask(self):
-
         p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
         base_plane_x = p[0] * x + p[1] * y + p[2]
@@ -121,8 +119,12 @@ class TestGetLinearPlane:
         s_lp = s.get_linear_plane(constrain_magnitude_variance=True, mask=mask)
         assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
 
-    def test_constrain_magnitude_variance_initial_values(self):
+        # Check wrong mask dimensions
+        mask = mask[:255]
+        with pytest.raises(ValueError):
+            s_lp = s.get_linear_plane(constrain_magnitude_variance=True, mask=mask)
 
+    def test_constrain_magnitude_variance_initial_values(self):
         p = [0.5] * 6  # Plane parameters
         x, y = np.meshgrid(np.arange(256), np.arange(256))
         base_plane_x = p[0] * x + p[1] * y + p[2]
@@ -157,17 +159,23 @@ class TestGetLinearPlane:
         s.compute()
         s.get_linear_plane()
 
-    def test_wrong_navigation_input_1d_error(self):
+    @pytest.mark.parametrize("constrain_magnitude_variance", [False, True])
+    def test_wrong_navigation_input_1d_error(self, constrain_magnitude_variance):
         s = BeamShift(np.zeros((50, 2)))
         with pytest.raises(NotImplementedError):
-            s.get_linear_plane()
+            s.get_linear_plane(
+                constrain_magnitude_variance=constrain_magnitude_variance
+            )
 
-    def test_wrong_navigation_input_3d_error(self):
+    @pytest.mark.parametrize("constrain_magnitude_variance", [False, True])
+    def test_wrong_navigation_input_3d_error(self, constrain_magnitude_variance):
         s = BeamShift(np.zeros((50, 40, 30, 2)))
         with pytest.raises(NotImplementedError):
-            s.get_linear_plane()
+            s.get_linear_plane(
+                constrain_magnitude_variance=constrain_magnitude_variance
+            )
         s1 = s.inav[:, :, 10]
-        s1.get_linear_plane()
+        s1.get_linear_plane(constrain_magnitude_variance=constrain_magnitude_variance)
 
     def test_wrong_input_fit_corners_and_mask(self):
         s = BeamShift(np.zeros((5, 5, 2)))

--- a/pyxem/utils/_beam_shift_tools.py
+++ b/pyxem/utils/_beam_shift_tools.py
@@ -105,7 +105,7 @@ def _f_min(X, p):
 def _residuals(params, X):
     return _f_min(X, params)
 
-def _distance_residuals(params, X):
+def _magnitude_deviations(params, X):
     plane_x_xy = params[0:2]
     plane_y_xy = params[3:5]
     distance_x = (plane_x_xy * X[:, :2]).sum(axis=1) + params[2]
@@ -167,7 +167,7 @@ def _get_linear_plane_from_signal2d(signal, mask=None, initial_values=None):
     return plane
 
 
-def _get_linear_xy_planes_from_signal2d(signal, mask=None, initial_values=None):
+def _get_linear_plane_by_minimizing_magnitude_variance(signal, mask=None, initial_values=None):
     if len(signal.axes_manager.navigation_axes) != 2:
         raise ValueError("signal needs to have 1 navigation dimensions")
     if len(signal.axes_manager.signal_axes) != 1:
@@ -188,7 +188,7 @@ def _get_linear_xy_planes_from_signal2d(signal, mask=None, initial_values=None):
             raise ValueError("signal and mask need to have the same navigation shape")
         points = points[np.invert(mask).flatten()]
 
-    p = opt.leastsq(_distance_residuals, initial_values, args=points)[0]
+    p = opt.leastsq(_magnitude_deviations, initial_values, args=points)[0]
 
     x, y = np.meshgrid(xaxis, yaxis)
     z_x = p[0] * x + p[1] * y + p[2]

--- a/pyxem/utils/_beam_shift_tools.py
+++ b/pyxem/utils/_beam_shift_tools.py
@@ -105,6 +105,7 @@ def _f_min(X, p):
 def _residuals(params, X):
     return _f_min(X, params)
 
+
 def _magnitude_deviations(params, X):
     plane_x_xy = params[0:2]
     plane_y_xy = params[3:5]
@@ -167,7 +168,9 @@ def _get_linear_plane_from_signal2d(signal, mask=None, initial_values=None):
     return plane
 
 
-def _get_linear_plane_by_minimizing_magnitude_variance(signal, mask=None, initial_values=None):
+def _get_linear_plane_by_minimizing_magnitude_variance(
+    signal, mask=None, initial_values=None
+):
     if len(signal.axes_manager.navigation_axes) != 2:
         raise ValueError("signal needs to have 2 navigation dimensions")
     if len(signal.axes_manager.signal_axes) != 1:

--- a/pyxem/utils/_beam_shift_tools.py
+++ b/pyxem/utils/_beam_shift_tools.py
@@ -169,9 +169,9 @@ def _get_linear_plane_from_signal2d(signal, mask=None, initial_values=None):
 
 def _get_linear_plane_by_minimizing_magnitude_variance(signal, mask=None, initial_values=None):
     if len(signal.axes_manager.navigation_axes) != 2:
-        raise ValueError("signal needs to have 1 navigation dimensions")
+        raise ValueError("signal needs to have 2 navigation dimensions")
     if len(signal.axes_manager.signal_axes) != 1:
-        raise ValueError("signal needs to have 2 signal dimension")
+        raise ValueError("signal needs to have 1 signal dimension")
     if initial_values is None:
         initial_values = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 

--- a/pyxem/utils/_beam_shift_tools.py
+++ b/pyxem/utils/_beam_shift_tools.py
@@ -105,6 +105,15 @@ def _f_min(X, p):
 def _residuals(params, X):
     return _f_min(X, params)
 
+def _distance_residuals(params, X):
+    plane_x_xy = params[0:2]
+    plane_y_xy = params[3:5]
+    distance_x = (plane_x_xy * X[:, :2]).sum(axis=1) + params[2]
+    distance_y = (plane_y_xy * X[:, :2]).sum(axis=1) + params[5]
+    distance = np.sqrt(((distance_x - X[:, 2]) ** 2 + (distance_y - X[:, 3]) ** 2))
+
+    return distance - np.mean(distance)
+
 
 def _plane_parameters_to_image(p, xaxis, yaxis):
     """Get a plane 2D array from plane parameters.
@@ -156,6 +165,36 @@ def _get_linear_plane_from_signal2d(signal, mask=None, initial_values=None):
 
     plane = _plane_parameters_to_image(p, xaxis, yaxis)
     return plane
+
+
+def _get_linear_xy_planes_from_signal2d(signal, mask=None, initial_values=None):
+    if len(signal.axes_manager.navigation_axes) != 2:
+        raise ValueError("signal needs to have 1 navigation dimensions")
+    if len(signal.axes_manager.signal_axes) != 1:
+        raise ValueError("signal needs to have 2 signal dimension")
+    if initial_values is None:
+        initial_values = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+    signal = signal.T
+    sam = signal.axes_manager.signal_axes
+    xaxis, yaxis = sam[0].axis, sam[1].axis
+    x, y = np.meshgrid(xaxis, yaxis)
+    xx, yy = x.flatten(), y.flatten()
+    values_x = signal.data[0].flatten()
+    values_y = signal.data[1].flatten()
+    points = np.stack((xx, yy, values_x, values_y)).T
+    if mask is not None:
+        if mask.__array__().shape != signal.T.__array__().shape[:2]:
+            raise ValueError("signal and mask need to have the same navigation shape")
+        points = points[np.invert(mask).flatten()]
+
+    p = opt.leastsq(_distance_residuals, initial_values, args=points)[0]
+
+    x, y = np.meshgrid(xaxis, yaxis)
+    z_x = p[0] * x + p[1] * y + p[2]
+    z_y = p[3] * x + p[4] * y + p[5]
+
+    return np.stack((z_x, z_y), axis=-1)
 
 
 def _get_limits_from_array(data, sigma=4, ignore_zeros=False, ignore_edges=False):


### PR DESCRIPTION
---
Fit linear plane in `pyxem.signals.BeamShift.get_linear_plane` by minimising magnitude variance
---

**Checklist**

- [x] implementation steps
- [x] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
In my work, there can be electromagnetic field in the sample areas where I want to fit linear planes for descan removal. However, using the existing algorithm in `pyxem.signals.BeamShift.get_linear_plane` by minimising the magnitudes through least squares gives poor results. 

What is better for my case is assuming the sample has uniform electromagnetic field strengths and therefore uniform deflection magnitudes, then fitting the linear planes from this. This is done by minimising the deflection magnitude variance so that ther is a constant deflection magnitude after fitting. This can be used by setting `constrain_magnitude` to `True`:

```python
import hyperspy.api as hs
import pyxem as pxm
import numpy as np

p = [0.5] * 6  # Plane parameters
x, y = np.meshgrid(np.arange(256), np.arange(256))
base_plane_x = p[0] * x + p[1] * y + p[2]
base_plane_y = p[3] * x + p[4] * y + p[5]

# Base descan plane
base_plane = np.stack((base_plane_x, base_plane_y)).T
data = base_plane.copy()

# Add electromagnetic shifts, four domains.
shifts = np.zeros_like(data)
shifts[:128, 128:] = (10, 10)
shifts[:128, :128] = (-10, -10)
shifts[128:, 128:] = (-10, 10)
shifts[128:, :128] = (10, 10)
data += shifts

s = pxm.signals.BeamShift(data)

# Regular plane fitting gives poor results
s_lp = s.get_linear_plane()
assert not np.allclose(s_lp.data, base_plane.data, rtol=1e-7)

# By minimising magnitude variance you get the original plane back
s_lp = s.get_linear_plane(constrain_magnitude=True)
assert np.allclose(s_lp.data, base_plane.data, rtol=1e-7)
```

However there are a couple issues. If there are few domains, then there will be many valid planes for this fitting, some very nonsensical. Therefore, I have exposed the `initial_values` parameter, which you can vary to get different results. Part of the reason is that since we fit the planes together, we have six parameters and therefore the algorithm seems to get stuck in many local minima. See the tests for an example where this is used to fix things. The algorithm is also very affected by noise, so a mask is often necessary where this is severe.

I have also added a check for the `mask` having a datatype of booleans. It can accept other datatypes silently, where it would most likely give wildly wrong results. So I found it useful to have an explicit check.

Regardless this is a very useful feature for me that has helped with my data-analysis. So I hope we can share it with others!