### PR TITLE
Override n_keep if n_best exceeds it

### DIFF
--- a/pyxem/signals/polar_diffraction2d.py
+++ b/pyxem/signals/polar_diffraction2d.py
@@ -28,6 +28,7 @@ from pyxem.utils.indexation_utils import (
     _mixed_matching_lib_to_polar,
     _get_integrated_polar_templates,
     _norm_rows,
+    _get_max_n,
 )
 
 from pyxem.utils._background_subtraction import (
@@ -346,6 +347,10 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
 
         Notes
         -----
+            If :code:`n_best` exceeds :code:`n_keep` or :code:`frac_keep * N` for :code:`N` simulations,
+            then full correlation is performed on :code:`n_best` simulations instead. This ensures the
+            output contains :code:`n_best` simulations.
+
             A gamma correction is often applied to the diffraction patterns. A good value
             to start with is the square root (gamma=0.5) of the diffraction patterns to
             increase the intensity of the low intensity reflections and decrease the
@@ -377,6 +382,11 @@ class PolarDiffraction2D(CommonDiffraction, Signal2D):
         )
         if normalize_templates:
             intensities_templates = _norm_rows(intensities_templates)
+
+        max_n = _get_max_n(N=r_templates.shape[0], n_keep=n_keep, frac_keep=frac_keep)
+        if max_n < n_best:
+            # n_keep takes precedence over frac_keep, so this ensures we get n_best simulations in the result
+            n_keep = n_best
         orientation = self.map(
             _mixed_matching_lib_to_polar,
             integrated_templates=integrated_templates,


### PR DESCRIPTION
---
Override n_keep if n_best exceeds it
---

As mentioned in #1128, n_best lower than n_keep or frac_keep throws an error.
With this change, n_keep is set to n_best if n_best exceeds n_keep/frac_keep.
This is different to before the recent refactor, where instead n_best was reduced to accomodate n_keep/frac_keep:
https://github.com/pyxem/pyxem/blob/01f161bed015eac781dbbbb58c04e675d5f81031/pyxem/utils/indexation_utils.py#L1568-L1571
In my opinion, it is more intuitive to limit n_keep than n_best, when a user requests a n_best. This is, of course, open for discussion.

All tests passed locally, and I tested manually with polar axis sizes smaller than n_best as discussed in #1128 without problems.

**Checklist**

- [ ] implementation steps
- [ ] update the Changelog
- [ ] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
