### PR TITLE
Consistent marker plotting, attempt 2

### DIFF
--- a/pyxem/signals/indexation_results.py
+++ b/pyxem/signals/indexation_results.py
@@ -486,7 +486,7 @@ def vectors_from_orientation_map(
         hkl = hkl[index]
     phase = dict2phase(**phase)
     # Copy manually, as deepcopy adds a lot of overhead with the phase
-    vectors = DiffractingVector(phase, xyz=data)
+    vectors = DiffractingVector(phase, xyz=data.copy())
     # Flip y, as discussed in https://github.com/pyxem/pyxem/issues/925
     vectors.y = -vectors.y
 
@@ -497,7 +497,7 @@ def vectors_from_orientation_map(
     vectors = ~rotation * vectors.to_miller()
     vectors = DiffractingVector(
         vectors.phase,
-        xyz=-vectors.data.copy(),  # Negating for proper alignment - is this flipping z direction?
+        xyz=-vectors.data,  # Negating for proper alignment - is this flipping z direction?
         intensity=intensities,
     )
     vectors.coordinate_format = coordinate_format


### PR DESCRIPTION
---
Consistent marker plotting, attempt 2
---

The transformation of coordinates for correct plotting modifies the data in-place, as `Object3d.y` is a view on the data. Copying before modifying seems to fix the issue, evident by running the example in #1124. 
I don't know a good way to test this, other than the existing test from #1126...

**Checklist**

- [x] implementation steps
- [ ] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
