### PR TITLE
Drop support python3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.13"]
         include:
           - os: ubuntu-latest
-            python-version: 3.8
-
-            DEPENDENCIES: diffsims==0.6.0 hyperspy~=2.0.rc0 lmfit==0.9.12 matplotlib==3.7.5 orix==0.12.1 scikit-image==0.19.0 scikit-learn==1.0.0
+            python-version: "3.9"
+            DEPENDENCIES: diffsims==0.7.0 hyperspy==2.0.0 lmfit==1.0.0 numpy==1.23.0 matplotlib==3.7.5 orix==0.12.1 scikit-image==0.19.0 scikit-learn==1.0.0
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.9"
-            DEPENDENCIES: diffsims==0.7.0 hyperspy==2.0.0 lmfit==1.0.0 numpy==1.23.0 matplotlib==3.7.5 orix==0.12.1 scikit-image==0.19.0 scikit-learn==1.0.0
+            DEPENDENCIES: diffsims==0.7.0 hyperspy==2.2.0 lmfit==1.0.0 numpy==1.23.0 matplotlib==3.7.5 orix==0.12.1 scikit-image==0.19.0 scikit-learn==1.0.0
             LABEL: -oldest
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     install_requires=[
         "dask",
         "diffsims       >= 0.7.0",  # ensure we use the latest version
-        "hyperspy       >= 2.0",
+        "hyperspy       >= 2.2.0",  # Use axes_manager set/get functionality
         "h5py",
         "lmfit          >= 1.0.0",  # support for recent version of numpy
         "matplotlib     >= 3.7.5",

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,11 @@ setup(
     ],
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -91,10 +91,10 @@ setup(
         "diffsims       >= 0.7.0",  # ensure we use the latest version
         "hyperspy       >= 2.0",
         "h5py",
-        "lmfit          >= 0.9.12",
+        "lmfit          >= 1.0.0",  # support for recent version of numpy
         "matplotlib     >= 3.7.5",
         "numba",
-        "numpy",
+        "numpy          >= 1.23.0",  # Needed for numpy.typing
         "orix           >= 0.12.1",
         "pooch",
         "psutil",
@@ -107,7 +107,7 @@ setup(
         "transforms3d",
         "zarr            < 3.0.0",  # for fast saving/loading (>=3.0.0 is not compatible)
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     package_data={
         "": ["LICENSE", "README.rst"],
         "pyxem": ["*.py", "hyperspy_extension.yaml"],


### PR DESCRIPTION
**Checklist**

- [x] Drop support for python 3.8,
- [x] add explicit support for python 3.12 and 3.13,
- [x] bump test matrix,
- [x] bump dependencies requirement where necessary,
- [ ] update the Changelog
- [ ] mark as ready for review
