### PR TITLE
Refactor: Download artifact from other workflows

### DIFF
--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -12,11 +12,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: doc_html
+          path: ./doc/_build/html
       - name: Deploy dev docs
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # uses a full len SHA per https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#using-shas
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: _build/html/
+          publish_dir:  doc/_build/html
           destination_dir: dev
           force_orphan: false

--- a/.github/workflows/docs-deploy-pr.yml
+++ b/.github/workflows/docs-deploy-pr.yml
@@ -13,10 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: preview-${{ github.ref }}
     steps:
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: doc_html
+          path: ./doc/_build/html
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@9f77b1d057b494e662c50b8ca40ecc63f21e0887 # uses a full len SHA per https://docs.github.com/en/actions/how-tos/write-workflows/choose-and-customize-actions#using-shas
         with:
-          source-dir: _build/html/
+          source-dir:  doc/_build/html
           deploy-repository: CSSFrancis/pyxem-docs-staging
           token: ${{ secrets.PREVIEW_DEPLOY_KEY }} # PAT with permissions to edit Content in CSSFrancis/pyxem-docs-staging
           comment: true # Add a comment to the PR with the preview link

--- a/.github/workflows/docs-deploy-release.yml
+++ b/.github/workflows/docs-deploy-release.yml
@@ -17,6 +17,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: doc_html
+          path: ./doc/_build/html
+
       - name: Build index redirect
         run: |
           VERSION=${{ github.event.inputs.version || github.ref_name }}
@@ -39,7 +45,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: _build/html/
+          publish_dir:  doc/_build/html
           destination_dir: ${{ github.event.inputs.version || github.ref_name }} # deploy to a folder matching the tag version
           force_orphan: false
 


### PR DESCRIPTION
This pull request updates the documentation deployment workflows to standardize the location of built documentation artifacts and ensure they are correctly downloaded before deployment. The changes affect the development, pull request preview, and release documentation workflows.

**Documentation deployment workflow improvements:**

* All workflows now include a step to download the built documentation artifact (`doc_html`) to `./doc/_build/html` before deployment, ensuring consistency and reliability in the deployment process. [[1]](diffhunk://#diff-57cdc4cad214bfd649fb9cb68cfbf63daf7976344041dfb2b837d23d5d15322eR15-R25) [[2]](diffhunk://#diff-5fa726aab8fa8a94b87859d730511b977a785a9c21020e1a2f4d940d4263ae4bR16-R24) [[3]](diffhunk://#diff-e7bbb69e083b1894849cfe061f8a0d3be8683265504211eff761ad4d5696f1b8R20-R25)
* The deployment actions in all workflows have been updated to use the new artifact path (`doc/_build/html`) for publishing or previewing documentation, replacing the previous `_build/html/` path. [[1]](diffhunk://#diff-57cdc4cad214bfd649fb9cb68cfbf63daf7976344041dfb2b837d23d5d15322eR15-R25) [[2]](diffhunk://#diff-5fa726aab8fa8a94b87859d730511b977a785a9c21020e1a2f4d940d4263ae4bR16-R24) [[3]](diffhunk://#diff-e7bbb69e083b1894849cfe061f8a0d3be8683265504211eff761ad4d5696f1b8L42-R48)
