### PR TITLE
Split handling of push and pull_request events in doc deploy

### DIFF
--- a/.github/workflows/docs-PR-preview-cleanup.yml
+++ b/.github/workflows/docs-PR-preview-cleanup.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  html_folder: ./doc/_build/html
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -18,25 +21,15 @@ jobs:
       - name: Create empty deploy folder
         run: mkdir -p empty
 
-      - name: Remove PR Preview folder using GitHub Pages Deploy Action
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages
-          folder: ./empty
-          target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          clean: true
-
       - name: Deploy PR preview
         # run on pull request only
         # until rossjrw/pr-preview-action suppports passing the PR number as input,
         # use the github-pages-deploy-action directly
-        if: inputs.pr_number != ''
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           personal_token: ${{ secrets.PREVIEW_DEPLOY_KEY }}
           publish_dir:  ${{ env.html_folder }}
-          destination_dir: pr-preview/${{ inputs.pr_number }}
+          destination_dir: pr-preview/${{ github.event.pull_request.number }}
           external_repository: CSSFrancis/pyxem-docs-staging
 
       - name: Get timestamp (UTC)

--- a/.github/workflows/docs-PR-preview.yml
+++ b/.github/workflows/docs-PR-preview.yml
@@ -1,4 +1,4 @@
-name: Docs deploy
+name: Docs PR-preview
 
 on:
   workflow_run:
@@ -31,10 +31,9 @@ jobs:
           echo "Parsing deploy_info/info.json:"
           cat deploy_info/info.json
           echo "workflow_run_id=$(jq -r '.workflow_run_id' deploy_info/info.json)" >> $GITHUB_OUTPUT # to get the run id of the workflow that built the docs
-          echo "ref_type=$(jq -r '.ref_type' deploy_info/info.json)" >> $GITHUB_OUTPUT # to check if tag or branch
-          echo "ref_name=$(jq -r '.ref_name' deploy_info/info.json)" >> $GITHUB_OUTPUT # to get the tag or branch name
           echo "pr_number=$(jq -r '.pr_number' deploy_info/info.json)" >> $GITHUB_OUTPUT # empty if not a PR
           echo "pull_request_action=$(jq -r '.pull_request_action' deploy_info/info.json)" >> $GITHUB_OUTPUT # 'The pull request event action that triggered the workflow building the docs (e.g. opened, closed, synchronize)'
+      
       # need to specify the run id to get the artifact from the correct workflow run
       # and set the github-token to access the actions scope
       # https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories
@@ -48,15 +47,6 @@ jobs:
 
       - name: Print doc files
         run: ls -l ${{ env.html_folder }}
-
-      - name: Deploy dev docs
-        # run on main branch only
-        if: ${{ steps.info.outputs.ref_name == 'main' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.html_folder }}
-          destination_dir: dev
 
       - name: Deploy PR preview
        # run on pull request only
@@ -85,7 +75,7 @@ jobs:
           message: |
             **PR Preview**
             :---:
-            :rocket: View PR Preview at https://cssfrancis.github.io/pyxem-docs-staging/pr-preview/pr-${{ steps.info.outputs.pr_number }}.
+            :rocket: View PR Preview at https://cssfrancis.github.io/pyxem-docs-staging/pr-preview/${{ steps.info.outputs.pr_number }}.
             If you see a 404 error, please wait a few seconds for the deployment to complete and refresh the page.
             ${{ steps.timestamp.outputs.utc }}
 
@@ -113,35 +103,3 @@ jobs:
             :---:
             Preview removed because the pull request was closed.
             ${{ steps.timestamp.outputs.utc }}
-
-      - name: Deploy versioned docs
-        if: ${{ steps.info.outputs.ref_type == 'tag' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.html_folder }}
-          destination_dir: ${{ steps.info.outputs.ref_name }}
-
-      - name: Download redirect files
-        # run on tag only
-        if: ${{ steps.info.outputs.ref_type == 'tag' }}
-        uses: actions/download-artifact@v5
-        with:
-          name: redirect
-          path: redirect
-          # need to specify the run id to get the artifact from the correct workflow run
-          # and set the github-token to access the actions scope
-          # https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories
-          run-id: ${{ steps.info.outputs.workflow_run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Deploy redirect to versioned docs
-        # run on tag only
-        if: ${{ steps.info.outputs.ref_type == 'tag' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: redirect
-          destination_dir: . # deploy the redirect to the root folder
-          keep_files: true
-

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -19,37 +19,30 @@ jobs:
       CACHE_GALLERY_EXAMPLES: './doc/examples' # cache sphinx-gallery examples for faster builds
       CACHE_POOCH: 'pyxem' # cache pooch downloads for pyxem data
 
-  Redirect-stable:
-    # build a redirect index.html to the stable version on tag builds
-    if: github.ref_type == 'tag' 
+  Push-dev:
+    needs: [Build]
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
     permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Build index redirect
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          mkdir -p redirect
-          cat <<EOF > redirect/index.html
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta http-equiv="refresh" content="0; url=${VERSION}/">
-              <script>window.location.href='${VERSION}/';</script>
-            </head>
-            <body>
-              <p>Redirecting to the <a href="${VERSION}/">documentation (stable)</a>...</p>
-            </body>
-          </html>
-          EOF
-      - uses: actions/upload-artifact@v4
-        if: github.ref_type == 'tag'
-        with:
-          path: redirect
-          name: redirect
+      # needs write permission to push the docs to gh-pages
+      contents: write
+    uses: hyperspy/.github/.github/workflows/push_doc.yml@main
+    with:
+      output_path: dev
 
-  Deploy:
+  Push-tag:
+    needs: [Build]
+    if: github.event_name != 'pull_request' && github.ref_type == 'tag'
+    permissions:
+      # needs write permission to push the docs to gh-pages
+      contents: write
+    uses: hyperspy/.github/.github/workflows/push_doc.yml@main
+    with:
+      output_path: ${{ github.ref_name }}
+      # Add a redirect index.html in the root folder pointing to the tag version
+      redirect_to_version: ${{ github.ref_name }}
+
+  Upload-PR_preview:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Write deploy info to file
@@ -58,10 +51,8 @@ jobs:
           cat <<EOF > deploy_info/info.json
           {
             "workflow_run_id": "${{ github.run_id }}",
-            "pr_number": "${{ github.event.pull_request.number || '' }}",
-            "ref_type": "${{ github.ref_type }}",
-            "ref_name": "${{ github.ref_name }}",
-            "pull_request_action": "${{ github.event.action || '' }}"
+            "pr_number": "${{ github.event.pull_request.number }}",
+            "pull_request_action": "${{ github.event.action }}"
           }
           EOF
 


### PR DESCRIPTION
As discussed in https://github.com/pyxem/pyxem/pull/1170#discussion_r2425494481. 

**Checklist**

- [x] Use https://github.com/hyperspy/.github/blob/main/.github/workflows/push_doc.yml to push dev and tag documentation
- [x] remove passing `ref_type` and `ref_name` to `docs-deploy`
- [ ] update the Changelog
- [ ] mark as ready for review