### PR TITLE
Clean up PR-preview workflow

### DIFF
--- a/.github/workflows/docs-PR-preview-cleanup.yml
+++ b/.github/workflows/docs-PR-preview-cleanup.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 env:
-  html_folder: ./doc/_build/html
+  html_folder: ./empty
 
 jobs:
   cleanup:
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create empty deploy folder
-        run: mkdir -p empty
+        run: |
+          mkdir -p ${{ env.html_folder }}
 
       - name: Deploy PR preview
         # run on pull request only

--- a/.github/workflows/docs-PR-preview.yml
+++ b/.github/workflows/docs-PR-preview.yml
@@ -32,7 +32,6 @@ jobs:
           cat deploy_info/info.json
           echo "workflow_run_id=$(jq -r '.workflow_run_id' deploy_info/info.json)" >> $GITHUB_OUTPUT # to get the run id of the workflow that built the docs
           echo "pr_number=$(jq -r '.pr_number' deploy_info/info.json)" >> $GITHUB_OUTPUT # empty if not a PR
-          echo "pull_request_action=$(jq -r '.pull_request_action' deploy_info/info.json)" >> $GITHUB_OUTPUT # 'The pull request event action that triggered the workflow building the docs (e.g. opened, closed, synchronize)'
       
       # need to specify the run id to get the artifact from the correct workflow run
       # and set the github-token to access the actions scope
@@ -49,10 +48,8 @@ jobs:
         run: ls -l ${{ env.html_folder }}
 
       - name: Deploy PR preview
-       # run on pull request only
         # until rossjrw/pr-preview-action suppports passing the PR number as input,
         # use the peaceiris/actions-gh-pages and implement cleanup on PR closed
-        if: ${{ steps.info.outputs.pr_number != '' && steps.info.outputs.pull_request_action != 'closed' }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           personal_token: ${{ secrets.PREVIEW_DEPLOY_KEY }}
@@ -61,13 +58,11 @@ jobs:
           external_repository: CSSFrancis/pyxem-docs-staging
 
       - name: Get timestamp (UTC)
-        if: ${{ steps.info.outputs.pr_number != '' }}
         id: timestamp
         run: |
           echo "utc=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
 
       - name: Post preview link as sticky PR comment
-        if: ${{ steps.info.outputs.pr_number != '' && steps.info.outputs.pull_request_action != 'closed' }}
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
         with:
           number: ${{ steps.info.outputs.pr_number }}
@@ -77,29 +72,4 @@ jobs:
             :---:
             :rocket: View PR Preview at https://cssfrancis.github.io/pyxem-docs-staging/pr-preview/${{ steps.info.outputs.pr_number }}.
             If you see a 404 error, please wait a few seconds for the deployment to complete and refresh the page.
-            ${{ steps.timestamp.outputs.utc }}
-
-      - name: Create empty deploy folder
-        if: ${{ steps.info.outputs.pr_number != '' && steps.info.outputs.pull_request_action == 'closed' }}
-        run: mkdir -p empty
-
-      - name: Remove PR preview
-        if: ${{ steps.info.outputs.pr_number != '' && steps.info.outputs.pull_request_action == 'closed' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          personal_token: ${{ secrets.PREVIEW_DEPLOY_KEY }}
-          publish_dir: ./empty
-          destination_dir: pr-preview/${{ steps.info.outputs.pr_number }}
-          external_repository: CSSFrancis/pyxem-docs-staging
-
-      - name: Update sticky PR comment
-        if: ${{ steps.info.outputs.pr_number != '' && steps.info.outputs.pull_request_action == 'closed' }}
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
-        with:
-          number: ${{ steps.info.outputs.pr_number }}
-          header: pr-preview
-          message: |
-            **PR Preview**
-            :---:
-            Preview removed because the pull request was closed.
             ${{ steps.timestamp.outputs.utc }}

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,7 +2,9 @@ name: Docs build
 
 on:
   pull_request:
-    types: [opened, closed, synchronize]
+    # on closed, the docs-PR-preview-cleanup.yml workflow will remove the preview
+    # and update the sticky comment accordingly
+    types: [opened, synchronize]
   push:
   workflow_dispatch:
 
@@ -52,7 +54,6 @@ jobs:
           {
             "workflow_run_id": "${{ github.run_id }}",
             "pr_number": "${{ github.event.pull_request.number }}",
-            "pull_request_action": "${{ github.event.action }}"
           }
           EOF
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,7 +23,10 @@ jobs:
 
   Push-dev:
     needs: [Build]
-    if: github.event_name != 'pull_request' && github.ref_name == 'main'
+    if: >
+      github.repository_owner == 'pyxem' && 
+      github.event_name != 'pull_request' && 
+      github.ref_name == 'main'
     permissions:
       # needs write permission to push the docs to gh-pages
       contents: write
@@ -33,7 +36,10 @@ jobs:
 
   Push-tag:
     needs: [Build]
-    if: github.event_name != 'pull_request' && github.ref_type == 'tag'
+    if: >
+      github.repository_owner == 'pyxem' &&
+      github.event_name != 'pull_request' &&
+      github.ref_type == 'tag'
     permissions:
       # needs write permission to push the docs to gh-pages
       contents: write
@@ -44,7 +50,9 @@ jobs:
       redirect_to_version: ${{ github.ref_name }}
 
   Upload-PR_preview:
-    if: github.event_name == 'pull_request'
+    if: >
+      github.repository_owner == 'pyxem' && 
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Write deploy info to file

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -46,8 +46,9 @@ jobs:
     uses: hyperspy/.github/.github/workflows/push_doc.yml@main
     with:
       output_path: ${{ github.ref_name }}
-      # Add a redirect index.html in the root folder pointing to the tag version
-      redirect_to_version: ${{ github.ref_name }}
+      create_redirect: true
+      create_stable_copy: true
+      persistent_name: stable
 
   Upload-PR_preview:
     if: >


### PR DESCRIPTION
Fix for #1172.

An alternative approach to this PR is to keep in a single workflow (`docs-PR-preview.yml`) and I have a small preference for this approach because:
- reduce the number of step conditions in the `docs-PR-preview.yml` workflow
- reduce the amount of information passed in the `json`
