### PR TITLE
Update documentation URLs in version switcher to use pyxem.org domain

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -6,24 +6,24 @@
     },
     {
         "name": "0.20.0",
-        "version": "0.20.0",
-        "url": "https://pyxem.org/en/v0.20.0/"
+        "version": "0.20",
+        "url": "https://pyxem.readthedocs.io/en/v0.20.0/"
     },
     {
         "name": "0.19.1",
-        "version": "0.19.1",
-        "url": "https://pyxem.org/en/v0.19.1/"
+        "version": "0.19",
+        "url": "https://pyxem.readthedocs.io/en/v0.19.1/"
     },
     {
-        "version": "0.18.0",
-        "url": "https://pyxem.org/en/v0.18.0/"
+        "version": "0.18",
+        "url": "https://pyxem.readthedocs.io/en/v0.18.0/"
     },
     {
-        "version": "0.17.0",
-        "url": "https://pyxem.org/en/v0.17.0/"
+        "version": "0.17",
+        "url": "https://pyxem.readthedocs.io/en/v0.17.0/"
     },
     {
-        "version": "0.16.0",
-        "url": "https://pyxem.org/en/v0.16.0/"
+        "version": "0.16",
+        "url": "https://pyxem.readthedocs.io/en/v0.16.0/"
     }
 ]

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -2,28 +2,28 @@
     {
         "name": "dev",
         "version": "dev",
-        "url": "https://pyxem.readthedocs.io/en/latest/"
+        "url": "https://pyxem.org/en/latest/"
     },
     {
         "name": "0.20.0",
         "version": "0.20.0",
-        "url": "https://pyxem.readthedocs.io/en/v0.20.0/"
+        "url": "https://pyxem.org/en/v0.20.0/"
     },
     {
         "name": "0.19.1",
         "version": "0.19.1",
-        "url": "https://pyxem.readthedocs.io/en/v0.19.1/"
+        "url": "https://pyxem.org/en/v0.19.1/"
     },
     {
         "version": "0.18.0",
-        "url": "https://pyxem.readthedocs.io/en/v0.18.0/"
+        "url": "https://pyxem.org/en/v0.18.0/"
     },
     {
         "version": "0.17.0",
-        "url": "https://pyxem.readthedocs.io/en/v0.17.0/"
+        "url": "https://pyxem.org/en/v0.17.0/"
     },
     {
         "version": "0.16.0",
-        "url": "https://pyxem.readthedocs.io/en/v0.16.0/"
+        "url": "https://pyxem.org/en/v0.16.0/"
     }
 ]


### PR DESCRIPTION
Updaing the version switcher which is broken because the link resolves to pyxem.org. 


At least I think that is the case. 
