### PR TITLE
Fix version switcher URLs and add stable redirect workflow

### DIFF
--- a/.github/workflows/docs-deploy-redirects.yml
+++ b/.github/workflows/docs-deploy-redirects.yml
@@ -1,0 +1,68 @@
+name: Deploy legacy URL redirects
+
+# Creates HTML redirect pages on gh-pages for old documentation paths
+# that pointed to the ReadTheDocs layout (/en/stable/, /stable/, etc.).
+# Run this manually once after the v0.21.0 migration, and whenever a
+# new stable release is made that changes the redirect target.
+
+on:
+  workflow_dispatch:
+    inputs:
+      stable_version:
+        description: "Stable version to redirect /stable/ to (e.g. v0.21.0)"
+        required: true
+        default: "v0.21.0"
+
+jobs:
+  deploy-redirects:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'pyxem'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Write redirect pages
+        env:
+          STABLE_VERSION: ${{ github.event.inputs.stable_version }}
+        run: |
+          write_redirect() {
+            local path="$1"
+            local target="$2"
+            mkdir -p "$path"
+            cat > "$path/index.html" <<HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <title>pyxem documentation – redirecting</title>
+            <meta http-equiv="refresh" content="0; url=${target}">
+            <link rel="canonical" href="${target}">
+          </head>
+          <body>
+            <p>This page has moved. If you are not redirected automatically,
+               <a href="${target}">click here</a>.</p>
+          </body>
+          </html>
+          HTML
+          }
+
+          STABLE_URL="https://pyxem.org/${STABLE_VERSION}/"
+
+          write_redirect "stable"    "$STABLE_URL"
+          write_redirect "latest"    "$STABLE_URL"
+          write_redirect "en/stable" "$STABLE_URL"
+          write_redirect "en/latest" "$STABLE_URL"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stable/ latest/ en/
+          git diff --cached --quiet && echo "Nothing to commit" || \
+            git commit -m "Add legacy redirect pages for stable/latest/en/* → ${STABLE_VERSION}"
+          git push

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -2,7 +2,12 @@
     {
         "name": "dev",
         "version": "dev",
-        "url": "https://pyxem.readthedocs.io/en/latest/"
+        "url": "https://pyxem.org/dev/"
+    },
+    {
+        "name": "0.21.0 (stable)",
+        "version": "0.21",
+        "url": "https://pyxem.org/stable/"
     },
     {
         "name": "0.20.0",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -84,6 +84,8 @@ linkcheck_ignore = [
     "https://doi.org/10.1016/j.ultramic.2016.12.021",
     "https://stackoverflow.com/questions/18603270/",  # 404 Client Error: Forbidden for url
     "https://scholar.google.com/scholar?q=pyxem",  # 403 Client Error: Forbidden for url
+    "https://pyxem.org/dev/_static/switcher.json",  # not available during PR builds
+    "https://pyxem.org/stable/",  # populated on tagged releases via create_stable_copy
 ]
 
 
@@ -110,9 +112,9 @@ html_theme_options = {
     "show_toc_level": 2,
     "use_edit_page_button": True,
     "announcement": "Check out the new "
-    "<a href='https://pyxem.readthedocs.io/en/latest/examples/index.html'>Examples Gallery!</a> ",
+    "<a href='https://pyxem.org/dev/examples/index.html'>Examples Gallery!</a> ",
     "switcher": {
-        "json_url": "https://pyxem.readthedocs.io/en/latest/_static/switcher.json",
+        "json_url": "https://pyxem.org/dev/_static/switcher.json",
         "version_match": version_match,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],

--- a/doc/dev_guide/contributing.rst
+++ b/doc/dev_guide/contributing.rst
@@ -225,18 +225,30 @@ Tips for writing Jupyter notebooks that are meant to be converted to reST text f
   must be added to the gallery in the README.rst to be included in the
   documentation pages.
 
-Switching between Documentation Versions
-----------------------------------------
+Documentation Hosting and Version Switcher
+------------------------------------------
 
-To make switching between documentation versions easier, we have a version switcher
-in the documentation. This switcher is located in the ``doc/_static/switcher.json`` file
-or at https://pyxem.readthedocs.io/en/latest/_static/switcher.json.  Because the switcher
-points to the latest version of the documentation, any update to the documentation will
-be retroactively applied to all previous versions which have the switcher enabled.
+The pyxem documentation is hosted on GitHub Pages at https://pyxem.org.  The URL
+structure is:
 
-To update the switcher, you will need to update the ``doc/_static/switcher.json`` file
-with the new version number. This will ensure that the version switcher in the
-documentation is up to date.
+- ``https://pyxem.org/dev/`` — latest development build (from ``main``)
+- ``https://pyxem.org/stable/`` — latest stable release (copy updated on each tagged release)
+- ``https://pyxem.org/v0.21.0/`` — specific versioned release
+
+For **intersphinx** mappings in other packages, use the stable URL::
+
+    intersphinx_mapping = {
+        "pyxem": ("https://pyxem.org/stable/", None),
+    }
+
+The version switcher dropdown is driven by ``doc/_static/switcher.json``, which is
+served from ``https://pyxem.org/dev/_static/switcher.json``.  Because the switcher
+always loads from the ``dev`` build, any update to this file is retroactively applied
+to all deployed versions that have the switcher enabled.
+
+To update the switcher when making a release, add the new version entry to
+``doc/_static/switcher.json`` before tagging.  The CI will automatically create
+``https://pyxem.org/stable/`` as a copy of the new release docs.
 
 Continuous integration (CI)
 ===========================
@@ -253,9 +265,8 @@ We use `GitHub Actions <https://github.com/pyxem/pyxem/actions>`_ to automatical
 create a new release. Each time a new tag is pushed to the repository, the CI server
 will:
 
-1. Build the documentation.  Each tagged release will be added as a
-   `stable <https://docs.readthedocs.io/en/stable/versions.html>`_ build
-   to `Read the Docs <https://pyxem.readthedocs.io/en/latest/>`_.
+1. Build the documentation and deploy it to ``https://pyxem.org/v<version>/`` and
+   ``https://pyxem.org/stable/`` on GitHub Pages.
 2. Publish a new version of pyxem to `PyPI <https://pypi.org/project/pyxem/>`_.
 3. Create a new `GitHub release <https://github.com/pyxem/pyxem/releases>`_.
 4. Publish a new version of pyxem to `Zenodo <https://zenodo.org/doi/10.5281/zenodo.2649351>`_.
@@ -267,16 +278,14 @@ To make a new release, follow these steps:
    the changes.
 3. Update the list of contributors in both the ``release_info.py`` and ``.zenodo.json``
    files. __ Make sure that the Zenodo file is valid JSON __.
-4. Commit the changes and push them to the repository.
-5. Create a new tag with the "v" + version number (e.g. "v0.16.0") and make a new release on GitHub.
-6. Wait for the CI server to finish the release process.
+4. Add the new version entry to ``doc/_static/switcher.json`` (point its URL to
+   ``https://pyxem.org/stable/`` and mark the previous stable as a plain versioned entry).
+5. Commit the changes and push them to the repository.
+6. Create a new tag with the "v" + version number (e.g. "v0.16.0") and make a new release on GitHub.
+7. Wait for the CI server to finish the release process.
 
 Then you can increase the version number in ``release_info.py`` to the next minor version
 and add a dev suffix (e.g. "0.17.dev0").
-
-After the new version documentation is public. You should update the doc/_static/switcher.json
-file with the new version of the documentation. This will ensure that the version switcher in the
-documentation is up to date.
 
 .. note::
    If any of the steps fail, you can restart the CI server by clicking on the "Re-run


### PR DESCRIPTION
## Summary

Fixes #1188 — documentation URLs broken after migration from ReadTheDocs to GitHub Pages.

- **Fix `conf.py`**: Update switcher `json_url` from the stale ReadTheDocs URL (`readthedocs.io/en/latest/_static/switcher.json`) to the GitHub Pages URL (`pyxem.org/dev/_static/switcher.json`). Also fix the announcement banner link.
- **Fix `switcher.json`**: Change the `dev` entry URL from ReadTheDocs to `https://pyxem.org/dev/`. Add a `0.21.0 (stable)` entry pointing to `https://pyxem.org/stable/` (the persistent copy that `create_stable_copy: true` creates on each tagged release).
- **Add `docs-deploy-redirects.yml`**: A manually-triggered workflow that writes HTML redirect pages to the `gh-pages` branch for `/stable/`, `/latest/`, `/en/stable/`, and `/en/latest/`. This is a one-time fix for the v0.21.0 release that was tagged before `create_stable_copy` was added to the workflow.
- **Update `contributing.rst`**: Document the GitHub Pages URL structure, the correct intersphinx URL (`https://pyxem.org/stable/`), and updated release steps.

## After merging

**Immediately**: trigger the new `Deploy legacy URL redirects` workflow from the GitHub Actions UI and set `stable_version = v0.21.0`. This will create HTML redirect pages at `/stable/`, `/latest/`, `/en/stable/`, and `/en/latest/` on the live site.

**For the intersphinx registry** (https://github.com/Quansight-Labs/intersphinx_registry/issues/107): the correct stable URL for pyxem is now `https://pyxem.org/stable/`. Once the redirect workflow is run, `https://pyxem.org/stable/objects.inv` will resolve correctly.

**Future releases**: the `Push-tag` CI job already has `create_stable_copy: true, persistent_name: stable`, so each new tagged release will automatically refresh `/stable/` with the new docs. No manual action needed.

## Test plan

- [ ] Confirm `https://pyxem.org/dev/_static/switcher.json` loads in a browser and the version dropdown shows `0.21.0 (stable)` and `dev`
- [ ] After running the redirect workflow: confirm `https://pyxem.org/stable/` and `https://pyxem.org/en/stable/` redirect to `https://pyxem.org/v0.21.0/`
- [ ] Confirm `https://pyxem.org/stable/objects.inv` resolves (needed for intersphinx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)