### PR TITLE
Set `output_dimension` when calling `decomposition` lazily 

### DIFF
--- a/pyxem/tests/signals/test_lazy_diffraction1d.py
+++ b/pyxem/tests/signals/test_lazy_diffraction1d.py
@@ -23,5 +23,5 @@ class TestDecomposition:
     def test_decomposition_class_assignment(self, electron_diffraction1d):
         s = Diffraction1D(electron_diffraction1d)
         s = s.as_lazy()
-        s.decomposition()
+        s.decomposition(output_dimension=3)
         assert isinstance(s, LazyDiffraction1D)

--- a/pyxem/tests/signals/test_lazy_diffraction2d.py
+++ b/pyxem/tests/signals/test_lazy_diffraction2d.py
@@ -23,5 +23,5 @@ class TestDecomposition:
     def test_decomposition_class_assignment(self, diffraction_pattern):
         s = Diffraction2D(diffraction_pattern)
         s = s.as_lazy()
-        s.decomposition()
+        s.decomposition(output_dimension=3)
         assert isinstance(s, LazyDiffraction2D)

--- a/pyxem/tests/signals/test_lazy_electron_diffraction1d.py
+++ b/pyxem/tests/signals/test_lazy_electron_diffraction1d.py
@@ -22,5 +22,5 @@ from pyxem.signals import LazyElectronDiffraction1D
 class TestDecomposition:
     def test_decomposition_class_assignment(self, electron_diffraction1d):
         s = electron_diffraction1d.as_lazy()
-        s.decomposition()
+        s.decomposition(output_dimension=3)
         assert isinstance(s, LazyElectronDiffraction1D)

--- a/pyxem/tests/signals/test_lazy_electron_diffraction2d.py
+++ b/pyxem/tests/signals/test_lazy_electron_diffraction2d.py
@@ -22,5 +22,5 @@ from pyxem.signals import LazyElectronDiffraction2D
 class TestDecomposition:
     def test_decomposition_class_assignment(self, diffraction_pattern):
         diffraction_pattern = diffraction_pattern.as_lazy()
-        diffraction_pattern.decomposition()
+        diffraction_pattern.decomposition(output_dimension=3)
         assert isinstance(diffraction_pattern, LazyElectronDiffraction2D)


### PR DESCRIPTION
See https://github.com/hyperspy/hyperspy/issues/3671 for context.

---
name
---

**Checklist**

- [x] Specify the `output_dimension` parameter, as required per new defaults - the default has changed because the old one doesn't work as expected.
- [n/a] update the Changelog
- [x] mark as ready for review

**What does this PR do? Please describe and/or link to an open issue.**
